### PR TITLE
🐛 fix: Skeleton missing loading a11y semantics and duplicated props

### DIFF
--- a/packages/ui/src/components/atoms/skeleton/skeleton.tsx
+++ b/packages/ui/src/components/atoms/skeleton/skeleton.tsx
@@ -52,10 +52,13 @@ const Skeleton = ({
 
   return (
     <div
+      role="status"
+      aria-label="로딩 중"
       className={cn(
         'flex items-center gap-3',
         //
       )}
+      {...props}
     >
       {avatar && (
         <Core
@@ -97,7 +100,6 @@ const Skeleton = ({
                 width: itemWidth,
                 height: itemHeight,
               }}
-              {...props}
             />
           );
         })}


### PR DESCRIPTION
## Summary
- `Skeleton`'s loading state had no ARIA semantics at all, so screen reader users get no indication that content is loading. Added a default `role="status"` and `aria-label="로딩 중"` on the wrapper (overridable via props), matching the aria-label pattern already used in `Sider`/`BackTop`.
- `{...props}` was spread onto every repeated skeleton item inside the `count` loop, so any identifying attribute (`id`, `data-testid`, etc.) got duplicated across all rendered lines when `count > 1` — invalid duplicate DOM ids and broken `getByTestId`-style lookups. Moved the passthrough to the root wrapper instead, applied once.

## Test plan
- [x] `pnpm check-types` (packages/ui)
- [x] `pnpm lint` (packages/ui)
- [x] `pnpm build` (packages/ui)