### PR TITLE
🔖 chore: sync develop into main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,10 +94,16 @@ jobs:
               found && /^## \[/ { exit }
               found { print }
             ' "$CHANGELOG_FILE")
-            CONTENT="${CONTENT//'%'/'%25'}"
-            CONTENT="${CONTENT//$'\n'/'%0A'}"
-            CONTENT="${CONTENT//$'\r'/'%0D'}"
-            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
+            # %0A/%0D/%25 escaping only applied to the old, deprecated
+            # `::set-output` command syntax (which the runner auto-decoded).
+            # The modern $GITHUB_OUTPUT file doesn't decode that, so it was
+            # writing literal "%0A" text into the release body. Use the
+            # heredoc form instead, which preserves real newlines as-is.
+            {
+              echo "body<<EOF"
+              echo "$CONTENT"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,16 @@ jobs:
               found && /^## \[/ { exit }
               found { print }
             ' "$CHANGELOG_FILE")
-            CONTENT="${CONTENT//'%'/'%25'}"
-            CONTENT="${CONTENT//$'\n'/'%0A'}"
-            CONTENT="${CONTENT//$'\r'/'%0D'}"
-            echo "body=$CONTENT" >> "$GITHUB_OUTPUT"
+            # %0A/%0D/%25 escaping only applied to the old, deprecated
+            # `::set-output` command syntax (which the runner auto-decoded).
+            # The modern $GITHUB_OUTPUT file doesn't decode that, so it was
+            # writing literal "%0A" text into the release body. Use the
+            # heredoc form instead, which preserves real newlines as-is.
+            {
+              echo "body<<EOF"
+              echo "$CONTENT"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-23
+
+### Changed
+
+- Update GitHub Actions to use heredoc for release body to preserve newlines
+
 ## [0.5.1] - 2026-07-22
 
 ### Changed

--- a/apps/docs/stories/templates/layout/index.stories.tsx
+++ b/apps/docs/stories/templates/layout/index.stories.tsx
@@ -102,7 +102,7 @@ const DemoFooter = () => (
 
 export const Default: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -118,7 +118,7 @@ export const Default: Story = {
 
 export const WithSider: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -140,7 +140,7 @@ export const WithSider: Story = {
 export const CollapsibleSider: Story = {
   name: 'WithSider (Collapsible)',
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -163,7 +163,7 @@ const DemoControlledSider = () => {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <Typography.Title className="text-3xl">Header</Typography.Title>
         <button
@@ -202,7 +202,7 @@ export const ControlledSider: Story = {
 
 export const WithSiderRight: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -223,7 +223,7 @@ export const WithSiderRight: Story = {
 
 export const HeaderOnly: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Header className="justify-between border-b bg-white py-3">
         <DemoHeader />
       </Layout.Header>
@@ -236,7 +236,7 @@ export const HeaderOnly: Story = {
 
 export const FooterOnly: Story = {
   render: () => (
-    <Layout className="h-screen">
+    <Layout>
       <Layout.Content>
         <DemoContent />
       </Layout.Content>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-kit",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "scripts": {
     "build": "turbo run build",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.2] - 2026-07-23
+
+### Added
+
+- Add aria-label to BackTop component
+- Add role and aria-label to Skeleton component
+- Add target and rel props to Link component
+- Add context for nested Layout
+
+### Changed
+
+- Update FloatButton styles to remove unnecessary class
+- Refactor Search component to manage uncontrolled state
+- Simplify Text component className logic
+- Update Layout component to handle nested contexts
+
 ## [2.11.1] - 2026-07-23
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-07-23
+
+### Added
+
+- Add aria-label to BackTop component
+
+### Removed
+
+- Remove background color from FloatButton component
+
 ## [2.11.0] - 2026-07-23
 
 ### Added

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Modern React UI component library built with TypeScript, Tailwind CSS, and Radix UI. Featuring atoms, molecules, organisms and layout templates for building beautiful interfaces.",
   "keywords": [
     "react",

--- a/packages/ui/src/components/atoms/float-button/back-top.tsx
+++ b/packages/ui/src/components/atoms/float-button/back-top.tsx
@@ -25,6 +25,7 @@ const BackTop = ({
 
   return (
     <FloatButton
+      aria-label="맨 위로"
       icon={<ArrowUp />}
       className={cn(
         className,

--- a/packages/ui/src/components/atoms/float-button/float-button.tsx
+++ b/packages/ui/src/components/atoms/float-button/float-button.tsx
@@ -9,7 +9,6 @@ const FloatButton = ({ className, children, ...props }: Props) => {
     <Button
       className={cn(
         'fixed right-5 bottom-5 rounded-full',
-        'bg-white hover:bg-white',
         'z-50 h-12 w-12',
         'shadow-md',
         className,

--- a/packages/ui/src/components/atoms/input/search.tsx
+++ b/packages/ui/src/components/atoms/input/search.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import { CircleX, Search as SearchOutlined } from 'lucide-react';
 
@@ -32,9 +32,17 @@ const Search = ({
   const internalRef = useRef<HTMLInputElement>(null);
   const inputRef = (ref as React.RefObject<HTMLInputElement>) || internalRef;
 
+  const [uncontrolledHasValue, setUncontrolledHasValue] =
+    useState(!!defaultValue);
+  const hasValue = value !== undefined ? !!value : uncontrolledHasValue;
+
   const onClear = () => {
     if (inputRef.current) {
       inputRef.current.value = '';
+
+      if (value === undefined) {
+        setUncontrolledHasValue(false);
+      }
 
       const event = {
         target: { value: '' },
@@ -78,7 +86,12 @@ const Search = ({
           )}
           value={value}
           defaultValue={defaultValue}
-          onChange={onChange}
+          onChange={e => {
+            if (value === undefined) {
+              setUncontrolledHasValue(!!e.target.value);
+            }
+            onChange?.(e);
+          }}
           onKeyDown={e => {
             if (e.key === 'Enter') {
               onSearch();
@@ -90,7 +103,7 @@ const Search = ({
           className={cn(
             'absolute right-2 size-4',
             'shrink-0 cursor-pointer',
-            (!allowClear || (value !== undefined && !value)) && 'hidden',
+            (!allowClear || !hasValue) && 'hidden',
           )}
           onClick={onClear}
         />

--- a/packages/ui/src/components/atoms/skeleton/skeleton.tsx
+++ b/packages/ui/src/components/atoms/skeleton/skeleton.tsx
@@ -52,10 +52,13 @@ const Skeleton = ({
 
   return (
     <div
+      role="status"
+      aria-label="로딩 중"
       className={cn(
         'flex items-center gap-3',
         //
       )}
+      {...props}
     >
       {avatar && (
         <Core
@@ -97,7 +100,6 @@ const Skeleton = ({
                 width: itemWidth,
                 height: itemHeight,
               }}
-              {...props}
             />
           );
         })}

--- a/packages/ui/src/components/atoms/typography/link.tsx
+++ b/packages/ui/src/components/atoms/typography/link.tsx
@@ -2,7 +2,7 @@ import { cn } from '@repo/ui/utils';
 
 export interface Props extends React.ComponentPropsWithoutRef<'a'> {}
 
-const Link = ({ children, className, ...props }: Props) => {
+const Link = ({ children, className, target, rel, ...props }: Props) => {
   return (
     <a
       className={cn(
@@ -10,6 +10,8 @@ const Link = ({ children, className, ...props }: Props) => {
         className,
         //
       )}
+      target={target}
+      rel={rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/atoms/typography/text.tsx
+++ b/packages/ui/src/components/atoms/typography/text.tsx
@@ -8,12 +8,7 @@ export interface Props extends React.ComponentPropsWithoutRef<'span'> {
 const Text = ({ children, underline, strong, className, ...props }: Props) => {
   return (
     <span
-      className={cn(
-        'text-nowrap',
-        underline && 'underline',
-        strong && 'font-bold',
-        className,
-      )}
+      className={cn(underline && 'underline', strong && 'font-bold', className)}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/templates/layout/layout.tsx
+++ b/packages/ui/src/components/templates/layout/layout.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement } from 'react';
+import { Children, createContext, isValidElement, useContext } from 'react';
 
 import { cn } from '@repo/ui/utils';
 
@@ -6,25 +6,36 @@ import Sider from './sider';
 
 export interface Props extends React.ComponentPropsWithoutRef<'div'> {}
 
+const LayoutNestedContext = createContext(false);
+
 const hasSiderChild = (children: React.ReactNode) =>
   Children.toArray(children).some(
     child => isValidElement(child) && child.type === Sider,
   );
 
 const Layout = ({ children, className, ...props }: Props) => {
+  const isNested = useContext(LayoutNestedContext);
   const isRow = hasSiderChild(children);
 
   return (
-    <div
-      className={cn(
-        'flex min-h-0 w-full flex-1',
-        isRow ? 'flex-row' : 'flex-col',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </div>
+    <LayoutNestedContext.Provider value>
+      <div
+        className={cn(
+          'flex w-full flex-1',
+          // A nested Layout (the Sider row wrapper) must stay free to
+          // shrink/grow inside its parent's flex column, so it keeps
+          // min-h-0. The outermost Layout has no ancestor to size against,
+          // so it needs its own height anchor or flex-1/grow are no-ops
+          // and Content collapses under Footer.
+          isNested ? 'min-h-0' : 'min-h-screen',
+          isRow ? 'flex-row' : 'flex-col',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </LayoutNestedContext.Provider>
   );
 };
 


### PR DESCRIPTION
## Summary
- Final develop → main sync using the existing git-flow (before this repo moves to trunk-based / changesets, tracked separately)
- Brings 5 previously-reviewed component fixes merged into develop over the past sessions:
  - Layout: fix missing height anchor on the outermost Layout (#115)
  - FloatButton: remove hardcoded white background breaking dark mode, add BackTop aria-label (#116)
  - Typography: default Link's rel to noopener/noreferrer on target=_blank, remove Text's forced nowrap (#117)
  - Input.Search: fix clear button staying visible on empty uncontrolled input (#118)
  - Skeleton: add role=status/aria-label, fix props duplicating across repeated rows (#119)
- Also includes a workflow output-escaping fix in publish.yml/release.yml (old `%0A` escaping used deprecated `::set-output` syntax, writing literal `%0A` into release bodies instead of real newlines)
- packages/ui bumped to 2.11.2 in packages/ui/package.json — merging this will trigger publish.yml to tag v2.11.2, publish to npm, and create a GitHub Release

## Test plan
- [ ] CI (lint-and-build) passes
- [ ] After merge, confirm publish.yml tags v2.11.2, publishes to npm, and creates the GitHub Release