### PR TITLE
🐛 fix(drawer): stop draggable mode from swallowing header/footer clicks

### DIFF
--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -161,6 +161,7 @@ const Drawer = ({
         }}
       >
         <DrawerHeader
+          data-vaul-no-drag
           className={cn(
             classNames?.header,
             !title && 'p-0',
@@ -200,7 +201,9 @@ const Drawer = ({
           {children}
         </div>
         {renderConditional(footer, v => (
-          <DrawerFooter className={cn(classNames?.footer)}>{v}</DrawerFooter>
+          <DrawerFooter data-vaul-no-drag className={cn(classNames?.footer)}>
+            {v}
+          </DrawerFooter>
         ))}
       </DrawerContent>
     </DrawerCore>


### PR DESCRIPTION
## Root cause
`Drawer`'s `draggable` prop maps to vaul's `handleOnly={!draggable}` on the underlying `Drawer.Root`. When `draggable={true}`, vaul's drag-gesture recognizer captures pointer events starting anywhere inside `DrawerContent` — including the close (X) button, `extra` header content, and footer buttons. A few pixels of pointer movement during an ordinary tap/click can get interpreted as a swipe start, suppressing the click event the button would otherwise fire.

`draggable` defaults to `false` on `Drawer` itself, so most direct consumers weren't affected — but the Storybook `Default` story sets `draggable: true` as its default arg, which is the likely way this got noticed.

## Fix
vaul exposes `data-vaul-no-drag` to opt an element (and its descendants, via `.closest()`) out of drag-gesture capture. Added it to `DrawerHeader` and `DrawerFooter`, so the header (close button, title, `extra`) and footer (action buttons) stay reliably clickable regardless of `draggable`, while the body content area remains the actual drag surface.

## Verification
`pnpm lint` / `pnpm check-types` / `turbo run build --filter=@repo/ui` all pass.

**Not visually verified in a browser** — the sandboxed browser tool can't reach localhost in this environment. This is a well-documented vaul behavior (confirmed by reading vaul's own `shouldDrag()` source, which explicitly checks for `data-vaul-no-drag` before proceeding), and the fix follows vaul's own documented escape hatch, but please click-test the close button with `draggable` on before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)