### PR TITLE
📝 docs: correct pr-139 changeset bump to patch

### DIFF
--- a/.changeset/pr-139.md
+++ b/.changeset/pr-139.md
@@ -1,5 +1,5 @@
 ---
-'@repo/ui': minor
+'@repo/ui': patch
 ---
 
-Update the dependency on '@jbpark/use-hooks' to version 2.5.0, which may include new features or improvements.
+Switch `List` and `FloatButton.BackTop` to use `@jbpark/use-hooks` instead of `@uidotdev/usehooks` internally (removes the `@uidotdev/usehooks` dependency). No public API or behavior changes.


### PR DESCRIPTION
## Summary
`.changeset/pr-139.md` was auto-drafted as `minor`, but the actual change (swapping `List`/`BackTop`'s internal hook source from `@uidotdev/usehooks` to `@jbpark/use-hooks`) has no public API or behavior change — downgrading to `patch`, feeds into the pending "Version Packages" PR (#140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)