### PR TITLE
develop -> main sync (version fix)

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.4] - 2026-07-21
+
+### Changed
+
+- Version bump only, no code changes. Skips 2.9.0-2.9.3: those version numbers are already published on npm and can't be reused, so this release picks up the next clean number.
+
 ## [2.9.0] - 2026-07-21
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.5] - 2026-07-21
+
+### Changed
+
+- Bump version to 2.9.4
+
 ## [2.9.4] - 2026-07-21
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.9.0",
+  "version": "2.9.4",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",


### PR DESCRIPTION
Version bump only, fixes npm publish collision from the previous merge.