### PR TITLE
♻️ refactor: drop @uidotdev/usehooks in favor of @jbpark/use-hooks

### DIFF
--- a/.changeset/pr-139.md
+++ b/.changeset/pr-139.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Update the dependency on '@jbpark/use-hooks' to version 2.5.0, which may include new features or improvements.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -83,7 +83,6 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
-    "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gsap": "^3.15.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
-    "@jbpark/use-hooks": "^2.1.0",
+    "@jbpark/use-hooks": "^2.5.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/ui/src/components/atoms/float-button/back-top.tsx
+++ b/packages/ui/src/components/atoms/float-button/back-top.tsx
@@ -2,7 +2,7 @@
 
 import { MouseEvent } from 'react';
 
-import { useWindowScroll } from '@uidotdev/usehooks';
+import { useWindowScroll } from '@jbpark/use-hooks';
 import { ArrowUp } from 'lucide-react';
 
 import { cn } from '@repo/ui/utils';
@@ -21,7 +21,7 @@ const BackTop = ({
   onClick,
   ...props
 }: Props) => {
-  const [{ y }, scrollTo] = useWindowScroll();
+  const { y } = useWindowScroll();
 
   return (
     <FloatButton
@@ -33,7 +33,7 @@ const BackTop = ({
         //
       )}
       onClick={e => {
-        scrollTo({ left: 0, top: 0, behavior: 'smooth' });
+        window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
         onClick?.(e);
       }}
       {...props}

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef } from 'react';
 
-import { useIntersectionObserver } from '@uidotdev/usehooks';
+import { useIntersectionObserver } from '@jbpark/use-hooks';
 
 import { cn, renderConditional } from '@repo/ui/utils';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,9 +213,6 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.2.6
         version: 1.2.6(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@uidotdev/usehooks':
-        specifier: ^2.4.1
-        version: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2240,13 +2237,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.53.0':
     resolution: {integrity: sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@uidotdev/usehooks@2.4.1':
-    resolution: {integrity: sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -6852,11 +6842,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.53.0
       eslint-visitor-keys: 4.2.1
-
-  '@uidotdev/usehooks@2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
 
   '@vitest/expect@3.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,8 +187,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.3)
       '@jbpark/use-hooks':
-        specifier: ^2.1.0
-        version: 2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.5.0
+        version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -853,8 +853,8 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@jbpark/use-hooks@2.1.0':
-    resolution: {integrity: sha512-/rgfrPG3zT74OFA/snZOJbBtgTiTDP0Naq/xWUNzTJGnyto7ssNCq9zTsGVeTVEqa3TYnUe/CS3bWoJ4WzCeBg==}
+  '@jbpark/use-hooks@2.5.0':
+    resolution: {integrity: sha512-7jKz3Lv8Xi+x8AG0N7Rm9cowIFRqwA7wl6TByUKPT8+mFmPiZqRXN3eKw85wjLpMfBIY7i4ILvmMo+Mw1Z7DbA==}
     peerDependencies:
       react: ^19.1.1
       react-dom: ^19.1.1
@@ -5477,7 +5477,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@jbpark/use-hooks@2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@jbpark/use-hooks@2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## Summary
Both remaining consumers of the external `@uidotdev/usehooks` package in this repo now use the family's own `@jbpark/use-hooks` instead, so the dependency is removed entirely.

- **`List`**: `useIntersectionObserver` swapped to `@jbpark/use-hooks`'s equivalent (`@jbpark/use-hooks@2.5.0`, same `[ref, entry]` shape, no call-site changes).
- **`FloatButton.BackTop`**: previously used `@uidotdev/usehooks`'s `useWindowScroll` for both the `y` position and its `scrollTo` helper. `@jbpark/use-hooks`'s `useWindowScroll` only returns state (no `scrollTo`) — rather than extending that hook or adding a new dedicated one just for this single native browser API call, `BackTop` now reads `y` from `@jbpark/use-hooks`'s `useWindowScroll` and calls `window.scrollTo(...)` directly.
- `@uidotdev/usehooks` removed from `packages/ui/package.json` (no remaining usages).

## Verification
`pnpm lint`, `pnpm check-types` (all packages, including `apps/web`/`apps/docs`), and `turbo run build --filter=@repo/ui` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)