### PR TITLE
♻️ refactor(chore/develop-changelog-pipeline): switch to Keep a Chang…

### DIFF
--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 // Changelog automation for .github/workflows/changelog-develop.yml.
-// Asks a GitHub Models chat completion for a semver bump + changelog entry per
-// changed public package (plus a dated entry for repo-root/tooling changes),
-// then applies that JSON directly to package.json / CHANGELOG.md. Exits
-// non-zero on failure, which fails the workflow run (no changelog PR that time).
+// Asks a GitHub Models chat completion for a semver bump + Keep a Changelog
+// (https://keepachangelog.com/en/1.1.0/) style entry per changed public
+// package — including a repo-root pseudo-package for tooling/CI/config
+// changes — then applies that JSON directly to package.json / CHANGELOG.md.
+// Exits non-zero on failure, which fails the workflow run (no changelog PR
+// that time).
 
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -12,6 +14,18 @@ import path from 'node:path';
 const MODEL = process.env.GITHUB_MODELS_MODEL || 'openai/gpt-4o';
 const API_URL = 'https://models.github.ai/inference/chat/completions';
 const MAX_DIFF_CHARS = 20000;
+
+const CATEGORY_ORDER = [
+  ['added', '추가'],
+  ['changed', '변경'],
+  ['deprecated', '사용 중단'],
+  ['removed', '제거'],
+  ['fixed', '수정'],
+  ['security', '보안'],
+];
+const CATEGORY_KEYS = CATEGORY_ORDER.map(([key]) => key);
+
+const ROOT_ID = '.';
 
 const token = requireEnv('GITHUB_TOKEN');
 const afterSha = requireEnv('AFTER_SHA');
@@ -31,8 +45,6 @@ function resolveBeforeSha(before, after) {
 function git(args) {
   return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
 }
-
-const ROOT_ID = '.';
 
 function listCandidatePackages() {
   const root = 'packages';
@@ -56,20 +68,21 @@ function listCandidatePackages() {
     .filter(pkg => !pkg.private);
 
   // Repo-root / tooling changes (CI workflows, root config, etc.) that don't
-  // belong to any individual package — tracked in a dated root CHANGELOG.md
-  // instead of a semver-versioned one, since the root package.json has no
-  // version field (it isn't published).
+  // belong to any individual package. The root package.json is versioned
+  // like any other package, so this is tracked the same way.
+  const rootPkgJsonPath = 'package.json';
+  const rootPkg = JSON.parse(fs.readFileSync(rootPkgJsonPath, 'utf8'));
   const rootEntry = {
     name: 'root',
     dir: ROOT_ID,
-    pkgJsonPath: null,
-    pkgName: 'ui-kit',
-    version: null,
-    private: false,
+    pkgJsonPath: rootPkgJsonPath,
+    pkgName: rootPkg.name,
+    version: rootPkg.version,
+    private: rootPkg.private === true,
     isRoot: true,
   };
 
-  return [...packages, rootEntry];
+  return rootEntry.private ? packages : [...packages, rootEntry];
 }
 
 function diffFor(pkg) {
@@ -96,53 +109,59 @@ function bumpVersion(version, bump) {
   return `${major}.${minor}.${patch + 1}`;
 }
 
-function bumpHeading(bump) {
-  if (bump === 'major') return 'Major 변경사항';
-  if (bump === 'minor') return 'Minor 변경사항';
-  return 'Patch 변경사항';
-}
-
 function applyVersionBump(pkg, newVersion) {
   const text = fs.readFileSync(pkg.pkgJsonPath, 'utf8');
   const updated = text.replace(/"version":\s*"[^"]+"/, `"version": "${newVersion}"`);
   fs.writeFileSync(pkg.pkgJsonPath, updated);
 }
 
-function applyChangelogEntry(pkg, newVersion, bump, entry) {
-  const changelogPath = path.posix.join(pkg.dir, 'CHANGELOG.md');
-  const section = `## ${newVersion}\n\n### ${bumpHeading(bump)}\n\n${entry.trim()}\n`;
-
-  if (!fs.existsSync(changelogPath)) {
-    fs.writeFileSync(changelogPath, `# ${pkg.pkgName}\n\n${section}`);
-    return;
+function formatSection(newVersion, changes) {
+  const today = new Date().toISOString().slice(0, 10);
+  const lines = [`## [${newVersion}] - ${today}`, ''];
+  for (const [key, label] of CATEGORY_ORDER) {
+    const items = changes[key];
+    if (!items || items.length === 0) continue;
+    lines.push(`### ${label}`, '');
+    for (const item of items) lines.push(`- ${item.trim()}`);
+    lines.push('');
   }
+  return lines;
+}
+
+function ensureChangelogSkeleton(changelogPath, pkgName) {
+  if (fs.existsSync(changelogPath)) return;
+  const header = [
+    `# ${pkgName}`,
+    '',
+    '이 프로젝트의 모든 주요 변경사항을 이 파일에 기록합니다.',
+    '',
+    '형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,',
+    '이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.',
+    '',
+    '## [Unreleased]',
+    '',
+  ].join('\n');
+  fs.writeFileSync(changelogPath, header);
+}
+
+function applyChangelogEntry(pkg, newVersion, changes) {
+  const changelogPath = path.posix.join(pkg.dir, 'CHANGELOG.md');
+  ensureChangelogSkeleton(changelogPath, pkg.pkgName);
 
   const content = fs.readFileSync(changelogPath, 'utf8');
   const lines = content.split('\n');
-  // lines[0] is the "# PackageName" title, lines[1] is the blank line after it.
-  lines.splice(2, 0, section);
-  fs.writeFileSync(changelogPath, lines.join('\n'));
-}
+  const unreleasedIdx = lines.findIndex(l => l.trim() === '## [Unreleased]');
 
-function applyRootChangelogEntry(pkg, entry) {
-  const changelogPath = path.posix.join(pkg.dir, 'CHANGELOG.md');
-  const today = new Date().toISOString().slice(0, 10);
-  const todayHeading = `## ${today}`;
-  const bullets = entry.trim();
-
-  const content = fs.existsSync(changelogPath) ? fs.readFileSync(changelogPath, 'utf8') : '# Changelog\n';
-
-  if (content.includes(`${todayHeading}\n`)) {
-    const updated = content.replace(`${todayHeading}\n\n`, `${todayHeading}\n\n${bullets}\n`);
-    fs.writeFileSync(changelogPath, updated);
-    return;
+  let insertAt;
+  if (unreleasedIdx !== -1) {
+    insertAt = unreleasedIdx + 1;
+    while (insertAt < lines.length && lines[insertAt].trim() === '') insertAt++;
+  } else {
+    insertAt = lines.findIndex(l => l.startsWith('## '));
+    if (insertAt === -1) insertAt = lines.length;
   }
 
-  const lines = content.split('\n');
-  const headingIdx = lines.findIndex(l => l.startsWith('## '));
-  const section = [todayHeading, '', bullets, ''];
-  const insertAt = headingIdx === -1 ? lines.length : headingIdx;
-  lines.splice(insertAt, 0, ...section);
+  lines.splice(insertAt, 0, ...formatSection(newVersion, changes));
   fs.writeFileSync(changelogPath, lines.join('\n'));
 }
 
@@ -157,11 +176,18 @@ function validateResults(results, candidates) {
   if (!Array.isArray(results)) throw new Error('Model response is not a JSON array');
   for (const r of results) {
     if (!r || typeof r !== 'object') throw new Error('Result entry is not an object');
-    const candidate = byDir.get(r.package);
-    if (!candidate) throw new Error(`Unknown package in result: ${r.package}`);
-    const allowedBumps = candidate.isRoot ? ['none'] : ['major', 'minor', 'patch'];
-    if (!allowedBumps.includes(r.bump)) throw new Error(`Invalid bump type "${r.bump}" for ${r.package}`);
-    if (!r.entry || typeof r.entry !== 'string' || !r.entry.trim()) throw new Error('Missing changelog entry text');
+    if (!byDir.has(r.package)) throw new Error(`Unknown package in result: ${r.package}`);
+    if (!['major', 'minor', 'patch'].includes(r.bump)) throw new Error(`Invalid bump type "${r.bump}" for ${r.package}`);
+    if (!r.changes || typeof r.changes !== 'object') throw new Error(`Missing changes object for ${r.package}`);
+    const hasAny = CATEGORY_KEYS.some(key => Array.isArray(r.changes[key]) && r.changes[key].length > 0);
+    if (!hasAny) throw new Error(`No changelog categories populated for ${r.package}`);
+    for (const key of Object.keys(r.changes)) {
+      if (!CATEGORY_KEYS.includes(key)) throw new Error(`Unknown changelog category "${key}" for ${r.package}`);
+      const items = r.changes[key];
+      if (!Array.isArray(items) || items.some(item => typeof item !== 'string' || !item.trim())) {
+        throw new Error(`Invalid entries for category "${key}" in ${r.package}`);
+      }
+    }
   }
   return results;
 }
@@ -180,9 +206,8 @@ async function main() {
   const styleExample = pkg => {
     const examplePath = path.posix.join(pkg.dir, 'CHANGELOG.md');
     if (!fs.existsSync(examplePath)) {
-      return pkg.isRoot
-        ? '(new file — start with "# Changelog" followed by a "## YYYY-MM-DD" heading and bullets)'
-        : '(no existing CHANGELOG.md yet — use a "## x.y.z" heading followed by "### Patch Changes" etc.)';
+      return '(파일 없음 — Keep a Changelog 형식 사용: "## [Unreleased]" 아래에 ' +
+        '"## [x.y.z] - YYYY-MM-DD" 헤딩과 "### 추가/변경/사용 중단/제거/수정/보안" 하위 섹션)';
     }
     return fs.readFileSync(examplePath, 'utf8').split('\n').slice(0, 20).join('\n');
   };
@@ -190,34 +215,37 @@ async function main() {
   const sections = changed
     .map(({ pkg, diff }) => {
       const label = pkg.isRoot
-        ? `## Repo root / tooling changes (package identifier: "${ROOT_ID}", no version — this is NOT a publishable package)`
+        ? `## 저장소 루트 / 공통 설정 변경 (identifier: "${ROOT_ID}", name: ${pkg.pkgName}, current version: ${pkg.version})`
         : `## Package: ${pkg.dir} (identifier: "${pkg.dir}", name: ${pkg.pkgName}, current version: ${pkg.version})`;
       return `${label}\n\n\`\`\`diff\n${diff}\n\`\`\`\n\nCHANGELOG.md style example for this entry:\n\`\`\`\n${styleExample(pkg)}\n\`\`\``;
     })
     .join('\n\n');
 
   const systemPrompt = [
-    'You are a release-notes assistant for a pnpm/turborepo monorepo.',
-    'You will be given a git diff for one or more changed packages, and possibly',
-    'a special repo-root entry (identifier ".") for changes to tooling/CI/root',
-    'config files that do not belong to any individual package.',
-    "Respond with ONLY a JSON array, no prose, no markdown code fences, matching:",
-    "Array<{ package: string; bump: 'major' | 'minor' | 'patch' | 'none'; entry: string }>",
+    'You are a release-notes assistant for a pnpm/turborepo monorepo that',
+    'follows the Keep a Changelog format (https://keepachangelog.com/en/1.1.0/).',
+    'You will be given a git diff for one or more changed packages, including a',
+    'special repo-root entry (identifier ".") for changes to tooling/CI/root',
+    'config files that do not belong to any individual package — it has its',
+    'own package.json version like any other package.',
+    'Respond with ONLY a JSON array, no prose, no markdown code fences, matching:',
+    "Array<{ package: string; bump: 'major' | 'minor' | 'patch'; changes: {",
+    'added?: string[]; changed?: string[]; deprecated?: string[];',
+    'removed?: string[]; fixed?: string[]; security?: string[]; } }>',
     '`package` must be exactly one of the identifiers given.',
-    'For a real package, decide a semver `bump`: major = breaking API change,',
-    'minor = new backward-compatible feature/prop/export, patch = bug fix,',
-    'internal refactor, docs, or other non-breaking change.',
-    'For the repo-root entry (identifier "."), `bump` must always be exactly "none"',
-    '— it has no version number, it only gets a dated changelog entry.',
-    '`entry` must be markdown bullet lines starting with "- ", matching the',
-    'structure and detail level of the style example given for that entry.',
-    'Write the bullet text itself in Korean (한국어), regardless of what',
-    'language the style example or older changelog entries happen to be in —',
-    'this only affects the language of new text you write, not existing content.',
-    'Keep each bullet concise and terse: do NOT end sentences with polite',
-    'full-sentence endings like "~했습니다" or "~합니다"; end with a short',
-    'noun/verb-stem form instead (e.g. "~추가", "~수정", "~개선", "~제거"),',
-    'matching this repository\'s commit-message convention style.',
+    'Decide a semver `bump`: major = breaking API change, minor = new',
+    'backward-compatible feature/prop/export, patch = bug fix, internal',
+    'refactor, docs, or other non-breaking change.',
+    '`changes` groups the update into Keep a Changelog categories — only',
+    'include the categories that actually apply; each value is an array of',
+    'short bullet strings (no leading "- ", that is added automatically).',
+    'Write bullet text in Korean (한국어), regardless of what language the',
+    'style example or older changelog entries happen to be in — this only',
+    'affects the language of new text you write, not existing content.',
+    'Keep each bullet concise and terse: do NOT end with polite full-sentence',
+    'endings like "~했습니다" or "~합니다"; end with a short noun/verb-stem',
+    'form instead (e.g. "~추가", "~수정", "~개선", "~제거"), matching this',
+    "repository's commit-message convention style.",
     'Only include entries that have a real, user-facing/API-relevant, or',
     'meaningfully-affects-contributors change; omit anything that is purely',
     'internal/test/story-only noise with no one who would care to read about it.',
@@ -260,14 +288,9 @@ async function main() {
 
   for (const result of results) {
     const { pkg } = changed.find(c => c.pkg.dir === result.package);
-    if (pkg.isRoot) {
-      applyRootChangelogEntry(pkg, result.entry);
-      console.log(`Updated ${pkg.dir}/CHANGELOG.md (dated entry)`);
-      continue;
-    }
     const newVersion = bumpVersion(pkg.version, result.bump);
     applyVersionBump(pkg, newVersion);
-    applyChangelogEntry(pkg, newVersion, result.bump, result.entry);
+    applyChangelogEntry(pkg, newVersion, result.changes);
     console.log(`Updated ${pkg.dir}: ${pkg.version} -> ${newVersion} (${result.bump})`);
   }
 }

--- a/.github/workflows/changelog-develop.yml
+++ b/.github/workflows/changelog-develop.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check for changelog changes
         id: changes
         run: |
-          if git status --porcelain -- 'packages/*/CHANGELOG.md' 'packages/*/package.json' 'CHANGELOG.md' | grep -q .; then
+          if git status --porcelain -- 'packages/*/CHANGELOG.md' 'packages/*/package.json' 'CHANGELOG.md' 'package.json' | grep -q .; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -47,7 +47,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -- 'packages/*/CHANGELOG.md' 'packages/*/package.json' 'CHANGELOG.md'
+          git add -- 'packages/*/CHANGELOG.md' 'packages/*/package.json' 'CHANGELOG.md' 'package.json'
           git commit -m "🔧 chore: changelog 자동 업데이트"
 
       - name: Open changelog PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+이 프로젝트의 모든 주요 변경사항을 이 파일에 기록합니다.
+
+형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
+이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-05
+
+### 추가
+
+- 루트 CHANGELOG.md 도입
+- `develop` 브랜치 통합 changelog 자동화 파이프라인 추가 (GitHub Models 기반 semver bump + changelog 작성, PR 자동 생성/머지)
+- CI 워크플로우에 `develop` 브랜치 트리거 추가

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ui-kit",
+  "version": "0.1.0",
   "private": false,
   "scripts": {
     "build": "turbo run build",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,150 +1,175 @@
 # @repo/ui
 
-## 2.5.0
+이 프로젝트의 모든 주요 변경사항을 이 파일에 기록합니다.
 
-### Minor Changes
+형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
+이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
-- 88a1ed9: ### Added
-  - Add a ConfigProvider export to the UI package for applying nested theme token overrides and dark mode settings.
+## [Unreleased]
 
-  ### Changed
-  - Update button, switch, and shared theme styling to respect provider-driven theme values.
-  - Add a Storybook example covering token overrides, dark mode, and nested provider usage.
+## [2.5.0] - 2026-04-05
 
-## 2.4.0
+### 추가
 
-### Minor Changes
+- `ConfigProvider` export 추가 (중첩 테마 토큰 오버라이드 및 다크 모드 설정 적용)
 
-- 37d5889: ### Added
-  - Add `optionType` (`'default' | 'button'`) and `buttonStyle`, `size`, `disabled` props to `Radio.Group` for button-style radio rendering
-  - Add `type` (`'primary' | 'default' | 'dashed' | 'text' | 'link'`) and `shape` (`'default' | 'circle' | 'round'`) props to `Button`
-  - Add `size` (`'small' | 'medium'`) prop to `Switch`
-  - Add `checkedChildren` and `unCheckedChildren` props to `Switch` for animated label rendering
-  - Expose `children` slot in core `Switch` primitive
+### 변경
 
-  ### Changed
-  - `Radio.Group` default orientation changed from `'vertical'` to `'horizontal'`
-  - `Button` now resolves `variant` from `type` prop via internal `typeToVariant` mapping when `variant` is not explicitly set
-  - `OptionValue` type moved to `Group` module and re-exported from parent for both `Radio` and `Checkbox`
-  - Icon-only `Button` sizing updated to include SVG size utilities via `iconClasses`
+- 버튼, 스위치, 공용 테마 스타일이 provider 기반 테마 값을 반영하도록 개선
+- 토큰 오버라이드/다크 모드/중첩 provider 사용 예시를 다루는 Storybook 스토리 추가
 
-## 2.3.4
+## [2.4.0] - 2026-03-22
 
-### Patch Changes
+### 추가
 
-- 59f10bf: Build pipeline cleanup: move to tsdown config, adjust CSS output name, and update TS build settings.
+- `Radio.Group`에 `optionType`(`'default' | 'button'`), `buttonStyle`, `size`, `disabled` prop 추가 (버튼 스타일 라디오 렌더링)
+- `Button`에 `type`(`'primary' | 'default' | 'dashed' | 'text' | 'link'`), `shape`(`'default' | 'circle' | 'round'`) prop 추가
+- `Switch`에 `size`(`'small' | 'medium'`) prop 추가
+- `Switch`에 `checkedChildren`, `unCheckedChildren` prop 추가 (애니메이션 라벨 렌더링)
+- core `Switch` 프리미티브에 `children` 슬롯 노출
 
-## 2.3.3
+### 변경
 
-### Patch Changes
+- `Radio.Group` 기본 방향을 `'vertical'`에서 `'horizontal'`로 변경
+- `Button`이 `variant`를 명시하지 않으면 내부 `typeToVariant` 매핑으로 `type`에서 결정하도록 변경
+- `OptionValue` 타입을 `Group` 모듈로 이동, `Radio`/`Checkbox` 양쪽에서 재노출
+- 아이콘 전용 `Button` 사이즈 처리에 `iconClasses` 기반 SVG 크기 유틸리티 반영
 
-- 92fb2eb: 🔧 Fix core export destructuring error in field component
+## [2.3.4] - 2026-02-10
 
-## 2.3.2
+### 변경
 
-### Patch Changes
+- 빌드 파이프라인 정리: tsdown 설정으로 전환, CSS 출력 이름 조정, TS 빌드 설정 업데이트
 
-- 958564b: 🔧 Support both namespace and direct imports for core primitives
+## [2.3.3] - 2026-02-06
 
-## 2.3.1
+### 수정
 
-### Patch Changes
+- field 컴포넌트의 core export 구조 분해 오류 수정
 
-- d72e24d: Expose core primitives through package exports
+## [2.3.2] - 2026-02-05
 
-## 2.3.0
+### 수정
 
-### Minor Changes
+- core 프리미티브에서 네임스페이스 import와 직접 import 방식 모두 지원하도록 수정
 
-- 79985b2: Add new components and improve component APIs
+## [2.3.1] - 2026-02-05
 
-## 2.2.2
+### 추가
 
-### Patch Changes
+- 패키지 export를 통해 core 프리미티브 노출
 
-- f2bd519: Bump version for current updates
+## [2.3.0] - 2026-02-05
 
-## 2.2.1
+### 추가
 
-### Patch Changes
+- 신규 컴포넌트 추가
 
-- ad5e9e0: Clamp progress values to 0–100 to stabilize rendering
+### 변경
 
-## 2.2.0
+- 컴포넌트 API 개선
 
-### Minor Changes
+## [2.2.2] - 2026-02-03
 
-- 85b738f: - Add new UI components: Radio, Select, and ColorPicker
-  - Improve styles and options across Popover, Progress, Switch, and Textarea
+### 변경
 
-## 2.1.0
+- 버전 정리 (기능 변경 없음)
 
-### Minor Changes
+## [2.2.1] - 2026-02-03
 
-- f115fdc: Refactor component architecture with centralized core exports and improve component APIs. Add Popover placement options, enhance conditional rendering patterns across Card and Drawer, and update multiple components (Button, Checkbox, Input, Progress, Skeleton, Switch) to use new core import structure.
+### 수정
 
-## 2.0.1
+- Progress 값을 0~100 범위로 clamp 처리해 렌더링 안정화
 
-### Patch Changes
+## [2.2.0] - 2026-02-03
 
-- 1ef2f59: chore: version bump
+### 추가
 
-## 2.0.0
+- Radio, Select, ColorPicker 신규 컴포넌트 추가
 
-### Major Changes
+### 변경
 
-- 21f313a: ✨ feat(Button): enhance button variant and color handling
+- Popover, Progress, Switch, Textarea 스타일 및 옵션 개선
 
-## 1.1.7
+## [2.1.0] - 2026-01-28
 
-### Patch Changes
+### 추가
 
-- d18a357: ✨ feat(Marquees): improve width handling and responsiveness
+- Popover placement 옵션 추가
 
-## 1.1.6
+### 변경
 
-### Patch Changes
+- 컴포넌트 아키텍처를 centralized core export 구조로 리팩터링
+- Card, Drawer의 조건부 렌더링 패턴 개선
+- Button, Checkbox, Input, Progress, Skeleton, Switch가 새로운 core import 구조를 사용하도록 변경
 
-- 1029930: ✨ feat(components): add Input component export
+## [2.0.1] - 2026-01-26
 
-## 1.1.5
+### 변경
 
-### Patch Changes
+- 버전 정리
 
-- 3ba1911: 🔧 chore(tsdown.config): remove unused external dependencies
+## [2.0.0] - 2026-01-24
 
-## 1.1.4
+### 변경
 
-### Patch Changes
+- **(주요 변경)** `Button` variant 및 color 처리 방식 개선
 
-- 661cd76: 📝 docs: update language links in README files
+## [1.1.7] - 2026-01-24
 
-## 1.1.3
+### 변경
 
-### Patch Changes
+- Marquees 너비 처리 및 반응형 개선
 
-- 9b84114: 🔧 chore(ci): restrict CI to main branch only
+## [1.1.6] - 2026-01-18
 
-## 1.1.2
+### 추가
 
-### Patch Changes
+- `Input` 컴포넌트 export 추가
 
-- 7a8117d: 🔧 chore(publish): update publish workflow and scripts
+## [1.1.5] - 2026-01-18
 
-## 1.1.1
+### 제거
 
-### Patch Changes
+- tsdown 설정에서 미사용 외부 의존성 제거
 
-- b41abee: chore: add changeset for @repo/ui minor version bump
+## [1.1.4] - 2026-01-18
 
-## 1.1.0
+### 변경
 
-### Minor Changes
+- README 파일 언어 링크 업데이트
 
-- e4053d1: Add Card and Label components, enhance Button and Checkbox
+## [1.1.3] - 2026-01-17
 
-## 1.0.1
+### 변경
 
-### Patch Changes
+- CI를 main 브랜치로만 제한
 
-- a2bd190: build: 빌드 설정 업데이트, 배포 스크립트 에러 처리 개선 및 .gitignore 규칙 수정
+## [1.1.2] - 2026-01-17
+
+### 변경
+
+- publish 워크플로우 및 스크립트 업데이트
+
+## [1.1.1] - 2026-01-17
+
+### 변경
+
+- 버전 관리용 changeset 정리
+
+## [1.1.0] - 2026-01-17
+
+### 추가
+
+- `Card`, `Label` 컴포넌트 추가
+
+### 변경
+
+- `Button`, `Checkbox` 개선
+
+## [1.0.1] - 2026-01-10
+
+### 변경
+
+- 빌드 설정 업데이트, 배포 스크립트 에러 처리 개선
+- `.gitignore` 규칙 수정


### PR DESCRIPTION
…elog format

- root and per-package CHANGELOG.md now use "## [x.y.z] - YYYY-MM-DD" headings with Added/Changed/Deprecated/Removed/Fixed/Security (한글) subsections, plus a standing "## [Unreleased]" section, per keepachangelog.com/en/1.1.0
- root package.json now has a real version (0.1.0), so the automation script treats it as a normal versioned package instead of a dated no-version log
- rewrote root CHANGELOG.md and packages/ui/CHANGELOG.md content into this format in Korean, using actual commit dates for each historical version

## Summary

<!-- Briefly describe the changes -->

## Changes

<!-- Describe the changes in detail -->

-

## Type of Change

<!-- Check all that apply -->

- [ ] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

<!-- If there are UI changes, attach screenshots or a Storybook link -->

## Checklist

- [ ] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [ ] A `.changeset/*.md` file has been added (run `changeset` command)
- [ ] Storybook stories are added for new components / features
- [ ] No type or lint errors (`pnpm lint`, `pnpm typecheck`)
- [ ] Build completes successfully (`pnpm build`)
