### PR TITLE
🔀 develop → main 동기화 (버전 충돌 수정)

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.2] - 2026-07-21
+
+### Changed
+
+- Version bump only, no code changes. Skips 2.9.0/2.9.1: those version numbers were already published to npm from an earlier direct-push-to-main mistake (since reverted) and can't be reused, so this release picks up the next clean number.
+
 ## [2.9.0] - 2026-07-21
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.3] - 2026-07-21
+
+### Changed
+
+- Bump version to 2.9.2
+
 ## [2.9.2] - 2026-07-21
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",


### PR DESCRIPTION
이전 #89 머지 이후 발견된 버전 충돌(2.9.0/2.9.1이 이미 npm에 발행되어 있어 publish가 스킵됨)을 바로잡기 위해 2.9.3으로 재범프.