### PR TITLE
chore: release 2.10.0 (List improvements, CI release fixes)

### DIFF
--- a/apps/docs/stories/organisms/list/index.stories.tsx
+++ b/apps/docs/stories/organisms/list/index.stories.tsx
@@ -32,6 +32,9 @@ const meta: Meta<typeof List<Item>> = {
     renderItem: {
       action: 'renderItem',
     },
+    itemKey: {
+      action: 'itemKey',
+    },
   },
 };
 
@@ -42,10 +45,26 @@ export const Default: Story = {
   args: {
     loading: false,
     data: defaultData,
+    itemKey: item => item.id,
     renderItem: item => (
-      <div key={item.id} className="rounded-lg border p-4">
+      <div className="rounded-lg border p-4">
         <h3 className="font-semibold">{item.name}</h3>
         <p className="text-gray-600">{item.description}</p>
+      </div>
+    ),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    loading: false,
+    data: [],
+    empty: (
+      <div
+        className="rounded-lg border border-dashed p-8 text-center
+          text-gray-500"
+      >
+        No items to display.
       </div>
     ),
   },

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-07-22
+
+### Added
+
+- Add role attribute to list item component
+- Add titleLevel prop to List component
+- Add itemKey prop to List component
+
+### Changed
+
+- Change title rendering to use Title component
+- Change list rendering to use role attribute
+
 ## [2.9.7] - 2026-07-22
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.9.7",
+  "version": "2.10.0",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",

--- a/packages/ui/src/components/organisms/list/item.tsx
+++ b/packages/ui/src/components/organisms/list/item.tsx
@@ -6,7 +6,7 @@ const Item = ({
   ...props
 }: React.ComponentPropsWithoutRef<'div'>) => {
   return (
-    <div className={cn(className)} {...props}>
+    <div role="listitem" className={cn(className)} {...props}>
       {children}
     </div>
   );

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -32,6 +32,7 @@ interface Props<T> extends Omit<
   };
   data?: T[];
   renderItem?: (item: T, index: number) => React.ReactNode;
+  itemKey?: (item: T, index: number) => React.Key;
 }
 
 const List = <T,>({
@@ -46,6 +47,7 @@ const List = <T,>({
   className,
   classNames,
   renderItem = () => null,
+  itemKey,
   ...props
 }: Props<T>) => {
   const [loaderRef, entry] = useIntersectionObserver({
@@ -82,7 +84,11 @@ const List = <T,>({
   }
 
   if (!data?.length && empty) {
-    return empty;
+    return (
+      <div className={cn(className)} {...props}>
+        {empty}
+      </div>
+    );
   }
 
   return (
@@ -106,12 +112,20 @@ const List = <T,>({
       ))}
       <div className={cn(classNames?.header)}>{header}</div>
       <div className={cn('space-y-2', classNames?.body)}>
-        {data?.map((item, i) => renderItem(item, i))}
+        {data?.map((item, i) =>
+          itemKey ? (
+            <React.Fragment key={itemKey(item, i)}>
+              {renderItem(item, i)}
+            </React.Fragment>
+          ) : (
+            renderItem(item, i)
+          ),
+        )}
         {scroll?.loading &&
           (scroll?.loader ?? (
             <Skeleton.Node count={10} gap={10} {...loaderProps} />
           ))}
-        <div ref={loaderRef} />
+        {scroll && <div ref={loaderRef} />}
       </div>
     </div>
   );

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { useIntersectionObserver } from '@uidotdev/usehooks';
 
 import { cn, renderConditional } from '@repo/ui/utils';
 
 import Skeleton from '../../atoms/skeleton';
+import { Title } from '../../atoms/typography';
 
 interface Props<T> extends Omit<
   React.ComponentPropsWithoutRef<'div'>,
@@ -16,6 +17,7 @@ interface Props<T> extends Omit<
   loaderProps?: React.ComponentProps<typeof Skeleton>;
   loader?: React.ReactNode;
   title?: React.ReactNode;
+  titleLevel?: 1 | 2 | 3 | 4 | 5 | 6;
   header?: React.ReactNode;
   empty?: React.ReactNode;
   classNames?: {
@@ -41,6 +43,7 @@ const List = <T,>({
   loader,
   header,
   title,
+  titleLevel = 2,
   empty,
   scroll,
   data,
@@ -57,12 +60,25 @@ const List = <T,>({
     ...scroll?.options,
   });
 
+  // `scroll` is typically a new object identity every render, so this
+  // effect re-runs often. Guard with a ref (updated synchronously, unlike
+  // the `loading` prop which only reflects the caller's next state update)
+  // to avoid firing `next()` again for the same in-flight request before
+  // the caller's `loading` has had a chance to become true.
+  const fetchingRef = useRef(false);
+
   useEffect(() => {
     if (!scroll) {
       return;
     }
 
-    if (entry?.isIntersecting && scroll.hasMore && !scroll.loading) {
+    if (scroll.loading) {
+      fetchingRef.current = false;
+      return;
+    }
+
+    if (entry?.isIntersecting && scroll.hasMore && !fetchingRef.current) {
+      fetchingRef.current = true;
       scroll.next();
     }
   }, [entry, scroll]);
@@ -100,7 +116,8 @@ const List = <T,>({
       {...props}
     >
       {renderConditional(title, v => (
-        <h2
+        <Title
+          level={titleLevel}
           className={cn(
             'px-1.5 py-4',
             'text-black-90 text-lg leading-5.75 font-bold',
@@ -108,10 +125,10 @@ const List = <T,>({
           )}
         >
           {v}
-        </h2>
+        </Title>
       ))}
       <div className={cn(classNames?.header)}>{header}</div>
-      <div className={cn('space-y-2', classNames?.body)}>
+      <div role="list" className={cn('space-y-2', classNames?.body)}>
         {data?.map((item, i) =>
           itemKey ? (
             <React.Fragment key={itemKey(item, i)}>


### PR DESCRIPTION
## Summary
- List component improvements: empty-state container consistency, itemKey, infinite-scroll observer/refetch guard, Typography.Title-based title with configurable level, list/listitem a11y roles
- CI: publish.yml now creates the GitHub Release inline (release.yml's tag-push trigger never fired due to GITHUB_TOKEN recursion guard), plus a changelog-extraction awk fix
- Version bumped to 2.10.0