### PR TITLE
🐛 fix: Typography Link/Text security and layout gaps

### DIFF
--- a/packages/ui/src/components/atoms/typography/link.tsx
+++ b/packages/ui/src/components/atoms/typography/link.tsx
@@ -2,7 +2,7 @@ import { cn } from '@repo/ui/utils';
 
 export interface Props extends React.ComponentPropsWithoutRef<'a'> {}
 
-const Link = ({ children, className, ...props }: Props) => {
+const Link = ({ children, className, target, rel, ...props }: Props) => {
   return (
     <a
       className={cn(
@@ -10,6 +10,8 @@ const Link = ({ children, className, ...props }: Props) => {
         className,
         //
       )}
+      target={target}
+      rel={rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/atoms/typography/text.tsx
+++ b/packages/ui/src/components/atoms/typography/text.tsx
@@ -8,12 +8,7 @@ export interface Props extends React.ComponentPropsWithoutRef<'span'> {
 const Text = ({ children, underline, strong, className, ...props }: Props) => {
   return (
     <span
-      className={cn(
-        'text-nowrap',
-        underline && 'underline',
-        strong && 'font-bold',
-        className,
-      )}
+      className={cn(underline && 'underline', strong && 'font-bold', className)}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- `Typography.Link` never set `rel` for `target="_blank"` links, leaving a reverse-tabnabbing gap (opened page can access `window.opener`). Consumers had to remember to pass `rel="noopener noreferrer"` manually per call site (as done once already in the github.io site). Now defaults to it automatically when `target="_blank"` and no `rel` is given, while still respecting an explicit `rel` override.
- `Typography.Text` unconditionally forced `text-nowrap`, so any longer content placed in it would overflow its container instead of wrapping. Removed it to match `Paragraph`/`Title`'s default wrap behavior; callers who want single-line truncation can still opt in via `className`.

## Test plan
- [x] `pnpm check-types` (packages/ui)
- [x] `pnpm lint` (packages/ui)
- [x] `pnpm build` (packages/ui)