### PR TITLE
chore: release 2.11.0 (responsive Title, tree-shaking)

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-07-23
+
+### Added
+
+- Add sideEffects configuration for CSS files
+- Implement responsive typography scaling for title component
+
 ## [2.10.0] - 2026-07-22
 
 ### Added

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/pjb0811/ui-kit/issues"
   },
   "private": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui/src/components/atoms/typography/title.tsx
+++ b/packages/ui/src/components/atoms/typography/title.tsx
@@ -8,13 +8,16 @@ export interface Props extends React.ComponentPropsWithoutRef<
 
 type ElementType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
+// Scale up at wider breakpoints instead of a single fixed size — the desktop
+// size stays the same as before, but narrow/mobile viewports now get a
+// smaller starting size instead of always rendering at the full desktop size.
 const styles: Record<string, string> = {
-  h1: 'text-6xl',
-  h2: 'text-5xl',
-  h3: 'text-4xl',
-  h4: 'text-3xl',
-  h5: 'text-2xl',
-  h6: 'text-xl',
+  h1: 'text-4xl sm:text-5xl lg:text-6xl',
+  h2: 'text-3xl sm:text-4xl lg:text-5xl',
+  h3: 'text-2xl sm:text-3xl lg:text-4xl',
+  h4: 'text-xl sm:text-2xl lg:text-3xl',
+  h5: 'text-lg sm:text-xl lg:text-2xl',
+  h6: 'text-base sm:text-lg lg:text-xl',
 };
 
 const Title = ({ children, level = 1, className, ...props }: Props) => {


### PR DESCRIPTION
## Summary
- Add sideEffects field to enable tree-shaking when consumers import multiple components from the root barrel
- Fix Typography.Title rendering at a single fixed font size regardless of viewport (mobile oversized headings) by scaling via sm:/lg: breakpoints
- Version bumped to 2.11.0