### PR TITLE
Feat/main

### DIFF
--- a/apps/docs/stories/atoms/ConfigProvider/index.stories.tsx
+++ b/apps/docs/stories/atoms/ConfigProvider/index.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button, ConfigProvider, Switch } from '@repo/ui';
+import { cn } from '@repo/ui/utils';
+
+const meta: Meta<typeof ConfigProvider> = {
+  title: 'UI/ConfigProvider',
+  component: ConfigProvider,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ThemeToken: Story = {
+  render: () => (
+    <div className={cn('flex flex-col gap-4')}>
+      <div className={cn('flex items-center gap-2')}>
+        <Button>Default Theme</Button>
+        <Switch />
+      </div>
+
+      <ConfigProvider
+        theme={{
+          token: { colorPrimary: 'oklch(0.6 0.25 30)' },
+        }}
+      >
+        <div className={cn('flex items-center gap-2')}>
+          <Button>Red Primary</Button>
+          <Switch />
+        </div>
+      </ConfigProvider>
+
+      <ConfigProvider
+        theme={{
+          token: { colorPrimary: 'oklch(0.55 0.2 260)' },
+        }}
+      >
+        <div className={cn('flex items-center gap-2')}>
+          <Button>Blue Primary</Button>
+          <Switch />
+        </div>
+      </ConfigProvider>
+    </div>
+  ),
+};
+
+export const DarkMode: Story = {
+  render: () => (
+    <div className={cn('flex gap-4')}>
+      <div className={cn('rounded-lg border p-4')}>
+        <p className={cn('mb-2 text-sm')}>Light</p>
+        <Button>Button</Button>
+      </div>
+
+      <ConfigProvider theme={{ dark: true }}>
+        <div
+          className={cn('bg-background text-foreground rounded-lg border p-4')}
+        >
+          <p className={cn('mb-2 text-sm')}>Dark</p>
+          <Button>Button</Button>
+        </div>
+      </ConfigProvider>
+    </div>
+  ),
+};
+
+export const Nested: Story = {
+  render: () => (
+    <ConfigProvider theme={{ token: { colorPrimary: 'oklch(0.55 0.2 260)' } }}>
+      <div className={cn('flex flex-col gap-4')}>
+        <div className={cn('flex items-center gap-2')}>
+          <Button>Blue (Parent)</Button>
+          <Switch />
+        </div>
+
+        <ConfigProvider
+          theme={{ token: { colorPrimary: 'oklch(0.6 0.2 150)' } }}
+        >
+          <div className={cn('flex items-center gap-2')}>
+            <Button>Green (Child)</Button>
+            <Switch />
+          </div>
+        </ConfigProvider>
+      </div>
+    </ConfigProvider>
+  ),
+};

--- a/packages/ui/src/components/atoms/Button/index.tsx
+++ b/packages/ui/src/components/atoms/Button/index.tsx
@@ -39,12 +39,12 @@ export interface Props extends Omit<ButtonProps, 'size' | 'variant' | 'type'> {
 const variantClasses: Record<string, string> = {
   solid: '',
   outlined: cn(
-    'border border-[rgb(var(--btn-border)/0.5)]',
+    'border border-[color-mix(in_oklch,var(--btn-border),transparent_50%)]',
     'bg-background text-foreground',
     'hover:bg-accent',
   ),
   dashed: cn(
-    'border border-dashed border-[rgb(var(--btn-border)/0.5)]',
+    'border border-dashed border-[color-mix(in_oklch,var(--btn-border),transparent_50%)]',
     'bg-background text-foreground',
     'hover:bg-accent',
   ),
@@ -141,7 +141,7 @@ const Button = ({
               ]
             : [
                 'text-(--btn-bg)',
-                'border-[rgb(var(--btn-border)/0.5)]',
+                'border-[color-mix(in_oklch,var(--btn-border),transparent_50%)]',
                 //
               ]),
         className,

--- a/packages/ui/src/components/atoms/Switch/index.tsx
+++ b/packages/ui/src/components/atoms/Switch/index.tsx
@@ -10,19 +10,23 @@ const { Switch: Core } = switchComponent;
 const sizeConfig = {
   medium: {
     core: 'default' as const,
+    track: 'h-8! w-12!',
+    handle: 'size-6!',
     handleChecked:
-      'data-[state=unchecked]:left-0 data-[state=checked]:left-[calc(100%-16px)]',
-    fontSize: 'text-[9px]',
-    marginChecked: 'mr-4.5 ml-1',
-    marginUnchecked: 'mr-1 ml-4.5',
+      'data-[state=unchecked]:left-0.5 data-[state=checked]:left-[calc(100%-26px)]',
+    fontSize: 'text-xs',
+    marginChecked: 'mr-7 ml-2',
+    marginUnchecked: 'mr-2 ml-7',
   },
   small: {
     core: 'sm' as const,
+    track: 'h-6! w-10!',
+    handle: 'size-5!',
     handleChecked:
-      'data-[state=unchecked]:left-0 data-[state=checked]:left-[calc(100%-12px)]',
-    fontSize: 'text-[7px]',
-    marginChecked: 'mr-3.5 ml-0.5',
-    marginUnchecked: 'mr-0.5 ml-3.5',
+      'data-[state=unchecked]:left-0.5 data-[state=checked]:left-[calc(100%-22px)]',
+    fontSize: 'text-[10px]',
+    marginChecked: 'mr-6 ml-1.5',
+    marginUnchecked: 'mr-1.5 ml-6',
   },
 };
 
@@ -77,17 +81,17 @@ const Switch = ({
       size={config.core}
       className={cn(
         'relative',
+        config.track,
         hasChildren && 'w-auto! overflow-hidden',
         className,
         classNames?.track,
         //
       )}
       handleClassName={cn(
-        hasChildren && [
-          '!absolute top-1/2 !-translate-y-1/2 !translate-x-0',
-          'transition-[left] duration-200',
-          config.handleChecked,
-        ],
+        config.handle,
+        '!absolute top-1/2 !-translate-y-1/2 !translate-x-0',
+        'transition-[left] duration-200 will-change-[left]',
+        config.handleChecked,
         classNames?.handle,
         //
       )}
@@ -99,7 +103,8 @@ const Switch = ({
       {hasChildren && (
         <span
           className={cn(
-            'grid leading-none text-white transition-[margin] duration-200',
+            `grid leading-none text-white transition-[margin] duration-200
+            will-change-[margin]`,
             config.fontSize,
             checked ? config.marginChecked : config.marginUnchecked,
             //

--- a/packages/ui/src/components/molecules/Menu/index.tsx
+++ b/packages/ui/src/components/molecules/Menu/index.tsx
@@ -63,10 +63,10 @@ export const MENU_CLASSNAMES = [
 
 export type SelectionMap = ReadonlyMap<React.Key, boolean>;
 
-export function buildSelectionMap(
+export const buildSelectionMap = (
   items: MenuItem[],
   selectedKeysSet: ReadonlySet<React.Key>,
-): SelectionMap {
+): SelectionMap => {
   const map = new Map<React.Key, boolean>();
 
   const dfs = (node: MenuItem): boolean => {
@@ -79,12 +79,12 @@ export function buildSelectionMap(
 
   items.forEach(dfs);
   return map;
-}
+};
 
-export function findKey(
+export const findKey = (
   menu: MenuItem,
   targetKeys: ReadonlySet<React.Key>,
-): boolean {
+): boolean => {
   if (targetKeys.has(menu.key)) {
     return true;
   }
@@ -98,7 +98,7 @@ export function findKey(
   }
 
   return false;
-}
+};
 
 const Menu = ({
   items,

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'tw-animate-css';
 
 @config "../tailwind.config.mjs";
 
@@ -141,71 +142,55 @@
 
   [data-slot='button'][data-color='default'] {
     --btn-bg: var(--muted);
-    --btn-border: 107 114 128;
+    --btn-border: var(--muted-foreground);
   }
 
   [data-slot='button'][data-color='primary'] {
     --btn-bg: var(--primary);
-    --btn-border: var(--primary);
     --btn-fg: var(--primary-foreground);
   }
 
   [data-slot='button'][data-color='danger'] {
     --btn-bg: var(--destructive);
-    --btn-border: 239 68 68;
-    --btn-fg: white;
   }
 
   [data-slot='button'][data-color='blue'] {
     --btn-bg: #3b82f6;
-    --btn-border: 59 130 246;
   }
   [data-slot='button'][data-color='purple'] {
     --btn-bg: #a855f7;
-    --btn-border: 168 85 247;
   }
   [data-slot='button'][data-color='cyan'] {
     --btn-bg: #06b6d4;
-    --btn-border: 6 182 212;
   }
   [data-slot='button'][data-color='green'] {
     --btn-bg: #22c55e;
-    --btn-border: 34 197 94;
   }
   [data-slot='button'][data-color='magenta'] {
     --btn-bg: #d946ef;
-    --btn-border: 217 70 239;
   }
   [data-slot='button'][data-color='pink'] {
     --btn-bg: #ec4899;
-    --btn-border: 236 72 153;
   }
   [data-slot='button'][data-color='red'] {
     --btn-bg: #ef4444;
-    --btn-border: 239 68 68;
   }
   [data-slot='button'][data-color='orange'] {
     --btn-bg: #f97316;
-    --btn-border: 249 115 22;
   }
   [data-slot='button'][data-color='yellow'] {
     --btn-bg: #eab308;
-    --btn-border: 234 179 8;
   }
   [data-slot='button'][data-color='volcano'] {
     --btn-bg: #ea580c;
-    --btn-border: 234 88 12;
   }
   [data-slot='button'][data-color='geekblue'] {
     --btn-bg: #6366f1;
-    --btn-border: 99 102 241;
   }
   [data-slot='button'][data-color='lime'] {
     --btn-bg: #84cc16;
-    --btn-border: 132 204 22;
   }
   [data-slot='button'][data-color='gold'] {
     --btn-bg: #f59e0b;
-    --btn-border: 245 158 11;
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,3 +4,4 @@ export * from './components/atoms';
 export * from './components/molecules';
 export * from './components/organisms';
 export * from './components/templates';
+export * from './providers';

--- a/packages/ui/src/lib/utils/index.ts
+++ b/packages/ui/src/lib/utils/index.ts
@@ -3,14 +3,14 @@ import * as React from 'react';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-export function cn(...inputs: ClassValue[]) {
+export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));
-}
+};
 
-export function renderConditional<T extends React.ReactNode>(
+export const renderConditional = <T extends React.ReactNode>(
   value: T,
   wrapper?: (value: NonNullable<T>) => React.ReactNode,
-): React.ReactNode {
+): React.ReactNode => {
   if (value === null || value === undefined) {
     return null;
   }
@@ -20,4 +20,4 @@ export function renderConditional<T extends React.ReactNode>(
   }
 
   return wrapper ? wrapper(value as NonNullable<T>) : value;
-}
+};

--- a/packages/ui/src/providers/ConfigProvider/ConfigContext.ts
+++ b/packages/ui/src/providers/ConfigProvider/ConfigContext.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+import type { ConfigContextValue } from './types';
+
+export const ConfigContext = createContext<ConfigContextValue>({
+  theme: {},
+});
+
+export const useConfig = () => useContext(ConfigContext);

--- a/packages/ui/src/providers/ConfigProvider/index.tsx
+++ b/packages/ui/src/providers/ConfigProvider/index.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { cn } from '@repo/ui/utils';
+
+import { ConfigContext, useConfig } from './ConfigContext';
+import type { ThemeConfig, ThemeToken } from './types';
+
+const tokenToCssVar: Record<keyof ThemeToken, string> = {
+  colorPrimary: '--primary',
+  colorPrimaryForeground: '--primary-foreground',
+  colorBackground: '--background',
+  colorForeground: '--foreground',
+  colorCard: '--card',
+  colorCardForeground: '--card-foreground',
+  colorPopover: '--popover',
+  colorPopoverForeground: '--popover-foreground',
+  colorSecondary: '--secondary',
+  colorSecondaryForeground: '--secondary-foreground',
+  colorMuted: '--muted',
+  colorMutedForeground: '--muted-foreground',
+  colorAccent: '--accent',
+  colorAccentForeground: '--accent-foreground',
+  colorDestructive: '--destructive',
+  colorBorder: '--border',
+  colorInput: '--input',
+  colorRing: '--ring',
+  borderRadius: '--radius',
+};
+
+const buildCssVars = (token?: ThemeToken): React.CSSProperties => {
+  if (!token) {
+    return {};
+  }
+
+  const vars: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(token)) {
+    if (value === undefined) {
+      continue;
+    }
+    const cssVar = tokenToCssVar[key as keyof ThemeToken];
+    if (cssVar) {
+      vars[cssVar] = value;
+    }
+  }
+
+  return vars as React.CSSProperties;
+};
+
+interface Props {
+  theme?: ThemeConfig;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const ConfigProvider = ({ theme = {}, className, children }: Props) => {
+  const parent = useConfig();
+
+  const mergedTheme = useMemo<ThemeConfig>(
+    () => ({
+      ...parent.theme,
+      ...theme,
+      token: {
+        ...parent.theme.token,
+        ...theme.token,
+      },
+    }),
+    [parent.theme, theme],
+  );
+
+  const contextValue = useMemo(() => ({ theme: mergedTheme }), [mergedTheme]);
+
+  const cssVars = useMemo(
+    () => buildCssVars(mergedTheme.token),
+    [mergedTheme.token],
+  );
+
+  const hasCssVars = Object.keys(cssVars).length > 0;
+  const hasDarkMode = mergedTheme.dark !== undefined;
+  const needsWrapper = hasCssVars || hasDarkMode || className;
+
+  return (
+    <ConfigContext.Provider value={contextValue}>
+      {needsWrapper ? (
+        <div
+          className={cn(mergedTheme.dark && 'dark', className)}
+          style={hasCssVars ? cssVars : undefined}
+        >
+          {children}
+        </div>
+      ) : (
+        children
+      )}
+    </ConfigContext.Provider>
+  );
+};
+
+export default ConfigProvider;
+export { useConfig };
+export type { Props, ThemeConfig, ThemeToken };

--- a/packages/ui/src/providers/ConfigProvider/types.ts
+++ b/packages/ui/src/providers/ConfigProvider/types.ts
@@ -1,0 +1,33 @@
+export interface ThemeToken {
+  // Colors
+  colorPrimary?: string;
+  colorPrimaryForeground?: string;
+  colorBackground?: string;
+  colorForeground?: string;
+  colorCard?: string;
+  colorCardForeground?: string;
+  colorPopover?: string;
+  colorPopoverForeground?: string;
+  colorSecondary?: string;
+  colorSecondaryForeground?: string;
+  colorMuted?: string;
+  colorMutedForeground?: string;
+  colorAccent?: string;
+  colorAccentForeground?: string;
+  colorDestructive?: string;
+  colorBorder?: string;
+  colorInput?: string;
+  colorRing?: string;
+
+  // Border Radius
+  borderRadius?: string;
+}
+
+export interface ThemeConfig {
+  token?: ThemeToken;
+  dark?: boolean;
+}
+
+export interface ConfigContextValue {
+  theme: ThemeConfig;
+}

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,0 +1,6 @@
+export { default as ConfigProvider, useConfig } from './ConfigProvider';
+export type {
+  Props as ConfigProviderProps,
+  ThemeConfig,
+  ThemeToken,
+} from './ConfigProvider';


### PR DESCRIPTION
## Summary

Adds a new ConfigProvider to the UI package so consumers can override theme tokens and enable dark mode at the provider level. It also updates core UI styling to respect those theme values and adds a Storybook story to demonstrate the new behavior.

## Changes

- Add a ConfigProvider implementation with context, theme token types, nested theme merging, and dark mode support
- Export the new provider from the UI package entry points so it can be consumed directly from @repo/ui
- Update button, switch, and menu-related UI code to align with provider-driven theming and refined style behavior
- Adjust shared CSS theme variables and utility exports to support the new configuration flow
- Add Storybook examples that showcase token overrides, dark mode rendering, and nested provider usage

## Type of Change

<!-- Check all that apply -->

- [ ] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

<!-- If there are UI changes, attach screenshots or a Storybook link -->

## Checklist

- [ ] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [ ] A `.changeset/*.md` file has been added (run `changeset` command)
- [ ] Storybook stories are added for new components / features
- [ ] No type or lint errors (`pnpm lint`, `pnpm typecheck`)
- [ ] Build completes successfully (`pnpm build`)
