### PR TITLE
🔧 ci(publish): update npm registry and authentication token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: 20.x
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install
@@ -49,3 +50,4 @@ jobs:
         run: pnpm -w publish-ui
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Add registry URL for npm in Node.js setup
- Include NODE_AUTH_TOKEN for npm publish step