### PR TITLE
fix: audit follow-ups (RadioGroup a11y, Drawer, Button, List docs, Swiper modules)

### DIFF
--- a/.changeset/pr-137.md
+++ b/.changeset/pr-137.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Introduce a new RadioGroup component that manages focus and state for radio buttons, allowing for better accessibility and usability.

--- a/.changeset/pr-137.md
+++ b/.changeset/pr-137.md
@@ -1,5 +1,12 @@
 ---
-'@repo/ui': minor
+'@repo/ui': major
 ---
 
-Introduce a new RadioGroup component that manages focus and state for radio buttons, allowing for better accessibility and usability.
+**BREAKING**: `Swiper` no longer bundles or activates any Swiper feature module. `Autoplay`, `EffectCards`, `Navigation` and `Scrollbar` (and their stylesheets) used to be imported statically and always enabled, which meant every carousel autoplayed by default via `initialOptions`. The component now ships only `swiper/css` and exposes a new `modules` prop (default `[]`) — import the modules you need from `swiper/modules` along with `swiper/css/<module>` and pass them explicitly, otherwise `autoplay` / `navigation` / `scrollbar` / `effect` options are inert. See `packages/ui/src/components/organisms/swiper/README.md` for the migration guide.
+
+Other changes in this release:
+
+- `RadioGroup` now owns a single shared Radix radiogroup root instead of wrapping each option in its own, so arrow keys move focus between options. Standalone `Radio`, the `icons` variant and `optionType="button"` groups are unaffected. `Radio` also accepts an optional `id` prop.
+- `Button` no longer calls `preventDefault()` on `mousedown`, restoring native focus-on-click behaviour (buttons now keep focus after a mouse click).
+- `Drawer` reference-counts `document.body.style.pointerEvents` so concurrent mask-less drawers no longer restore a stale value.
+- `List` documents the `scroll.next()` contract: callers must reset `loading` to `false` when a fetch settles, including on failure.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,6 +21,7 @@
     "postcss": "^8.4.31",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "swiper": "^11.2.10",
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {

--- a/apps/docs/stories/organisms/swiper/index.stories.tsx
+++ b/apps/docs/stories/organisms/swiper/index.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Autoplay, Navigation } from 'swiper/modules';
 
 import { Swiper } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
+
+// `Swiper` ships only the core bundle. Feature modules and their stylesheets
+// are opted into by the consumer and passed through the `modules` prop.
+import 'swiper/css/autoplay';
+import 'swiper/css/navigation';
 
 interface Item {
   id: number;
@@ -36,6 +42,9 @@ const meta: Meta<typeof Swiper<Item>> = {
     renderItem: {
       action: 'renderItem',
     },
+    modules: {
+      control: false,
+    },
   },
 };
 
@@ -46,6 +55,14 @@ export const Default: Story = {
   args: {
     loading: false,
     data: defaultData,
+    modules: [Autoplay, Navigation],
+    options: {
+      navigation: true,
+      autoplay: {
+        delay: 2500,
+        disableOnInteraction: false,
+      },
+    },
     style: {
       width: 480,
     },

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -148,7 +148,6 @@ const Button = ({
         //
       )}
       onMouseDown={e => {
-        e.preventDefault();
         onMouseDown?.(e);
       }}
       {...props}

--- a/packages/ui/src/components/atoms/radio/context.tsx
+++ b/packages/ui/src/components/atoms/radio/context.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { createContext } from 'react';
+
+/**
+ * Internal only — not exported from the package entry points.
+ *
+ * `true` when a `Radio` is rendered inside a `RadioGroup` that already owns a
+ * single shared `RadioGroupPrimitive.Root`. In that case each `Radio` renders
+ * only its `RadioGroupItem` so that Radix can manage roving focus (arrow-key
+ * navigation) across every option of the group.
+ *
+ * `false` (default) means the `Radio` is standalone and has to wrap itself in
+ * its own `Root` to stay functional.
+ */
+export const RadioGroupContext = createContext(false);

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
+import { radio } from '@repo/ui/core';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../button';
+import { RadioGroupContext } from './context';
 import Radio from './radio';
+
+const { RadioGroup: Core } = radio;
 
 export type OptionValue = string | number | boolean;
 
@@ -77,7 +81,25 @@ const RadioGroup = ({
     _onChange(optionValue);
   };
 
-  return (
+  // A single Radix radiogroup root owns every option so that arrow keys move
+  // focus across the whole group. Radix addresses items by string value, so
+  // each option gets a deterministic id derived from a stable base id.
+  const baseId = useId();
+  const getOptionId = (index: number) => `${baseId}-${index}`;
+  const checkedIndex = options.findIndex(item => item.value === value);
+  const checkedId = checkedIndex === -1 ? '' : getOptionId(checkedIndex);
+
+  const onValueChange = (optionId: string) => {
+    const item = options.find((_, index) => getOptionId(index) === optionId);
+
+    if (!item) {
+      return;
+    }
+
+    onChange(true, item.value);
+  };
+
+  const list = (
     <ul
       {...props}
       className={cn(
@@ -112,6 +134,7 @@ const RadioGroup = ({
               </Button>
             ) : (
               <Radio
+                id={getOptionId(index)}
                 placement={placement}
                 className={cn(classNames?.item)}
                 value={item.value}
@@ -126,6 +149,20 @@ const RadioGroup = ({
         );
       })}
     </ul>
+  );
+
+  // `optionType='button'` renders `Button`s instead of radios, so it keeps the
+  // plain list and stays out of the Radix radiogroup entirely.
+  if (isButton) {
+    return list;
+  }
+
+  return (
+    <RadioGroupContext.Provider value={true}>
+      <Core className="block" value={checkedId} onValueChange={onValueChange}>
+        {list}
+      </Core>
+    </RadioGroupContext.Provider>
   );
 };
 

--- a/packages/ui/src/components/atoms/radio/radio.tsx
+++ b/packages/ui/src/components/atoms/radio/radio.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useContext, useId, useState } from 'react';
 
 import { Circle, CircleCheck } from 'lucide-react';
 
 import { field, radio } from '@repo/ui/core';
 import { cn } from '@repo/ui/utils';
 
+import { RadioGroupContext } from './context';
 import { type OptionValue } from './group';
 
 const { RadioGroup: Core, RadioGroupItem: Item } = radio;
@@ -21,6 +22,12 @@ export interface Props extends Omit<
   checked?: boolean;
   value?: OptionValue;
   disabled?: boolean;
+  /**
+   * Id shared by the underlying control and its label. Generated internally
+   * when omitted. `RadioGroup` passes a deterministic id so that the group's
+   * single Radix root can address each option.
+   */
+  id?: string;
   icons?: { checked: React.ReactNode; unchecked: React.ReactNode };
   onChange?: (checked: boolean) => void;
 }
@@ -34,6 +41,7 @@ const Radio = ({
   disabled,
   defaultChecked,
   checked: _checked,
+  id: _id,
   onChange: _onChange = () => {},
   ...props
 }: Props) => {
@@ -41,7 +49,9 @@ const Radio = ({
     defaultChecked || false,
   );
 
-  const id = useId();
+  const generatedId = useId();
+  const id = _id ?? generatedId;
+  const grouped = useContext(RadioGroupContext);
   const controlled = _checked !== undefined;
   const checked = controlled ? _checked : uncontrolledChecked;
 
@@ -57,6 +67,22 @@ const Radio = ({
     }
     _onChange(next);
   };
+
+  // When rendered inside a `RadioGroup`, the group owns the single shared
+  // `Core` (Radix radiogroup root) so that arrow keys move focus across every
+  // option. A standalone `Radio` still has to provide its own root.
+  const renderField = (
+    <Field
+      orientation="horizontal"
+      className={cn('flex gap-2', placement === 'right' && 'flex-row-reverse')}
+      data-disabled={disabled}
+    >
+      <Item value={id} id={id} checked={checked} disabled={disabled} />
+      <FieldLabel htmlFor={id} className={cursorClassName}>
+        {children}
+      </FieldLabel>
+    </Field>
+  );
 
   const renderContent = icons ? (
     <>
@@ -98,21 +124,11 @@ const Radio = ({
         </label>
       )}
     </>
+  ) : grouped ? (
+    renderField
   ) : (
     <Core value={checked ? id : ''} onValueChange={() => onChange(true)}>
-      <Field
-        orientation="horizontal"
-        className={cn(
-          'flex gap-2',
-          placement === 'right' && 'flex-row-reverse',
-        )}
-        data-disabled={disabled}
-      >
-        <Item value={id} id={id} checked={checked} disabled={disabled} />
-        <FieldLabel htmlFor={id} className={cursorClassName}>
-          {children}
-        </FieldLabel>
-      </Field>
+      {renderField}
     </Core>
   );
 

--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -18,6 +18,14 @@ const {
   DrawerTitle,
 } = drawer;
 
+// `document.body.style.pointerEvents` is global state, so several mask-less
+// overlays opening at once would otherwise race: each instance would capture
+// whatever the previous one had already written and the last cleanup would
+// restore a stale value. Reference counting makes only the first instance
+// capture the original value and only the last one restore it.
+let maskLessOverlayCount = 0;
+let originalBodyPointerEvents: string | null = null;
+
 export interface Props {
   open: boolean;
   children?: React.ReactNode;
@@ -95,7 +103,10 @@ const Drawer = ({
       return;
     }
 
-    const originalPointerEvents = document.body.style.pointerEvents;
+    if (maskLessOverlayCount === 0) {
+      originalBodyPointerEvents = document.body.style.pointerEvents;
+    }
+    maskLessOverlayCount += 1;
 
     const raf = window.requestAnimationFrame(() => {
       document.body.style.pointerEvents = 'auto';
@@ -103,7 +114,12 @@ const Drawer = ({
 
     return () => {
       window.cancelAnimationFrame(raf);
-      document.body.style.pointerEvents = originalPointerEvents;
+      maskLessOverlayCount -= 1;
+
+      if (maskLessOverlayCount === 0) {
+        document.body.style.pointerEvents = originalBodyPointerEvents ?? '';
+        originalBodyPointerEvents = null;
+      }
     };
   }, [open, mask]);
 

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -30,6 +30,13 @@ interface Props<T> extends Omit<
     loading: boolean;
     loader?: React.ReactNode;
     options?: IntersectionObserverInit;
+    /**
+     * Called when more items should be fetched. `List` tracks in-flight
+     * requests via `loading` — the caller MUST flip `loading` back to
+     * `false` when the fetch settles, including on failure/rejection.
+     * If `loading` never becomes `false` again after a failed fetch,
+     * `List` will stop calling `next()` for subsequent intersections.
+     */
     next: () => void;
   };
   data?: T[];

--- a/packages/ui/src/components/organisms/swiper/README.md
+++ b/packages/ui/src/components/organisms/swiper/README.md
@@ -1,0 +1,72 @@
+# Swiper
+
+A thin wrapper around [Swiper](https://swiperjs.com/)'s React component that
+adds `loading` / `loader` handling and a `data` + `renderItem` rendering API.
+
+## Modules are opt-in
+
+`Swiper` ships **only the Swiper core** — `import 'swiper/css'` and nothing
+else. Feature modules (`Autoplay`, `Navigation`, `Scrollbar`, `EffectCards`, …)
+and their stylesheets are **not** bundled by the library.
+
+Why: previously every consumer paid for all four modules and their CSS in the
+bundle, whether or not their carousel used them. Making modules an explicit
+consumer-side injection (the same pattern shadcn/Radix-style libraries use)
+keeps the baseline bundle small and lets each call site pay only for what it
+actually renders.
+
+## Usage
+
+Import the modules you need from `swiper/modules`, import their stylesheets
+from `swiper/css/<module>`, and pass the modules through the `modules` prop:
+
+```tsx
+import { Swiper } from '@jbpark/ui-kit';
+import { Autoplay, Navigation } from 'swiper/modules';
+
+import 'swiper/css';
+import 'swiper/css/autoplay';
+import 'swiper/css/navigation';
+
+<Swiper
+  modules={[Autoplay, Navigation]}
+  options={{
+    navigation: true,
+    autoplay: { delay: 2500, disableOnInteraction: false },
+  }}
+  data={items}
+  renderItem={item => <Swiper.Slide key={item.id}>{item.title}</Swiper.Slide>}
+/>;
+```
+
+`swiper` is a direct dependency of `@jbpark/ui-kit`, but add it to your own
+`package.json` as well so that `swiper/modules` and `swiper/css/*` resolve
+under strict package managers such as pnpm.
+
+Available modules and their option keys are documented in the
+[Swiper modules reference](https://swiperjs.com/swiper-api#modules). Common
+pairings:
+
+| Module        | Import           | Stylesheet                | Option key   |
+| ------------- | ---------------- | ------------------------- | ------------ |
+| `Autoplay`    | `swiper/modules` | `swiper/css/autoplay`     | `autoplay`   |
+| `Navigation`  | `swiper/modules` | `swiper/css/navigation`   | `navigation` |
+| `Scrollbar`   | `swiper/modules` | `swiper/css/scrollbar`    | `scrollbar`  |
+| `EffectCards` | `swiper/modules` | `swiper/css/effect-cards` | `effect`     |
+
+## Migrating from an older version
+
+Before this change, `Swiper` always imported and activated `Autoplay`,
+`EffectCards`, `Navigation` and `Scrollbar`, plus all of their CSS. Because the
+built-in `initialOptions` sets `autoplay: { delay: 2500, disableOnInteraction: false }`,
+**every carousel autoplayed by default**.
+
+After this change nothing is active unless it is explicitly passed via
+`modules`. Concretely:
+
+- Carousels that relied on the implicit default autoplay will stop autoplaying.
+  Add `modules={[Autoplay]}` (plus `import 'swiper/css/autoplay'`) to keep it.
+- `navigation: true`, `scrollbar`, and `effect: 'cards'` in `options` become
+  inert no-ops until the matching module is passed.
+- If you did not want autoplay in the first place, no action is needed — you now
+  get the smaller bundle for free.

--- a/packages/ui/src/components/organisms/swiper/swiper.tsx
+++ b/packages/ui/src/components/organisms/swiper/swiper.tsx
@@ -1,19 +1,19 @@
 'use client';
 
-import { Autoplay, EffectCards, Navigation, Scrollbar } from 'swiper/modules';
 import { Swiper as SwiperCore, SwiperProps } from 'swiper/react';
-import { SwiperOptions } from 'swiper/types';
+import { SwiperModule, SwiperOptions } from 'swiper/types';
 
 import { cn } from '@repo/ui/utils';
 
 import 'swiper/css';
-import 'swiper/css/autoplay';
-import 'swiper/css/effect-cards';
-import 'swiper/css/navigation';
-import 'swiper/css/scrollbar';
 
 import { Spin } from '../../atoms';
 
+/**
+ * Baseline Swiper options. `navigation` / `autoplay` are inert unless the
+ * matching modules are passed through the `modules` prop — see the README next
+ * to this file.
+ */
 export const initialOptions: SwiperOptions = {
   loop: false,
   spaceBetween: 8,
@@ -32,6 +32,21 @@ interface Props<T> extends SwiperProps {
   loader?: React.ReactNode;
   loadingClassName?: string;
   options?: SwiperOptions;
+  /**
+   * Swiper feature modules to activate. Nothing is bundled by default — import
+   * the modules you need from `swiper/modules` together with their stylesheets
+   * (`swiper/css/<module>`) and pass them here.
+   *
+   * @example
+   * import { Autoplay, Navigation } from 'swiper/modules';
+   * import 'swiper/css/autoplay';
+   * import 'swiper/css/navigation';
+   *
+   * <Swiper modules={[Autoplay, Navigation]} ... />
+   *
+   * @default []
+   */
+  modules?: SwiperModule[];
   data: T[];
   renderItem(item: T, key: number): React.ReactNode;
 }
@@ -40,6 +55,7 @@ const Swiper = <T,>({
   loading,
   loader,
   options = {},
+  modules = [],
   data = [],
   style,
   renderItem,
@@ -56,7 +72,7 @@ const Swiper = <T,>({
 
   return (
     <SwiperCore
-      modules={[Navigation, Scrollbar, Autoplay, EffectCards]}
+      modules={modules}
       {...initialOptions}
       {...options}
       style={{ ...initialStyle, ...style }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.3(react@19.2.3)
+      swiper:
+        specifier: ^11.2.10
+        version: 11.2.10
       tailwindcss:
         specifier: ^4.1.12
         version: 4.1.18


### PR DESCRIPTION
Follow-up sweep for the 5 items deliberately deferred from the full component audit (`memory/ui-kit-audit-2026-07-27.md`), after PRs #133 / #135 / #136 landed the mechanical 12.

Each of these needed a design decision rather than a straight patch. One commit per item.

## 1. RadioGroup arrow-key navigation (`♿️ fix(radio)`)

Every `<Radio>` used to wrap itself in its own `RadioGroupPrimitive.Root`, so a `RadioGroup` rendered N sibling isolated Radix radiogroups and arrow keys never moved between options.

- New internal `RadioGroupContext` (`components/atoms/radio/context.tsx`, not exported from any public entry point) tells a `Radio` whether a parent group already owns the root.
- `RadioGroup` now derives a stable base id via `useId()`, gives each option a deterministic `${baseId}-${index}`, and wraps the whole `<ul>` in a single `<Core value={checkedId} onValueChange={...}>` inside the provider.
- Grouped `Radio`s render only `<Field><Item/><FieldLabel/></Field>`; standalone `<Radio>` keeps its existing self-wrapping `Core` behaviour unchanged.
- `Radio` gained an optional `id` prop (falls back to `useId()` as before).
- `optionType="button"` (renders `Button`s, not radios) returns the plain list and stays out of the radiogroup entirely. The `icons` variant is untouched.

Minor knock-on effects worth reviewing: the default-option path now has one extra block-level wrapper `<div role="radiogroup">` around the `<ul>` (the `<ul>` still receives `className`/`...props`), and a standalone `<Radio id="x">` now applies `id` to the control rather than the outer wrapper div.

## 2. Drawer body `pointer-events` race (`🐛 fix(drawer)`)

Concurrent mask-less drawers each captured `document.body.style.pointerEvents` and the last cleanup restored a stale value. Now reference-counted at module scope: only the first instance captures, only the last restores.

## 3. Button `onMouseDown` → `preventDefault()` (`♿️ fix(button)`)

**Behaviour change**: the blanket `e.preventDefault()` is gone, so buttons now retain focus after a mouse click (native `<button>` semantics). Nothing in `packages/ui/src` relied on it — the only other `onMouseDown` is Dropdown's, on `Menu`, and is unrelated. The consumer's own handler is still forwarded.

## 4. List `scroll.next()` contract (`📝 docs(list)`)

Docs only, no runtime change. `next()` is `void`-typed so `List` can't observe a rejection; added TSDoc making the caller's obligation explicit — `loading` must return to `false` when a fetch settles, **including on failure**, or `List` silently stops requesting more pages.

## 5. ⚠️ Swiper modules are now opt-in — BREAKING (`💥 perf(swiper)`)

Swiper used to statically import and always activate `Autoplay`, `EffectCards`, `Navigation` and `Scrollbar` plus all their CSS, so every consumer paid for all four regardless of use.

Adopted the consumer-injection pattern (shadcn/Radix style): the library now ships only `swiper/css` and a new `modules?: SwiperModule[]` prop, defaulting to `[]`.

**This changes default runtime behaviour.** `initialOptions` sets `autoplay: { delay: 2500 }`, so *every* carousel autoplayed by default before. After this change autoplay/navigation/scrollbar/effect config is inert until the matching module is passed. `initialOptions` is kept as-is (harmless inert config).

Migration guide: **[`packages/ui/src/components/organisms/swiper/README.md`](https://github.com/pjb0811/ui-kit/blob/fix/a11y-swiper-followups-0727/packages/ui/src/components/organisms/swiper/README.md)**

```tsx
import { Swiper } from '@jbpark/ui-kit';
import { Autoplay, Navigation } from 'swiper/modules';
import 'swiper/css';
import 'swiper/css/autoplay';
import 'swiper/css/navigation';

<Swiper modules={[Autoplay, Navigation]} options={{ navigation: true, autoplay: { delay: 2500 } }} data={items} renderItem={...} />
```

The Storybook story was updated to import `Autoplay`/`Navigation` + their CSS and pass `modules` explicitly, so the published example still demonstrates autoplay and also teaches the new pattern. `swiper` was added as a direct dependency of `apps/docs` so those imports resolve under pnpm.

This one should be released as a **major** — please make sure the drafted changeset reflects that.

## Verification

No test suite in this repo. From the root, all green:

- `pnpm lint` — 0 errors; only 2 pre-existing `_value is assigned a value but never used` warnings (checkbox + radio, both present on `main`)
- `pnpm check-types` — 3/3 successful
- `pnpm build` — 3/3 successful
- `pnpm build-storybook` in `apps/docs` also verified to compile the updated story

Refs: `memory/ui-kit-audit-2026-07-27.md`