### PR TITLE
🔧 chore: add changeset and remove tw-animate-css import

### DIFF
--- a/.changeset/main.md
+++ b/.changeset/main.md
@@ -1,0 +1,12 @@
+---
+'@repo/ui': minor
+---
+
+### Added
+
+- Add a ConfigProvider export to the UI package for applying nested theme token overrides and dark mode settings.
+
+### Changed
+
+- Update button, switch, and shared theme styling to respect provider-driven theme values.
+- Add a Storybook example covering token overrides, dark mode, and nested provider usage.

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -1,5 +1,4 @@
 @import 'tailwindcss';
-@import 'tw-animate-css';
 
 @config "../tailwind.config.mjs";
 


### PR DESCRIPTION
- Add a changeset for the ConfigProvider release
- Remove the tw-animate-css import from the UI global stylesheet

## Summary

<!-- Briefly describe the changes -->

## Changes

<!-- Describe the changes in detail -->

-

## Type of Change

<!-- Check all that apply -->

- [ ] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

<!-- If there are UI changes, attach screenshots or a Storybook link -->

## Checklist

- [ ] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [ ] A `.changeset/*.md` file has been added (run `changeset` command)
- [ ] Storybook stories are added for new components / features
- [ ] No type or lint errors (`pnpm lint`, `pnpm typecheck`)
- [ ] Build completes successfully (`pnpm build`)
