### PR TITLE
fix: %0A literal text in GitHub Release body

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,10 +94,16 @@ jobs:
               found && /^## \[/ { exit }
               found { print }
             ' "$CHANGELOG_FILE")
-            CONTENT="${CONTENT//'%'/'%25'}"
-            CONTENT="${CONTENT//$'\n'/'%0A'}"
-            CONTENT="${CONTENT//$'\r'/'%0D'}"
-            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
+            # %0A/%0D/%25 escaping only applied to the old, deprecated
+            # `::set-output` command syntax (which the runner auto-decoded).
+            # The modern $GITHUB_OUTPUT file doesn't decode that, so it was
+            # writing literal "%0A" text into the release body. Use the
+            # heredoc form instead, which preserves real newlines as-is.
+            {
+              echo "body<<EOF"
+              echo "$CONTENT"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,16 @@ jobs:
               found && /^## \[/ { exit }
               found { print }
             ' "$CHANGELOG_FILE")
-            CONTENT="${CONTENT//'%'/'%25'}"
-            CONTENT="${CONTENT//$'\n'/'%0A'}"
-            CONTENT="${CONTENT//$'\r'/'%0D'}"
-            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
+            # %0A/%0D/%25 escaping only applied to the old, deprecated
+            # `::set-output` command syntax (which the runner auto-decoded).
+            # The modern $GITHUB_OUTPUT file doesn't decode that, so it was
+            # writing literal "%0A" text into the release body. Use the
+            # heredoc form instead, which preserves real newlines as-is.
+            {
+              echo "body<<EOF"
+              echo "$CONTENT"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- \$GITHUB_OUTPUT's file-based mechanism doesn't decode %0A/%0D/%25 (that escaping only worked with the old, deprecated ::set-output command syntax), so release bodies were showing literal "%0A" instead of line breaks
- Switch to \$GITHUB_OUTPUT's heredoc (body<<EOF ... EOF) syntax in both publish.yml and release.yml