### PR TITLE
🐛 fix(calendar): fix squished layout from unwrapped --cell-size refs

### DIFF
--- a/.changeset/fix-calendar-cell-size-var.md
+++ b/.changeset/fix-calendar-cell-size-var.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix `Calendar`/`DatePicker` rendering squished — `--cell-size` references used square-bracket arbitrary values (`h-[--cell-size]`) which compile without `var()` in this repo's Tailwind v4 setup, producing invalid CSS. Switched to the parenthesis syntax (`h-(--cell-size)`) already used elsewhere in the codebase (e.g. `atoms/button.tsx`).

--- a/.changeset/pr-147.md
+++ b/.changeset/pr-147.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Update calendar component to use parentheses for CSS custom properties, improving consistency in styling.

--- a/packages/ui/src/core/calendar.tsx
+++ b/packages/ui/src/core/calendar.tsx
@@ -57,20 +57,20 @@ function Calendar({
         ),
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
-          'h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50',
+          'h-(--cell-size) w-(--cell-size) select-none p-0 aria-disabled:opacity-50',
           defaultClassNames.button_previous,
         ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
-          'h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50',
+          'h-(--cell-size) w-(--cell-size) select-none p-0 aria-disabled:opacity-50',
           defaultClassNames.button_next,
         ),
         month_caption: cn(
-          'flex h-[--cell-size] w-full items-center justify-center px-[--cell-size]',
+          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
           defaultClassNames.month_caption,
         ),
         dropdowns: cn(
-          'flex h-[--cell-size] w-full items-center justify-center gap-1.5 text-sm font-medium',
+          'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
           defaultClassNames.dropdowns,
         ),
         dropdown_root: cn(
@@ -99,7 +99,7 @@ function Calendar({
         ),
         week: cn('mt-2 flex w-full', defaultClassNames.week),
         week_number_header: cn(
-          'w-[--cell-size] select-none',
+          'w-(--cell-size) select-none',
           defaultClassNames.week_number_header,
         ),
         week_number: cn(
@@ -171,7 +171,7 @@ function Calendar({
           return (
             <td {...props}>
               <div
-                className="flex size-[--cell-size] items-center justify-center
+                className="flex size-(--cell-size) items-center justify-center
                   text-center"
               >
                 {children}
@@ -225,7 +225,7 @@ function CalendarDayButton({
         data-[range-end=true]:text-primary-foreground
         group-data-[focused=true]/day:border-ring
         group-data-[focused=true]/day:ring-ring/50 flex aspect-square h-auto
-        w-full min-w-[--cell-size] flex-col gap-1 leading-none font-normal
+        w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal
         group-data-[focused=true]/day:relative
         group-data-[focused=true]/day:z-10
         group-data-[focused=true]/day:ring-[3px]


### PR DESCRIPTION
## Summary
- `Calendar` (and `DatePicker`, which uses it) rendered squished — day/nav buttons never got their intended 2rem square sizing.
- Root cause: 7 references to the `--cell-size` CSS variable used square-bracket arbitrary values (`h-[--cell-size]`, `w-[--cell-size]`, `min-w-[--cell-size]`, `px-[--cell-size]`, `size-[--cell-size]`). Under this repo's Tailwind v4 setup, that syntax compiles without a `var()` wrapper (`height: --cell-size;`), which is invalid CSS and gets dropped by the browser.
- Fix: switched all 7 to the parenthesis CSS-variable syntax (`h-(--cell-size)`, etc.), matching the convention already used elsewhere in the codebase (`atoms/button.tsx`'s `bg-(--btn-bg)`). The variable *definition* (`[--cell-size:2rem]`) was untouched — only reference sites were broken.
- Patch changeset included.

## Verification
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Diffed the actual compiled CSS served by the docs Storybook dev server before/after the fix — confirmed `height: --cell-size;` (invalid) became `height: var(--cell-size);` (valid) for all affected classes
- [x] Searched the rest of `packages/ui/src` for the same bracket-reference pattern — no other occurrences found

🤖 Generated with [Claude Code](https://claude.com/claude-code)