### PR TITLE
fix: changelog entry extraction returning empty content

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,15 @@ jobs:
           VERSION=${{ steps.tag_check.outputs.version }}
           CHANGELOG_FILE="packages/ui/CHANGELOG.md"
           if [ -f "$CHANGELOG_FILE" ]; then
-            CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
+            # Can't use awk's `/start/,/end/` range here: the end pattern
+            # (any "## [" header) also matches the start line itself, so the
+            # range would close immediately and yield nothing. Skip the
+            # start header explicitly and exit before printing the next one.
+            CONTENT=$(awk -v version="$VERSION" '
+              $0 ~ "^## \\[" version "\\]" { found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' "$CHANGELOG_FILE")
             CONTENT="${CONTENT//'%'/'%25'}"
             CONTENT="${CONTENT//$'\n'/'%0A'}"
             CONTENT="${CONTENT//$'\r'/'%0D'}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,15 @@ jobs:
           VERSION=${VERSION#v}
           CHANGELOG_FILE="packages/ui/CHANGELOG.md"
           if [ -f "$CHANGELOG_FILE" ]; then
-            CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
+            # Can't use awk's `/start/,/end/` range here: the end pattern
+            # (any "## [" header) also matches the start line itself, so the
+            # range would close immediately and yield nothing. Skip the
+            # start header explicitly and exit before printing the next one.
+            CONTENT=$(awk -v version="$VERSION" '
+              $0 ~ "^## \\[" version "\\]" { found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' "$CHANGELOG_FILE")
             CONTENT="${CONTENT//'%'/'%25'}"
             CONTENT="${CONTENT//$'\n'/'%0A'}"
             CONTENT="${CONTENT//$'\r'/'%0D'}"


### PR DESCRIPTION
## Summary
- Fix the awk range pattern used to extract a CHANGELOG.md entry for GitHub Release bodies: the end pattern (any `## [` header) also matched the start line itself, so the range closed immediately and always produced empty content
- Applies to both publish.yml's inline release-creation step and release.yml's manual backfill workflow
- Verified locally against the 2.9.7 and 2.9.0 entries — now extracts the expected bullet content