### PR TITLE
🔧 chore: reset root version/changelog, retire dead changelog automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,124 +1,13 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+The repo root (`ui-kit`) isn't a published package — its version and this
+file are not tied to any real release, and nothing automates them
+anymore (the `develop`-branch changelog automation this used to track has
+been retired). For actual release history, see:
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- [`packages/ui/CHANGELOG.md`](./packages/ui/CHANGELOG.md) — `@repo/ui`
+  (published as `@jbpark/ui-kit`), versioned via
+  [changesets](https://github.com/changesets/changesets).
 
-## [Unreleased]
-
-## [0.5.2] - 2026-07-23
-
-### Changed
-
-- Update GitHub Actions to use heredoc for release body to preserve newlines
-
-## [0.5.1] - 2026-07-22
-
-### Changed
-
-- Improve changelog extraction logic in publish and release workflows
-
-## [0.5.0] - 2026-07-22
-
-### Added
-
-- Add manual fallback workflow for creating GitHub Releases for existing tags
-- Add input parameter for existing git tag in manual release workflow
-- Add changelog entry retrieval in publish workflow
-
-### Changed
-
-- Change release workflow trigger from tag push to manual dispatch
-- Update publish workflow to create GitHub Release immediately after tagging
-
-## [0.4.5] - 2026-07-22
-
-### Added
-
-- Add Tag component to README
-
-### Changed
-
-- Update changelog workflow descriptions to English
-- Update commit messages in changelog workflow to English
-
-## [0.4.4] - 2026-07-20
-
-### Changed
-
-- Update changelog script to use English for category labels
-- Change default message for missing changelog file to English
-- Update changelog script documentation to use English
-
-## [0.4.3] - 2026-07-19
-
-### Added
-
-- Add coding style guide
-
-### Changed
-
-- Change folder naming convention for new component creation
-- Change folder naming convention for new Storybook story creation
-
-## [0.4.2] - 2026-07-12
-
-### Changed
-
-- Improve publish check command
-
-### Removed
-
-- Remove Changesets-related config files
-
-## [0.4.1] - 2026-07-05
-
-### Added
-
-- Splitter: add resizable panel splitter
-- Config: add CSS variable-based theme token overrides and dark mode configuration
-
-### Changed
-
-- Layout: change to include collapsible Sider
-
-## [0.4.0] - 2026-07-05
-
-### Added
-
-- Add commit message writing guide
-- Add new component creation guide
-- Add new story creation guide
-
-## [0.3.0] - 2026-07-05
-
-### Added
-
-- Add workflow_dispatch event
-- Add diff start commit SHA input
-
-### Changed
-
-- Use personal PAT instead of GITHUB_TOKEN for model requests
-
-## [0.2.0] - 2026-07-05
-
-### Added
-
-- Introduce root CHANGELOG.md
-- Add `develop` branch integrated changelog automation pipeline (GitHub Models-based semver bump + changelog authoring, automatic PR creation/merge)
-- Add `develop` branch trigger to CI workflow
-
-### Changed
-
-- Add Keep a Changelog format support to changelog automation script
-- Add version field to root package.json
-
-## [0.1.0] - 2026-07-05
-
-### Added
-
-- Introduce root CHANGELOG.md
-- Add `develop` branch integrated changelog automation pipeline (GitHub Models-based semver bump + changelog authoring, automatic PR creation/merge)
-- Add `develop` branch trigger to CI workflow
+For infra/tooling changes that don't belong to a specific package, see
+the git commit history.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-kit",
-  "version": "0.5.2",
-  "private": false,
+  "version": "0.0.0",
+  "private": true,
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",


### PR DESCRIPTION
## Summary
Root `package.json`'s version (`0.5.2`) and `CHANGELOG.md` were tracking a dead automation pipeline — a `develop`-branch-triggered GitHub Models changelog writer that stopped updating once `develop` was retired. Nothing publishes or references the root version (no `files`/`publishConfig`, not in `.changeset/config.json`'s scope), so it was just stale, confusing leftover state.

- Reset root `version` to `0.0.0`.
- Flip `private: false` → `true` (the root package was never actually published, this just makes that explicit).
- Replace `CHANGELOG.md`'s ~20 stale entries with a short pointer to `packages/ui/CHANGELOG.md` (the real, changesets-tracked release history) and git log for infra/tooling changes.

## Verification
`pnpm lint` and `pnpm check-types` pass repo-wide. No workflow references the root `package.json`'s version/private fields (confirmed via grep — `publish.yml`/`version.yml` only ever read `packages/ui/package.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)