### PR TITLE
chore: sync main with develop (CI release-creation fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,3 +72,34 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "v${{ steps.tag_check.outputs.version }}"
           git push origin "v${{ steps.tag_check.outputs.version }}"
+
+      # release.yml used to do this on tag push, but a tag pushed with the
+      # default GITHUB_TOKEN (as above) never triggers another workflow run
+      # — GitHub blocks that to prevent recursive runs — so it never fired.
+      # Doing it here, in the same job/token context, sidesteps that
+      # entirely instead of needing a separate PAT.
+      - name: Get changelog entry
+        if: steps.tag_check.outputs.already_tagged == 'false'
+        id: changelog
+        run: |
+          VERSION=${{ steps.tag_check.outputs.version }}
+          CHANGELOG_FILE="packages/ui/CHANGELOG.md"
+          if [ -f "$CHANGELOG_FILE" ]; then
+            CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
+            CONTENT="${CONTENT//'%'/'%25'}"
+            CONTENT="${CONTENT//$'\n'/'%0A'}"
+            CONTENT="${CONTENT//$'\r'/'%0D'}"
+            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.already_tagged == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.tag_check.outputs.version }}
+          body: ${{ steps.changelog.outputs.body || format('Release {0}', steps.tag_check.outputs.version) }}
+          draft: false
+          prerelease: ${{ contains(steps.tag_check.outputs.version, 'alpha') || contains(steps.tag_check.outputs.version, 'beta') || contains(steps.tag_check.outputs.version, 'rc') }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,20 @@
-name: Release
+name: Release (manual backfill)
 
+# publish.yml now creates the GitHub Release itself right after tagging, in
+# the same job/token context — a tag pushed with the default GITHUB_TOKEN
+# never triggers another workflow run, so a `push: tags` trigger here would
+# never fire. This workflow is kept only as a manual fallback to (re)create
+# a release for an existing tag, e.g. to backfill one that's missing.
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to create/recreate a GitHub Release for (e.g. v2.9.7)'
+        required: true
+        type: string
 
 permissions:
   contents: write
-  discussions: write
 
 jobs:
   release:
@@ -17,44 +24,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm run build
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Get changelog entry
         id: changelog
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          CHANGELOG_FILE="CHANGELOG.md"
+          VERSION=${{ github.event.inputs.tag }}
+          VERSION=${VERSION#v}
+          CHANGELOG_FILE="packages/ui/CHANGELOG.md"
           if [ -f "$CHANGELOG_FILE" ]; then
-            # Extract changelog for this version
             CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
             CONTENT="${CONTENT//'%'/'%25'}"
             CONTENT="${CONTENT//$'\n'/'%0A'}"
             CONTENT="${CONTENT//$'\r'/'%0D'}"
-            echo "body=$CONTENT" >> $GITHUB_OUTPUT
+            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          body: ${{ steps.changelog.outputs.body || format('Release {0}', github.ref_name) }}
+          tag_name: ${{ github.event.inputs.tag }}
+          body: ${{ steps.changelog.outputs.body || format('Release {0}', github.event.inputs.tag) }}
           draft: false
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          prerelease: ${{ contains(github.event.inputs.tag, 'alpha') || contains(github.event.inputs.tag, 'beta') || contains(github.event.inputs.tag, 'rc') }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-22
+
+### Added
+
+- Add manual fallback workflow for creating GitHub Releases for existing tags
+- Add input parameter for existing git tag in manual release workflow
+- Add changelog entry retrieval in publish workflow
+
+### Changed
+
+- Change release workflow trigger from tag push to manual dispatch
+- Update publish workflow to create GitHub Release immediately after tagging
+
 ## [0.4.5] - 2026-07-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-kit",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "private": false,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## Summary
- Brings the publish.yml/release.yml fix (GitHub Release now created inline in publish.yml, since the tag push never triggered release.yml's old trigger) onto main
- packages/ui stays at 2.9.7 (no new version this round) — this PR only carries CI/workflow + root tooling changes