### PR TITLE
🐛 fix: FloatButton hardcoded white background and missing BackTop label

### DIFF
--- a/packages/ui/src/components/atoms/float-button/back-top.tsx
+++ b/packages/ui/src/components/atoms/float-button/back-top.tsx
@@ -25,6 +25,7 @@ const BackTop = ({
 
   return (
     <FloatButton
+      aria-label="맨 위로"
       icon={<ArrowUp />}
       className={cn(
         className,

--- a/packages/ui/src/components/atoms/float-button/float-button.tsx
+++ b/packages/ui/src/components/atoms/float-button/float-button.tsx
@@ -9,7 +9,6 @@ const FloatButton = ({ className, children, ...props }: Props) => {
     <Button
       className={cn(
         'fixed right-5 bottom-5 rounded-full',
-        'bg-white hover:bg-white',
         'z-50 h-12 w-12',
         'shadow-md',
         className,


### PR DESCRIPTION
## Summary
- `FloatButton` hardcoded `bg-white hover:bg-white`, which overrode the `outlined` variant's theme tokens (`bg-background`/`hover:bg-accent`) that `Button` already provides — forced a white circle even in dark mode. Removing it lets the theme-aware variant styling apply as intended.
- `BackTop` renders an icon-only button (`<ArrowUp />`, no text) with no accessible name. Added a default `aria-label` (overridable via props), matching the pattern already used in `Sider`'s collapse trigger.

## Test plan
- [x] `pnpm check-types` (packages/ui)
- [x] `pnpm lint` (packages/ui)
- [x] `pnpm build` (packages/ui)