### PR TITLE
♻️ refactor: retire develop branch references

### DIFF
--- a/.claude/commands/publish-check.md
+++ b/.claude/commands/publish-check.md
@@ -25,8 +25,8 @@
    npm view @repo/ui version 2>/dev/null || echo "not published yet"
    ```
 
-   - `packages/ui/package.json` 버전이 npm 최신 버전보다 앞서 있으면, `develop`에서 changesets의 "Version Packages" PR이 이미 버전을 승격시킨 상태 — `main`에 머지되는 즉시 `publish.yml`이 자동으로 빌드/퍼블리시/태그한다.
-   - 두 버전이 같으면 아직 퍼블리시할 변경사항이 없다는 뜻(= `.changeset/*.md`가 없거나 아직 develop에 Version Packages PR이 머지 안 됨). `packages/ui/CHANGELOG.md` 최상단 섹션이 최신 버전과 일치하는지로도 확인 가능.
+   - `packages/ui/package.json` 버전이 npm 최신 버전보다 앞서 있으면, changesets의 "Version Packages" PR이 `main`에 이미 머지되어 버전을 승격시킨 상태 — 다음 `main` push 시 `publish.yml`이 자동으로 빌드/퍼블리시/태그한다.
+   - 두 버전이 같으면 아직 퍼블리시할 변경사항이 없다는 뜻(= `.changeset/*.md`가 없거나 아직 Version Packages PR이 머지 안 됨). `packages/ui/CHANGELOG.md` 최상단 섹션이 최신 버전과 일치하는지로도 확인 가능.
 
 4. **exports 필드 확인**
    - `packages/ui/package.json`의 `exports` 필드에 새로 추가된 컴포넌트 진입점이 누락되지 않았는지 확인

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   lint-and-build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,19 +202,19 @@ import './local';
 
 ## 기술 스택 요약
 
-| 항목          | 기술                                                                               |
-| ------------- | ---------------------------------------------------------------------------------- |
-| 런타임        | React 19, Node ≥18                                                                 |
-| 언어          | TypeScript 5.9                                                                     |
-| 스타일        | Tailwind CSS v4                                                                    |
-| UI 프리미티브 | Radix UI                                                                           |
-| 아이콘        | lucide-react                                                                       |
-| 애니메이션    | motion (framer), GSAP                                                              |
-| 패키지 매니저 | pnpm 10                                                                            |
-| 모노레포      | turborepo                                                                          |
-| 빌드          | tsdown                                                                             |
-| 포맷          | prettier (single quote, 2 spaces, trailing comma)                                  |
-| 릴리스        | changesets (develop의 Version Packages PR 버전 승격) + npm OIDC Trusted Publishing |
+| 항목          | 기술                                                                            |
+| ------------- | ------------------------------------------------------------------------------- |
+| 런타임        | React 19, Node ≥18                                                              |
+| 언어          | TypeScript 5.9                                                                  |
+| 스타일        | Tailwind CSS v4                                                                 |
+| UI 프리미티브 | Radix UI                                                                        |
+| 아이콘        | lucide-react                                                                    |
+| 애니메이션    | motion (framer), GSAP                                                           |
+| 패키지 매니저 | pnpm 10                                                                         |
+| 모노레포      | turborepo                                                                       |
+| 빌드          | tsdown                                                                          |
+| 포맷          | prettier (single quote, 2 spaces, trailing comma)                               |
+| 릴리스        | changesets (main의 Version Packages PR 버전 승격) + npm OIDC Trusted Publishing |
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -154,11 +154,12 @@ pnpm run format
 
 ### 배포
 
-배포는 완전히 자동화되어 있다. `develop`에 머지되면 AI가 생성한 changelog
-항목이 `packages/ui/package.json`의 버전을 승격시키고, `develop`이 `main`에
-머지되면 `publish.yml` 워크플로우가 빌드 → npm OIDC Trusted Publishing으로
-퍼블리시 → 릴리스 태그까지 자동으로 처리한다. 수동 버전 범프나 퍼블리시
-명령은 필요 없다.
+배포는 [changesets](https://github.com/changesets/changesets)로 완전히
+자동화되어 있다. PR마다 AI가 changeset 파일을 초안으로 작성하고, `main`에
+changeset들이 쌓이면 "Version Packages" PR이 `packages/ui/package.json`의
+버전을 승격시키고 changelog를 정리한다. 이 PR이 머지되면 `publish.yml`
+워크플로우가 빌드 → npm OIDC Trusted Publishing으로 퍼블리시 → 릴리스
+태그까지 자동으로 처리한다. 수동 버전 범프나 퍼블리시 명령은 필요 없다.
 
 ## 📚 문서화
 

--- a/README.md
+++ b/README.md
@@ -154,11 +154,12 @@ pnpm run format
 
 ### Deployment
 
-Releases are fully automated. Merging to `develop` triggers an AI-generated
-changelog entry that bumps `packages/ui/package.json`'s version; merging
-`develop` into `main` then triggers the `publish.yml` workflow, which builds,
-publishes to npm via OIDC Trusted Publishing, and tags the release. No manual
-version bump or publish command is needed.
+Releases are fully automated via [changesets](https://github.com/changesets/changesets).
+Each PR gets an AI-drafted changeset file; once changesets accumulate on
+`main`, a "Version Packages" PR bumps `packages/ui/package.json`'s version
+and consolidates the changelog. Merging that PR triggers the `publish.yml`
+workflow, which builds, publishes to npm via OIDC Trusted Publishing, and
+tags the release. No manual version bump or publish command is needed.
 
 ## 📚 Documentation
 


### PR DESCRIPTION
## Summary
- `develop` branch itself was already deleted (confirmed no diff existed between it and `main` before deletion) — this PR just cleans up the remaining references to it
- `ci.yml`: drop `develop` from push/pull_request triggers
- Update `CLAUDE.md`, `.claude/commands/publish-check.md`, `README.md`, `README.ko.md` to describe the current main-only changesets release flow instead of the old develop → main sync

## Test plan
- [ ] CI passes
- [ ] `draft` check passes (no packages/ui changes in this PR, so it should no-op)