### PR TITLE
🐛 fix(ci): update publish workflow to separate publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,12 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm exec changeset version
-          publish: pnpm -w publish-ui
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm (changesets only)
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        run: pnpm -w publish-ui
+        env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Move publish command to its own step for clarity
- Ensure publishing only occurs if there are changesets