### PR TITLE
🐛 fix: layout root missing height anchor

### DIFF
--- a/apps/docs/stories/templates/layout/index.stories.tsx
+++ b/apps/docs/stories/templates/layout/index.stories.tsx
@@ -102,7 +102,7 @@ const DemoFooter = () => (
 
 export const Default: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -118,7 +118,7 @@ export const Default: Story = {
 
 export const WithSider: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -140,7 +140,7 @@ export const WithSider: Story = {
 export const CollapsibleSider: Story = {
   name: 'WithSider (Collapsible)',
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -163,7 +163,7 @@ const DemoControlledSider = () => {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <Typography.Title className="text-3xl">Header</Typography.Title>
         <button
@@ -202,7 +202,7 @@ export const ControlledSider: Story = {
 
 export const WithSiderRight: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -223,7 +223,7 @@ export const WithSiderRight: Story = {
 
 export const HeaderOnly: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -236,7 +236,7 @@ export const HeaderOnly: Story = {
 
 export const FooterOnly: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Content>
         <DemoContent />
       </Layout.Content>

--- a/packages/ui/src/components/templates/layout/layout.tsx
+++ b/packages/ui/src/components/templates/layout/layout.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement } from 'react';
+import { Children, createContext, isValidElement, useContext } from 'react';
 
 import { cn } from '@repo/ui/utils';
 
@@ -6,25 +6,36 @@ import Sider from './sider';
 
 export interface Props extends React.ComponentPropsWithoutRef<'div'> {}
 
+const LayoutNestedContext = createContext(false);
+
 const hasSiderChild = (children: React.ReactNode) =>
   Children.toArray(children).some(
     child => isValidElement(child) && child.type === Sider,
   );
 
 const Layout = ({ children, className, ...props }: Props) => {
+  const isNested = useContext(LayoutNestedContext);
   const isRow = hasSiderChild(children);
 
   return (
-    <div
-      className={cn(
-        'flex min-h-0 w-full flex-1',
-        isRow ? 'flex-row' : 'flex-col',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </div>
+    <LayoutNestedContext.Provider value>
+      <div
+        className={cn(
+          'flex w-full flex-1',
+          // A nested Layout (the Sider row wrapper) must stay free to
+          // shrink/grow inside its parent's flex column, so it keeps
+          // min-h-0. The outermost Layout has no ancestor to size against,
+          // so it needs its own height anchor or flex-1/grow are no-ops
+          // and Content collapses under Footer.
+          isNested ? 'min-h-0' : 'min-h-screen',
+          isRow ? 'flex-row' : 'flex-col',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </LayoutNestedContext.Provider>
   );
 };
 


### PR DESCRIPTION
## Summary
- Layout root had no height anchor (`min-h-0` only), so `flex-1`/`grow` were no-ops when Layout is used as the outermost element — Content collapsed under Footer on the live site (pjb0811.github.io main page).
- Added `LayoutNestedContext` so the outermost `Layout` gets `min-h-screen` by default, while the nested `Layout` row-wrapper used for `Sider` layouts keeps `min-h-0` (still needs to shrink/grow inside its flex-column parent).
- Removed the now-redundant `className="h-screen"` workaround from Storybook stories, which had been masking this exact bug in every demo.

## Test plan
- [x] `pnpm check-types` (packages/ui)
- [x] `pnpm lint` (packages/ui)
- [x] `pnpm build` (packages/ui)