### PR TITLE
🐛 fix: audit and patch several ui-kit components

### DIFF
--- a/.changeset/pr-131.md
+++ b/.changeset/pr-131.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Refactor Checkbox and Radio components to use a new value prop naming convention, and update Skeleton component to handle null children. Enhance Marquees component with responsive ref handling.

--- a/.changeset/pr-131.md
+++ b/.changeset/pr-131.md
@@ -1,5 +1,5 @@
 ---
-'@repo/ui': minor
+'@repo/ui': patch
 ---
 
-Refactor Checkbox and Radio components to use a new value prop naming convention, and update Skeleton component to handle null children. Enhance Marquees component with responsive ref handling.
+Fix several component bugs found in a follow-up audit: Marquees now measures against its own container instead of `document.body`, Skeleton no longer throws when `loading={false}` with no children, and Checkbox/Radio no longer generate colliding DOM ids when separate instances share the same option value.

--- a/packages/ui/src/components/atoms/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/atoms/checkbox/checkbox.tsx
@@ -28,7 +28,7 @@ export interface Props extends Omit<
 
 const Checkbox = ({
   placement = 'left',
-  value = '',
+  value: _value,
   children,
   className,
   icons,
@@ -42,9 +42,8 @@ const Checkbox = ({
     defaultChecked || false,
   );
 
-  const reactId = useId();
+  const id = useId();
 
-  const id = typeof value === 'boolean' || !value ? reactId : String(value);
   const controlled = _checked !== undefined;
   const checked = controlled ? _checked : uncontrolledChecked;
 

--- a/packages/ui/src/components/atoms/radio/radio.tsx
+++ b/packages/ui/src/components/atoms/radio/radio.tsx
@@ -27,7 +27,7 @@ export interface Props extends Omit<
 
 const Radio = ({
   placement = 'left',
-  value = '',
+  value: _value,
   children,
   className,
   icons,
@@ -41,8 +41,7 @@ const Radio = ({
     defaultChecked || false,
   );
 
-  const reactId = useId();
-  const id = typeof value === 'boolean' || !value ? reactId : String(value);
+  const id = useId();
   const controlled = _checked !== undefined;
   const checked = controlled ? _checked : uncontrolledChecked;
 

--- a/packages/ui/src/components/atoms/skeleton/skeleton.tsx
+++ b/packages/ui/src/components/atoms/skeleton/skeleton.tsx
@@ -47,7 +47,7 @@ const Skeleton = ({
   ...props
 }: Props) => {
   if (!loading) {
-    return children;
+    return children ?? null;
   }
 
   return (

--- a/packages/ui/src/components/molecules/marquees/marquees.tsx
+++ b/packages/ui/src/components/molecules/marquees/marquees.tsx
@@ -32,8 +32,12 @@ const Marquees = ({
 
   const throttledWidth = useThrottle(width, 200);
 
-  const { size } = useResponsiveSize<HTMLDivElement>();
+  const { size, ref: responsiveRef } = useResponsiveSize<HTMLDivElement>();
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const setContainerRef = (node: HTMLDivElement | null) => {
+    containerRef.current = node;
+    responsiveRef(node);
+  };
   const hoverEvents = pauseOnHover
     ? {
         onMouseEnter: () => {
@@ -59,21 +63,9 @@ const Marquees = ({
     setWidth(size.width);
   }, [size]);
 
-  useEffect(() => {
-    const onScroll = () => {
-      setWidth(document.body.scrollWidth);
-    };
-
-    window.addEventListener('scroll', onScroll);
-
-    return () => {
-      window.removeEventListener('scroll', onScroll);
-    };
-  }, []);
-
   return (
     <div
-      ref={containerRef}
+      ref={setContainerRef}
       className={cn(
         className,
         //


### PR DESCRIPTION
## Summary
- Marquees: measure against its own container instead of `document.body`, and remove the scroll-based width override that fought the correct measurement
- Skeleton: fall back to `null` instead of `undefined` when `loading={false}` with no children (was throwing at render)
- Checkbox/Radio: derive the DOM `id` from `useId()` instead of the `value` prop, which collided when separate instances shared the same option value

## Why
Follow-up sweep after merging the Layout footer fix — found similar concrete bugs (not stylistic nitpicks) while auditing a handful of other components.

## Test plan
- [x] `pnpm lint` — clean (2 pre-existing-pattern warnings for intentionally-unused destructured `value`, non-blocking)
- [x] `pnpm check-types` — passes
- [x] `pnpm build` — passes