### PR TITLE
🐛 fix: Input.Search clear button visible on empty uncontrolled input

### DIFF
--- a/packages/ui/src/components/atoms/input/search.tsx
+++ b/packages/ui/src/components/atoms/input/search.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import { CircleX, Search as SearchOutlined } from 'lucide-react';
 
@@ -32,9 +32,17 @@ const Search = ({
   const internalRef = useRef<HTMLInputElement>(null);
   const inputRef = (ref as React.RefObject<HTMLInputElement>) || internalRef;
 
+  const [uncontrolledHasValue, setUncontrolledHasValue] =
+    useState(!!defaultValue);
+  const hasValue = value !== undefined ? !!value : uncontrolledHasValue;
+
   const onClear = () => {
     if (inputRef.current) {
       inputRef.current.value = '';
+
+      if (value === undefined) {
+        setUncontrolledHasValue(false);
+      }
 
       const event = {
         target: { value: '' },
@@ -78,7 +86,12 @@ const Search = ({
           )}
           value={value}
           defaultValue={defaultValue}
-          onChange={onChange}
+          onChange={e => {
+            if (value === undefined) {
+              setUncontrolledHasValue(!!e.target.value);
+            }
+            onChange?.(e);
+          }}
           onKeyDown={e => {
             if (e.key === 'Enter') {
               onSearch();
@@ -90,7 +103,7 @@ const Search = ({
           className={cn(
             'absolute right-2 size-4',
             'shrink-0 cursor-pointer',
-            (!allowClear || (value !== undefined && !value)) && 'hidden',
+            (!allowClear || !hasValue) && 'hidden',
           )}
           onClick={onClear}
         />


### PR DESCRIPTION
## Summary
- `Input.Search`'s clear (X) button visibility logic only checked the controlled `value` prop (`value !== undefined && !value`). In uncontrolled usage (`defaultValue` only, no `value` prop), that condition never triggers, so the clear button was always visible even when the input was empty.
- Derive `hasValue` from the controlled `value` prop when present, otherwise from local state kept in sync via the input's `onChange` and `onClear`, so both controlled and uncontrolled modes correctly hide the button when empty.

## Test plan
- [x] `pnpm check-types` (packages/ui)
- [x] `pnpm lint` (packages/ui)
- [x] `pnpm build` (packages/ui)