### PR TITLE
🐛 fix(drawer): close button not clickable due to renderConditional wrapper

### DIFF
--- a/.changeset/pr-155.md
+++ b/.changeset/pr-155.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix Drawer close button not working: it was rendered via `renderConditional`, which short-circuits on already-valid React elements and skipped the `onClick={onClose}` wrapper, leaving a click handler-less icon.

--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -168,17 +168,17 @@ const Drawer = ({
           )}
         >
           <div className="flex items-start gap-2">
-            {renderConditional(closable ? closeIcon || <X /> : null, v => (
+            {closable && (
               <Button
                 type="text"
                 shape="circle"
                 size="small"
                 aria-label="닫기"
-                icon={v}
+                icon={closeIcon || <X />}
                 onClick={onClose}
                 className={cn(classNames?.close)}
               />
-            ))}
+            )}
             <div className="flex flex-1 items-start justify-between gap-2">
               <DrawerTitle className={cn(classNames?.title)}>
                 {title}


### PR DESCRIPTION
## Root cause
`renderConditional` receives `closable ? closeIcon || <X /> : null`. Since `<X />` is already a valid React element, `React.isValidElement()` short-circuits and returns it as-is, skipping the wrapper callback that would render the actual `<Button onClick={onClose} ...>`. The result is a bare icon with no click handler — the close button visually renders but clicking it does nothing.

## Fix
Render the close button directly via a `closable &&` conditional instead of routing it through `renderConditional`, so `onClick={onClose}` is always attached when the button is shown.

## Verification
`pnpm lint` / `pnpm check-types` / `turbo run build --filter=@repo/ui` all pass (from prior session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)