### PR TITLE
♻️ refactor(docs): group Storybook sidebar by functional category

### DIFF
--- a/apps/docs/stories/atoms/button/index.stories.tsx
+++ b/apps/docs/stories/atoms/button/index.stories.tsx
@@ -37,7 +37,7 @@ const colorOptions: ColorType[] = [
 ];
 
 const meta: Meta<typeof Button> = {
-  title: 'UI/Button',
+  title: 'General/Button',
   component: Button,
 
   parameters: {

--- a/apps/docs/stories/atoms/checkbox/group/index.stories.tsx
+++ b/apps/docs/stories/atoms/checkbox/group/index.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Checkbox } from '@repo/ui';
 
 const meta: Meta<typeof Checkbox.Group> = {
-  title: 'UI/Checkbox/Group',
+  title: 'Data Entry/Checkbox/Group',
   component: Checkbox.Group,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/checkbox/index.stories.tsx
+++ b/apps/docs/stories/atoms/checkbox/index.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Checkbox } from '@repo/ui';
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'UI/Checkbox',
+  title: 'Data Entry/Checkbox',
   component: Checkbox,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/color-picker/index.stories.tsx
+++ b/apps/docs/stories/atoms/color-picker/index.stories.tsx
@@ -8,7 +8,7 @@ import { ColorPicker } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof ColorPicker> = {
-  title: 'UI/ColorPicker',
+  title: 'Data Entry/ColorPicker',
   component: ColorPicker,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/config/index.stories.tsx
+++ b/apps/docs/stories/atoms/config/index.stories.tsx
@@ -4,7 +4,7 @@ import { Button, Config, Switch } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Config> = {
-  title: 'UI/Config',
+  title: 'Providers/Config',
   component: Config,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/date-picker/index.stories.tsx
+++ b/apps/docs/stories/atoms/date-picker/index.stories.tsx
@@ -8,7 +8,7 @@ import { DatePicker } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof DatePicker> = {
-  title: 'UI/DatePicker',
+  title: 'Data Entry/DatePicker',
   component: DatePicker,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/float-button/back-top/index.stories.tsx
+++ b/apps/docs/stories/atoms/float-button/back-top/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { FloatButton } from '@repo/ui';
 
 const meta: Meta<typeof FloatButton.BackTop> = {
-  title: 'UI/FloatButton/BackTop',
+  title: 'Navigation/FloatButton/BackTop',
   component: FloatButton.BackTop,
   parameters: {
     layout: 'fullscreen',

--- a/apps/docs/stories/atoms/float-button/index.stories.tsx
+++ b/apps/docs/stories/atoms/float-button/index.stories.tsx
@@ -4,7 +4,7 @@ import { Settings } from 'lucide-react';
 import { FloatButton } from '@repo/ui';
 
 const meta: Meta<typeof FloatButton> = {
-  title: 'UI/FloatButton',
+  title: 'Navigation/FloatButton',
   component: FloatButton,
   parameters: {
     layout: 'fullscreen',

--- a/apps/docs/stories/atoms/input/index.stories.tsx
+++ b/apps/docs/stories/atoms/input/index.stories.tsx
@@ -8,7 +8,7 @@ import { Input } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Input> = {
-  title: 'UI/Input',
+  title: 'Data Entry/Input',
   component: Input,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/input/search/index.stories.tsx
+++ b/apps/docs/stories/atoms/input/search/index.stories.tsx
@@ -8,7 +8,7 @@ import { Input } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Input.Search> = {
-  title: 'UI/Input/Search',
+  title: 'Data Entry/Input/Search',
   component: Input.Search,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/input/text-area/index.stories.tsx
+++ b/apps/docs/stories/atoms/input/text-area/index.stories.tsx
@@ -8,7 +8,7 @@ import { Input } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Input.TextArea> = {
-  title: 'UI/Input/TextArea',
+  title: 'Data Entry/Input/TextArea',
   component: Input.TextArea,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/popover/index.stories.tsx
+++ b/apps/docs/stories/atoms/popover/index.stories.tsx
@@ -4,7 +4,7 @@ import { Button, Popover } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Popover> = {
-  title: 'UI/Popover',
+  title: 'Data Display/Popover',
   component: Popover,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/progress/index.stories.tsx
+++ b/apps/docs/stories/atoms/progress/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Progress } from '@repo/ui';
 
 const meta: Meta<typeof Progress> = {
-  title: 'UI/Progress',
+  title: 'Feedback/Progress',
   component: Progress,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/radio/group/index.stories.tsx
+++ b/apps/docs/stories/atoms/radio/group/index.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Radio } from '@repo/ui';
 
 const meta: Meta<typeof Radio.Group> = {
-  title: 'UI/Radio/Group',
+  title: 'Data Entry/Radio/Group',
   component: Radio.Group,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/radio/index.stories.tsx
+++ b/apps/docs/stories/atoms/radio/index.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Radio } from '@repo/ui';
 
 const meta: Meta<typeof Radio> = {
-  title: 'UI/Radio',
+  title: 'Data Entry/Radio',
   component: Radio,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/select/index.stories.tsx
+++ b/apps/docs/stories/atoms/select/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Select } from '@repo/ui';
 
 const meta: Meta<typeof Select> = {
-  title: 'UI/Select',
+  title: 'Data Entry/Select',
   component: Select,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/skeleton/button/index.stories.tsx
+++ b/apps/docs/stories/atoms/skeleton/button/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Skeleton } from '@repo/ui';
 
 const meta: Meta<typeof Skeleton.Button> = {
-  title: 'UI/Skeleton/Button',
+  title: 'Feedback/Skeleton/Button',
   component: Skeleton.Button,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/skeleton/index.stories.tsx
+++ b/apps/docs/stories/atoms/skeleton/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Skeleton } from '@repo/ui';
 
 const meta: Meta<typeof Skeleton> = {
-  title: 'UI/Skeleton',
+  title: 'Feedback/Skeleton',
   component: Skeleton,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/skeleton/node/index.stories.tsx
+++ b/apps/docs/stories/atoms/skeleton/node/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Skeleton } from '@repo/ui';
 
 const meta: Meta<typeof Skeleton.Node> = {
-  title: 'UI/Skeleton/Node',
+  title: 'Feedback/Skeleton/Node',
   component: Skeleton.Node,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/spin/index.stories.tsx
+++ b/apps/docs/stories/atoms/spin/index.stories.tsx
@@ -4,7 +4,7 @@ import { Spin } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Spin> = {
-  title: 'UI/Spin',
+  title: 'Feedback/Spin',
   component: Spin,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/switch/index.stories.tsx
+++ b/apps/docs/stories/atoms/switch/index.stories.tsx
@@ -4,7 +4,7 @@ import { Switch } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Switch> = {
-  title: 'UI/Switch',
+  title: 'Data Entry/Switch',
   component: Switch,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/tag/index.stories.tsx
+++ b/apps/docs/stories/atoms/tag/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Tag } from '@repo/ui';
 
 const meta: Meta<typeof Tag> = {
-  title: 'UI/Tag',
+  title: 'General/Tag',
   component: Tag,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/typography/index.stories.tsx
+++ b/apps/docs/stories/atoms/typography/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Typography } from '@repo/ui';
 
 const meta: Meta<typeof Typography> = {
-  title: 'UI/Typography',
+  title: 'General/Typography',
   component: Typography,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/typography/link/index.stories.tsx
+++ b/apps/docs/stories/atoms/typography/link/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Typography } from '@repo/ui';
 
 const meta: Meta<typeof Typography.Link> = {
-  title: 'UI/Typography/Link',
+  title: 'General/Typography/Link',
   component: Typography.Link,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/typography/paragraph/index.stories.tsx
+++ b/apps/docs/stories/atoms/typography/paragraph/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Typography } from '@repo/ui';
 
 const meta: Meta<typeof Typography.Paragraph> = {
-  title: 'UI/Typography/Paragraph',
+  title: 'General/Typography/Paragraph',
   component: Typography.Paragraph,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/typography/text/index.stories.tsx
+++ b/apps/docs/stories/atoms/typography/text/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Typography } from '@repo/ui';
 
 const meta: Meta<typeof Typography.Text> = {
-  title: 'UI/Typography/Text',
+  title: 'General/Typography/Text',
   component: Typography.Text,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/atoms/typography/title/index.stories.tsx
+++ b/apps/docs/stories/atoms/typography/title/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Typography } from '@repo/ui';
 
 const meta: Meta<typeof Typography.Title> = {
-  title: 'UI/Typography/Title',
+  title: 'General/Typography/Title',
   component: Typography.Title,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/molecules/card/index.stories.tsx
+++ b/apps/docs/stories/molecules/card/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Card } from '@repo/ui';
 
 const meta: Meta<typeof Card> = {
-  title: 'UI/Card',
+  title: 'Data Display/Card',
   component: Card,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/molecules/collapse/index.stories.tsx
+++ b/apps/docs/stories/molecules/collapse/index.stories.tsx
@@ -6,7 +6,7 @@ import { ChevronDown, Plus } from 'lucide-react';
 import { Collapse } from '@repo/ui';
 
 const meta: Meta<typeof Collapse> = {
-  title: 'UI/Collapse',
+  title: 'Data Display/Collapse',
   component: Collapse,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/molecules/dropdown/index.stories.tsx
+++ b/apps/docs/stories/molecules/dropdown/index.stories.tsx
@@ -4,7 +4,7 @@ import { ChevronDown } from 'lucide-react';
 import { Button, Dropdown } from '@repo/ui';
 
 const meta: Meta<typeof Dropdown> = {
-  title: 'UI/Dropdown',
+  title: 'Navigation/Dropdown',
   component: Dropdown,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/molecules/marquees/index.stories.tsx
+++ b/apps/docs/stories/molecules/marquees/index.stories.tsx
@@ -4,7 +4,7 @@ import { Marquees } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Marquees> = {
-  title: 'UI/Marquees',
+  title: 'Data Display/Marquees',
   component: Marquees,
   parameters: {
     layout: 'fullscreen',

--- a/apps/docs/stories/molecules/menu/index.stories.tsx
+++ b/apps/docs/stories/molecules/menu/index.stories.tsx
@@ -66,7 +66,7 @@ const defaultItems = [
 ];
 
 const meta: Meta<typeof Menu> = {
-  title: 'UI/Menu',
+  title: 'Navigation/Menu',
   component: Menu,
   parameters: {
     layout: 'fullscreen',

--- a/apps/docs/stories/molecules/reveals/index.stories.tsx
+++ b/apps/docs/stories/molecules/reveals/index.stories.tsx
@@ -38,7 +38,7 @@ const defaultItems = [
 ];
 
 const meta: Meta<typeof Reveals> = {
-  title: 'UI/Reveals',
+  title: 'Data Display/Reveals',
   component: Reveals,
   parameters: {
     layout: 'fullscreen',

--- a/apps/docs/stories/molecules/space/index.stories.tsx
+++ b/apps/docs/stories/molecules/space/index.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Button, Space } from '@repo/ui';
 
 const meta: Meta<typeof Space> = {
-  title: 'UI/Space',
+  title: 'General/Space',
   component: Space,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/molecules/splitter/index.stories.tsx
+++ b/apps/docs/stories/molecules/splitter/index.stories.tsx
@@ -4,7 +4,7 @@ import { Splitter, Typography } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Splitter> = {
-  title: 'UI/Splitter',
+  title: 'Layout/Splitter',
   component: Splitter,
   parameters: {
     layout: 'fullscreen',

--- a/apps/docs/stories/molecules/upload/index.stories.tsx
+++ b/apps/docs/stories/molecules/upload/index.stories.tsx
@@ -8,7 +8,7 @@ import { Upload, type UploadFile } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Upload> = {
-  title: 'UI/Upload',
+  title: 'Data Entry/Upload',
   component: Upload,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/organisms/drawer/index.stories.tsx
+++ b/apps/docs/stories/organisms/drawer/index.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Button, Drawer } from '@repo/ui';
 
 const meta: Meta<typeof Drawer> = {
-  title: 'UI/Drawer',
+  title: 'Feedback/Drawer',
   component: Drawer,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/organisms/list/index.stories.tsx
+++ b/apps/docs/stories/organisms/list/index.stories.tsx
@@ -17,7 +17,7 @@ const defaultData: Item[] = [
 ];
 
 const meta: Meta<typeof List<Item>> = {
-  title: 'UI/List',
+  title: 'Data Display/List',
   component: List,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/organisms/modal/index.stories.tsx
+++ b/apps/docs/stories/organisms/modal/index.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Button, Modal } from '@repo/ui';
 
 const meta: Meta<typeof Modal> = {
-  title: 'UI/Modal',
+  title: 'Feedback/Modal',
   component: Modal,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/organisms/swiper/index.stories.tsx
+++ b/apps/docs/stories/organisms/swiper/index.stories.tsx
@@ -24,7 +24,7 @@ const defaultData: Item[] = [
 ];
 
 const meta: Meta<typeof Swiper<Item>> = {
-  title: 'UI/Swiper',
+  title: 'Data Display/Swiper',
   component: Swiper,
   parameters: {
     layout: 'centered',

--- a/apps/docs/stories/templates/layout/index.stories.tsx
+++ b/apps/docs/stories/templates/layout/index.stories.tsx
@@ -6,7 +6,7 @@ import { Layout, Typography } from '@repo/ui';
 import { cn } from '@repo/ui/utils';
 
 const meta: Meta<typeof Layout> = {
-  title: 'UI/Layout',
+  title: 'Layout/Layout',
   component: Layout,
   parameters: {
     layout: 'fullscreen',

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "pnpm build-storybook",
+  "outputDirectory": "storybook-static"
+}

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "framework": null,
   "buildCommand": "pnpm build-storybook",
   "outputDirectory": "storybook-static"
 }


### PR DESCRIPTION
## Summary
- Regroup all 41 Storybook stories from a single flat `UI/*` list into functional categories: **General**, **Data Entry**, **Data Display**, **Feedback**, **Navigation**, **Layout**, **Providers** — matching the taxonomy convention used by Ant Design and similar component library docs.
- Add `apps/docs/vercel.json` so the deployed docs site builds and serves Storybook directly (`pnpm build-storybook` → `storybook-static`) instead of the default `create-turbo` Next.js scaffold page.

## Category mapping
- **General**: Button, Tag, Typography(+Link/Paragraph/Text/Title), Space
- **Data Entry**: Checkbox(+Group), ColorPicker, DatePicker, Input(+Search/TextArea), Radio(+Group), Select, Switch, Upload
- **Data Display**: Card, Collapse, List, Marquees, Popover, Reveals, Swiper
- **Feedback**: Drawer, Modal, Progress, Skeleton(+Button/Node), Spin
- **Navigation**: Dropdown, Menu, FloatButton(+BackTop)
- **Layout**: Layout, Splitter
- **Providers**: Config

## Not done here
The default Next.js `app/` scaffold files in `apps/docs` are left in place (unused now that Storybook is the deploy target) — cleanup/removal is a separate follow-up if wanted.

## Verification
`pnpm lint` passes repo-wide. `pnpm build-storybook` (from `apps/docs`) succeeds; confirmed the generated `storybook-static/index.json` shows all 41 stories correctly grouped under the new category prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)