### PR TITLE
📝 docs: correct pr-135 changeset bump to minor

### DIFF
--- a/.changeset/pr-135.md
+++ b/.changeset/pr-135.md
@@ -1,5 +1,5 @@
 ---
-'@repo/ui': major
+'@repo/ui': minor
 ---
 
-Remove the enums export from the library, which may affect components relying on it.
+Remove the unused `enums` subpath export (`TEXT_LEVELS`), which was not referenced by any component internally.


### PR DESCRIPTION
## Summary
- The `enums` export removal in #135 was flagged as a `major` changeset, but `TEXT_LEVELS` was never referenced internally — nothing actually depended on it, so this isn't an intentional breaking change.
- Downgrades `.changeset/pr-135.md` from `major` to `minor` and clarifies the summary text accordingly.

## Why
This changeset feeds the auto-generated "Version Packages" PR (#133), which currently proposes `@repo/ui@3.0.0`. Once this merges, that PR should recompute to a minor bump instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)