### PR TITLE
ci: fix GitHub Release creation for tagged publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,3 +72,34 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "v${{ steps.tag_check.outputs.version }}"
           git push origin "v${{ steps.tag_check.outputs.version }}"
+
+      # release.yml used to do this on tag push, but a tag pushed with the
+      # default GITHUB_TOKEN (as above) never triggers another workflow run
+      # — GitHub blocks that to prevent recursive runs — so it never fired.
+      # Doing it here, in the same job/token context, sidesteps that
+      # entirely instead of needing a separate PAT.
+      - name: Get changelog entry
+        if: steps.tag_check.outputs.already_tagged == 'false'
+        id: changelog
+        run: |
+          VERSION=${{ steps.tag_check.outputs.version }}
+          CHANGELOG_FILE="packages/ui/CHANGELOG.md"
+          if [ -f "$CHANGELOG_FILE" ]; then
+            CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
+            CONTENT="${CONTENT//'%'/'%25'}"
+            CONTENT="${CONTENT//$'\n'/'%0A'}"
+            CONTENT="${CONTENT//$'\r'/'%0D'}"
+            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.already_tagged == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.tag_check.outputs.version }}
+          body: ${{ steps.changelog.outputs.body || format('Release {0}', steps.tag_check.outputs.version) }}
+          draft: false
+          prerelease: ${{ contains(steps.tag_check.outputs.version, 'alpha') || contains(steps.tag_check.outputs.version, 'beta') || contains(steps.tag_check.outputs.version, 'rc') }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,20 @@
-name: Release
+name: Release (manual backfill)
 
+# publish.yml now creates the GitHub Release itself right after tagging, in
+# the same job/token context — a tag pushed with the default GITHUB_TOKEN
+# never triggers another workflow run, so a `push: tags` trigger here would
+# never fire. This workflow is kept only as a manual fallback to (re)create
+# a release for an existing tag, e.g. to backfill one that's missing.
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to create/recreate a GitHub Release for (e.g. v2.9.7)'
+        required: true
+        type: string
 
 permissions:
   contents: write
-  discussions: write
 
 jobs:
   release:
@@ -17,44 +24,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm run build
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Get changelog entry
         id: changelog
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          CHANGELOG_FILE="CHANGELOG.md"
+          VERSION=${{ github.event.inputs.tag }}
+          VERSION=${VERSION#v}
+          CHANGELOG_FILE="packages/ui/CHANGELOG.md"
           if [ -f "$CHANGELOG_FILE" ]; then
-            # Extract changelog for this version
             CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
             CONTENT="${CONTENT//'%'/'%25'}"
             CONTENT="${CONTENT//$'\n'/'%0A'}"
             CONTENT="${CONTENT//$'\r'/'%0D'}"
-            echo "body=$CONTENT" >> $GITHUB_OUTPUT
+            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          body: ${{ steps.changelog.outputs.body || format('Release {0}', github.ref_name) }}
+          tag_name: ${{ github.event.inputs.tag }}
+          body: ${{ steps.changelog.outputs.body || format('Release {0}', github.event.inputs.tag) }}
           draft: false
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          prerelease: ${{ contains(github.event.inputs.tag, 'alpha') || contains(github.event.inputs.tag, 'beta') || contains(github.event.inputs.tag, 'rc') }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- publish.yml now creates the GitHub Release itself right after tagging, in the same job (previously relied on release.yml's `push: tags` trigger, which never fired because the tag is pushed with the default GITHUB_TOKEN and GitHub blocks GITHUB_TOKEN-authored pushes from triggering other workflows)
- release.yml converted to a manual workflow_dispatch fallback for backfilling a missing release, now reading from packages/ui/CHANGELOG.md to match actual per-package versioning