### PR TITLE
fix: component audit sweep (RadioGroup, Dropdown, Modal, Menu, Search, a11y)

### DIFF
--- a/.changeset/pr-135.md
+++ b/.changeset/pr-135.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': major
+---
+
+Remove the enums export from the library, which may affect components relying on it.

--- a/apps/docs/stories/molecules/dropdown/index.stories.tsx
+++ b/apps/docs/stories/molecules/dropdown/index.stories.tsx
@@ -20,9 +20,6 @@ const meta: Meta<typeof Dropdown> = {
     menu: {
       control: { type: 'object' },
     },
-    placement: {
-      table: { disable: true },
-    },
   },
 };
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,7 +49,6 @@
     "./Reveals": "./src/components/molecules/reveals/index.ts",
     "./Layout": "./src/components/templates/layout/index.ts",
     "./utils": "./src/lib/utils/index.ts",
-    "./enums": "./src/lib/enums/index.ts",
     "./core": "./src/core/index.ts",
     "./style.css": "./src/globals.css"
   },

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -126,8 +126,8 @@ const Button = ({
         'h-auto py-0',
         'transition-all',
         variantClasses[resolvedVariant],
-        sizesClasses[size || 'medium'],
-        iconOnly && ['p-0', iconClasses[size || 'medium']],
+        sizesClasses[size],
+        iconOnly && ['p-0', iconClasses[size]],
         shapesClasses[shape || 'default'],
         block && 'w-full',
         colored &&

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -11,6 +11,7 @@ export type OptionValue = string | number | boolean;
 type Option = {
   label: string;
   value: OptionValue;
+  disabled?: boolean;
 };
 
 type Options = string[] | number[] | boolean[] | Option[];
@@ -87,6 +88,7 @@ const Group = ({
               className={cn(classNames?.item)}
               value={item.value}
               checked={checked}
+              disabled={item.disabled}
               onChange={checked => onChange(checked, item.value)}
             >
               {item.label}

--- a/packages/ui/src/components/atoms/color-picker.tsx
+++ b/packages/ui/src/components/atoms/color-picker.tsx
@@ -40,11 +40,19 @@ const ColorPicker = ({
       content={<HexColorPicker color={value} onChange={onChange} />}
     >
       <div
+        role="button"
+        tabIndex={0}
         className={cn(
           'inline-flex items-center',
           'rounded border p-0.5',
           //
         )}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.currentTarget.click();
+          }
+        }}
       >
         <div
           className={cn(

--- a/packages/ui/src/components/atoms/input/search.tsx
+++ b/packages/ui/src/components/atoms/input/search.tsx
@@ -46,18 +46,19 @@ const Search = ({
   const hasValue = value !== undefined ? !!value : uncontrolledHasValue;
 
   const onClear = () => {
-    if (inputRef.current) {
-      inputRef.current.value = '';
-
-      if (value === undefined) {
-        setUncontrolledHasValue(false);
-      }
-
-      const event = {
-        target: { value: '' },
-      } as React.ChangeEvent<HTMLInputElement>;
-      onChange?.(event);
+    if (!inputRef.current) {
+      return;
     }
+
+    if (value === undefined) {
+      inputRef.current.value = '';
+      setUncontrolledHasValue(false);
+    }
+
+    const event = {
+      target: { value: '' },
+    } as React.ChangeEvent<HTMLInputElement>;
+    onChange?.(event);
   };
 
   const onSearch = () => {

--- a/packages/ui/src/components/atoms/input/search.tsx
+++ b/packages/ui/src/components/atoms/input/search.tsx
@@ -109,14 +109,18 @@ const Search = ({
           }}
           {...props}
         />
-        <CircleX
+        <button
+          type="button"
+          aria-label="지우기"
           className={cn(
-            'absolute right-2 size-4',
+            'absolute right-2',
             'shrink-0 cursor-pointer',
             (!allowClear || !hasValue) && 'hidden',
           )}
           onClick={onClear}
-        />
+        >
+          <CircleX className="size-4" />
+        </button>
       </div>
       <Button
         icon={<SearchOutlined />}

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -116,7 +116,7 @@ const RadioGroup = ({
                 className={cn(classNames?.item)}
                 value={item.value}
                 checked={checked}
-                disabled={item.disabled}
+                disabled={disabled || item.disabled}
                 onChange={checked => onChange(checked, item.value)}
               >
                 {item.label}

--- a/packages/ui/src/components/atoms/spin.tsx
+++ b/packages/ui/src/components/atoms/spin.tsx
@@ -14,6 +14,8 @@ const Spin = ({ spinning, className, children, ...props }: Props) => {
   if (!children) {
     return (
       <div
+        role="status"
+        aria-label="로딩 중"
         className={cn(
           'flex h-full items-center justify-center',
           //
@@ -41,7 +43,11 @@ const Spin = ({ spinning, className, children, ...props }: Props) => {
       {...props}
     >
       <div className="pointer-events-none opacity-50">{children}</div>
-      <div className="absolute inset-0 flex items-center justify-center">
+      <div
+        role="status"
+        aria-label="로딩 중"
+        className="absolute inset-0 flex items-center justify-center"
+      >
         <Loader2 className="animate-spin" />
       </div>
     </div>

--- a/packages/ui/src/components/molecules/dropdown.tsx
+++ b/packages/ui/src/components/molecules/dropdown.tsx
@@ -67,14 +67,27 @@ const Dropdown = ({
       }}
     >
       <div
+        aria-haspopup="menu"
+        aria-expanded={open}
         onClick={() => {
           if (!isClickTrigger) {
             return;
           }
           onOpenChange(!open);
         }}
+        onFocus={() => {
+          if (isClickTrigger) {
+            return;
+          }
+          onOpenChange(true);
+        }}
         onBlur={() => {
           onOpenChange(false);
+        }}
+        onKeyDown={e => {
+          if (e.key === 'Escape') {
+            onOpenChange(false);
+          }
         }}
       >
         {children}

--- a/packages/ui/src/components/molecules/dropdown.tsx
+++ b/packages/ui/src/components/molecules/dropdown.tsx
@@ -14,7 +14,6 @@ interface Props extends React.ComponentPropsWithoutRef<'div'> {
   open?: boolean;
   trigger?: string;
   menu?: MenuProps;
-  placement?: string;
   onOpenChange?: ChangeEventHandler;
 }
 

--- a/packages/ui/src/components/molecules/menu/menu.tsx
+++ b/packages/ui/src/components/molecules/menu/menu.tsx
@@ -55,7 +55,8 @@ export type ClickEventHandler = (params: {
 
 export const MENU_CLASSNAMES = [
   'p-0',
-  'bg-white',
+  'bg-popover',
+  'text-popover-foreground',
   'shadow-md',
   'rounded-md',
   //

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -66,8 +66,23 @@ interface StaticProps extends Props {
 const isBrowser =
   typeof window !== 'undefined' && typeof document !== 'undefined';
 
-let modalStack: StaticProps[] = [];
-let updateStack: (() => void) | null = null;
+type ContainerState = {
+  stack: StaticProps[];
+  update: (() => void) | null;
+};
+
+const containerStates = new Map<HTMLElement, ContainerState>();
+
+const getContainerState = (container: HTMLElement): ContainerState => {
+  let state = containerStates.get(container);
+
+  if (!state) {
+    state = { stack: [], update: null };
+    containerStates.set(container, state);
+  }
+
+  return state;
+};
 
 const createModalRoot = (container?: HTMLElement) => {
   if (!isBrowser) {
@@ -279,19 +294,22 @@ const StaticModal = ({
   );
 };
 
-const ModalStackRenderer = () => {
+const ModalStackRenderer = ({ container }: { container: HTMLElement }) => {
   const [, forceUpdate] = useState({});
 
   useEffect(() => {
-    updateStack = () => forceUpdate({});
+    const state = getContainerState(container);
+    state.update = () => forceUpdate({});
     return () => {
-      updateStack = null;
+      state.update = null;
     };
-  }, []);
+  }, [container]);
+
+  const { stack } = getContainerState(container);
 
   return (
     <>
-      {modalStack.map(({ id, ...props }) => (
+      {stack.map(({ id, ...props }) => (
         <StaticModal key={id} id={id} {...props} />
       ))}
     </>
@@ -311,25 +329,43 @@ const renderModal = (props: StaticProps) => {
   if (!modalRoots.has(targetContainer)) {
     const root = createRoot(rootElement);
     modalRoots.set(targetContainer, root);
-    root.render(<ModalStackRenderer />);
+    root.render(<ModalStackRenderer container={targetContainer} />);
   }
 
+  const state = getContainerState(targetContainer);
   const id = props.id || uuid();
-  modalStack.push({ ...props, id });
-  updateStack?.();
+  state.stack.push({ ...props, id });
+  state.update?.();
 
   return id;
 };
 
 Modal.destroy = (id?: string) => {
-  modalStack = id ? modalStack.filter(modal => modal.id !== id) : [];
-
-  updateStack?.();
-
-  if (!modalStack.length) {
+  if (!id) {
+    containerStates.forEach(state => {
+      state.stack = [];
+      state.update?.();
+    });
     modalRoots.forEach(root => root.unmount());
     modalRoots.clear();
+    containerStates.clear();
+    return;
   }
+
+  containerStates.forEach((state, container) => {
+    if (!state.stack.some(modal => modal.id === id)) {
+      return;
+    }
+
+    state.stack = state.stack.filter(modal => modal.id !== id);
+    state.update?.();
+
+    if (!state.stack.length) {
+      modalRoots.get(container)?.unmount();
+      modalRoots.delete(container);
+      containerStates.delete(container);
+    }
+  });
 };
 
 Modal.destroyAll = () => {

--- a/packages/ui/src/lib/enums/index.ts
+++ b/packages/ui/src/lib/enums/index.ts
@@ -1,8 +1,0 @@
-export const TEXT_LEVELS: Record<string, string> = {
-  1: 'text-2xl',
-  2: 'text-xl',
-  3: 'text-lg',
-  4: 'text-base',
-  5: 'text-sm',
-  6: 'text-xs',
-};

--- a/packages/ui/tsdown.config.ts
+++ b/packages/ui/tsdown.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
     Reveals: 'src/components/molecules/reveals/index.ts',
     Layout: 'src/components/templates/layout/index.ts',
     utils: 'src/lib/utils/index.ts',
-    enums: 'src/lib/enums/index.ts',
     core: 'src/core/index.ts',
     style: 'src/globals.css',
   },


### PR DESCRIPTION
## Summary
Fixes from the 2026-07-27 component audit (`memory/ui-kit-audit-2026-07-27.md`), addressed in priority order: bugs, type/code quality, then a11y.

### Bugs
- RadioGroup: group-level `disabled` now applies to default (non-button) Radio options, matching button-option behavior
- Dropdown: removed the unimplemented `placement` prop (was leaking into DOM attrs via `...props`, no actual positioning logic existed)
- Modal: static API (`Modal.info/success/...`) stack state is now isolated per `container` instead of sharing one module-scope stack/update callback across all containers
- Menu: replaced hardcoded `bg-white` with `bg-popover`/`text-popover-foreground` theme tokens so dark mode renders correctly
- Search: clear button no longer mutates `inputRef.current.value` directly when controlled; only uncontrolled usage still needs the direct DOM write

### Type/code quality
- CheckboxGroup: `Option` now supports `disabled?: boolean`, matching RadioGroup's `Option` API
- Button: removed the dead `'medium'` fallback typo (valid keys are `small`/`middle`/`large`; `size` already defaults to `'middle'`)
- Removed unused `TEXT_LEVELS` enum module (no references anywhere; also dropped the now-empty `./enums` build entry/export)

### Accessibility
- Search: clear icon wrapped in a `<button type="button" aria-label="지우기">` for keyboard operability
- ColorPicker: swatch trigger gets `role="button"`/`tabIndex`/`onKeyDown` so it's focusable and operable via Enter/Space
- Spin: added `role="status"` + label, matching the existing Skeleton pattern
- Dropdown: added `aria-haspopup`/`aria-expanded`, Escape-to-close, and `onFocus` support for keyboard users on hover triggers

Also fixed a Storybook argType (`apps/docs/stories/molecules/dropdown/index.stories.tsx`) that referenced the removed `placement` prop, which broke `check-types`.

## Not addressed (see audit for detail)
- Radio: each `Radio` instance owns its own isolated `RadioGroupPrimitive.Root`, so arrow-key navigation across a `RadioGroup`'s options doesn't work — this needs a larger restructuring (`Group` owning one shared `Root`) beyond this sweep's scope.
- Swiper: always imports `Autoplay`/`EffectCards`/`Navigation`/`Scrollbar` modules regardless of usage — bundle-size improvement, not a correctness bug.
- Drawer: `document.body.style.pointerEvents` global mutation for `mask=false` can race across concurrent instances — needs a ref-counting mechanism.
- List: no handling for `scroll.next()` rejecting, which can permanently wedge `fetchingRef` — needs a documented contract or timeout/retry.
- Modal's known Shadow DOM `@todo` limitation (radix-ui #3384) is left as-is per audit notes.

## Test plan
- [x] `pnpm lint` (turbo, all packages) — 0 errors (2 pre-existing unrelated warnings in checkbox.tsx/radio.tsx)
- [x] `pnpm check-types` (turbo, all packages) — passes
- [x] `pnpm build` (turbo, all packages) — passes
- [ ] Manual visual/browser check (not performed in this sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)