### PR TITLE
🎨 refactor(radio): export Props interface for RadioGroup component

### DIFF
--- a/packages/ui/src/components/atoms/Radio/Group/index.tsx
+++ b/packages/ui/src/components/atoms/Radio/Group/index.tsx
@@ -11,7 +11,7 @@ type Option = {
 
 type Options = string[] | number[] | boolean[] | Option[];
 
-interface Props extends Omit<
+export interface Props extends Omit<
   React.ComponentPropsWithoutRef<'div'>,
   'onChange' | 'defaultValue' | 'value'
 > {


### PR DESCRIPTION
- Change Props interface declaration from internal to exported
- Enhance usability for external components