### PR TITLE
chore: sync main with develop (changelog extraction fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,15 @@ jobs:
           VERSION=${{ steps.tag_check.outputs.version }}
           CHANGELOG_FILE="packages/ui/CHANGELOG.md"
           if [ -f "$CHANGELOG_FILE" ]; then
-            CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
+            # Can't use awk's `/start/,/end/` range here: the end pattern
+            # (any "## [" header) also matches the start line itself, so the
+            # range would close immediately and yield nothing. Skip the
+            # start header explicitly and exit before printing the next one.
+            CONTENT=$(awk -v version="$VERSION" '
+              $0 ~ "^## \\[" version "\\]" { found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' "$CHANGELOG_FILE")
             CONTENT="${CONTENT//'%'/'%25'}"
             CONTENT="${CONTENT//$'\n'/'%0A'}"
             CONTENT="${CONTENT//$'\r'/'%0D'}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,15 @@ jobs:
           VERSION=${VERSION#v}
           CHANGELOG_FILE="packages/ui/CHANGELOG.md"
           if [ -f "$CHANGELOG_FILE" ]; then
-            CONTENT=$(awk "/## \[$VERSION\]/,/## \[/" "$CHANGELOG_FILE" | head -n -1)
+            # Can't use awk's `/start/,/end/` range here: the end pattern
+            # (any "## [" header) also matches the start line itself, so the
+            # range would close immediately and yield nothing. Skip the
+            # start header explicitly and exit before printing the next one.
+            CONTENT=$(awk -v version="$VERSION" '
+              $0 ~ "^## \\[" version "\\]" { found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' "$CHANGELOG_FILE")
             CONTENT="${CONTENT//'%'/'%25'}"
             CONTENT="${CONTENT//$'\n'/'%0A'}"
             CONTENT="${CONTENT//$'\r'/'%0D'}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-22
+
+### Changed
+
+- Improve changelog extraction logic in publish and release workflows
+
 ## [0.5.0] - 2026-07-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-kit",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## Summary
- Brings the awk changelog-extraction fix onto main (was producing empty GitHub Release bodies)
- packages/ui stays at 2.9.7 (no new version this round) — CI/workflow-only change