### PR TITLE
🐛 fix: Layout Footer stuck mid-page when Content is taller than viewport

### DIFF
--- a/.changeset/pr-129.md
+++ b/.changeset/pr-129.md
@@ -1,5 +1,5 @@
 ---
-'@repo/ui': minor
+'@repo/ui': patch
 ---
 
-Update the Content component to use 'basis-auto' for better height management, allowing it to maintain its natural height based on content.
+Fix Layout's Footer rendering mid-page instead of after the content when Content is taller than the viewport.

--- a/.changeset/pr-129.md
+++ b/.changeset/pr-129.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Update the Content component to use 'basis-auto' for better height management, allowing it to maintain its natural height based on content.

--- a/packages/ui/src/components/templates/layout/content.tsx
+++ b/packages/ui/src/components/templates/layout/content.tsx
@@ -5,7 +5,19 @@ export interface Props extends React.ComponentPropsWithoutRef<'main'> {}
 const Content = ({ children, className, ...props }: Props) => {
   return (
     <main
-      className={cn('min-h-0 min-w-0 shrink grow basis-0', className)}
+      className={cn(
+        'min-w-0 shrink grow basis-auto',
+        // basis-auto (not basis-0) sizes Content from its actual content
+        // height first, so flex-grow only adds extra space when content is
+        // shorter than the viewport — when content is taller, Content
+        // keeps its natural (larger) height instead of clipping to
+        // available space and pushes Footer below it. min-h-0 is
+        // intentionally omitted here: with basis-auto, the default
+        // min-height:auto (content-based) is what makes that possible; on
+        // the Sider row's cross axis it's harmless since min-height there
+        // governs stretch, not main-axis growth.
+        className,
+      )}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- `Content` used `flex-grow` + `basis-0` + `min-h-0`, which sizes it against the flex container's guaranteed `min-height` (100vh) rather than its actual content — when content is taller than one screen, the excess just overflows visually (default `overflow: visible`) without growing Content's own box or pushing Footer down, so Footer renders right at the bottom of the first viewport instead of after the full content
- Switch to `basis-auto` (drop `basis-0` and the `min-h-0` override): `flex-grow` now only adds extra space when content is shorter than the viewport, and lets Content take its natural (larger) height when content is taller, so Footer follows the actual content bottom in both cases. `min-w-0` is kept (guards the Sider row's horizontal axis, unrelated to this)

## Verification
Reproduced and verified with Storybook + Playwright (2000px tall content):
- Before: Footer rendered at y=743–800 (stuck at the first viewport's bottom edge), while content overflowed past it — matches the reported bug
- After: Footer renders at y=2064–2121 (correctly after the full content), both with and without `Sider`
- Ordinary (viewport-height-or-shorter) content unchanged: Footer still pinned to the bottom of the viewport (no regression)

## Test plan
- [x] `pnpm check-types` — 0 errors
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [x] Verified visually in Storybook (Default, WithSider, and temporary tall-content stories) — see summary above
- [ ] CI passes