### PR TITLE
feat(components): add Toast organism component

### DIFF
--- a/.changeset/pr-157.md
+++ b/.changeset/pr-157.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add a new Toast organism component with a shadcn/sonner-style notification card, using ui-kit's existing imperative stack+portal mechanism (matching Modal's pattern). Exposes `Toast.info()`, `.success()`, `.error()`, and `.warning()` trigger functions plus a controlled `<Toast>` component.

--- a/apps/docs/stories/organisms/toast/index.stories.tsx
+++ b/apps/docs/stories/organisms/toast/index.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button, Toast } from '@repo/ui';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Feedback/Toast',
+  component: Toast,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['info', 'success', 'error', 'warning'],
+    },
+    closable: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    type: 'info',
+    title: '알림',
+    description: '이것은 토스트 알림입니다.',
+    closable: true,
+  },
+};
+
+export const StaticToast: Story = {
+  render: () => {
+    const showInfo = () => {
+      Toast.info('정보', { description: '이것은 정보 토스트입니다.' });
+    };
+
+    const showSuccess = () => {
+      Toast.success('성공', {
+        description: '작업이 성공적으로 완료되었습니다.',
+      });
+    };
+
+    const showError = () => {
+      Toast.error('오류', { description: '오류가 발생했습니다.' });
+    };
+
+    const showWarning = () => {
+      Toast.warning('경고', { description: '주의가 필요한 작업입니다.' });
+    };
+
+    return (
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={showInfo} variant="outlined">
+          Info
+        </Button>
+        <Button onClick={showSuccess} variant="outlined">
+          Success
+        </Button>
+        <Button onClick={showError} variant="outlined">
+          Error
+        </Button>
+        <Button onClick={showWarning} variant="outlined">
+          Warning
+        </Button>
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/components/organisms/index.ts
+++ b/packages/ui/src/components/organisms/index.ts
@@ -3,3 +3,5 @@ export type { Props as DrawerProps } from './drawer';
 export { default as List } from './list';
 export { default as Modal } from './modal';
 export { default as Swiper } from './swiper';
+export { default as Toast } from './toast';
+export type { ToastOptions } from './toast';

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Root, createRoot } from 'react-dom/client';
+
+import { Check, Info, OctagonAlert, OctagonX, X } from 'lucide-react';
+import { v4 as uuid } from 'uuid';
+
+import { cn } from '@repo/ui/utils';
+
+import Button from '../atoms/button';
+
+type ToastType = 'info' | 'success' | 'error' | 'warning';
+
+export interface Props {
+  type?: ToastType;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: React.ReactNode;
+  closable?: boolean;
+  action?: React.ReactNode;
+  className?: string;
+  onClose?: () => void;
+}
+
+interface StaticProps extends Props {
+  id?: string;
+  duration?: number;
+  container?: HTMLElement;
+}
+
+const isBrowser =
+  typeof window !== 'undefined' && typeof document !== 'undefined';
+
+type ContainerState = {
+  stack: StaticProps[];
+  update: (() => void) | null;
+};
+
+const containerStates = new Map<HTMLElement, ContainerState>();
+
+const getContainerState = (container: HTMLElement): ContainerState => {
+  let state = containerStates.get(container);
+
+  if (!state) {
+    state = { stack: [], update: null };
+    containerStates.set(container, state);
+  }
+
+  return state;
+};
+
+const createToastRoot = (container?: HTMLElement) => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const targetContainer = container || document.body;
+  let rootEl = targetContainer.querySelector(
+    '#toast-root',
+  ) as HTMLElement | null;
+
+  if (!rootEl) {
+    rootEl = document.createElement('div');
+    rootEl.setAttribute('id', 'toast-root');
+    rootEl.setAttribute('role', 'region');
+    rootEl.setAttribute('aria-label', 'Notifications');
+    rootEl.style.zIndex = '10000';
+    rootEl.style.position = 'fixed';
+    rootEl.style.right = '0';
+    rootEl.style.bottom = '0';
+    rootEl.style.display = 'flex';
+    rootEl.style.flexDirection = 'column-reverse';
+    rootEl.style.gap = '8px';
+    rootEl.style.padding = '16px';
+    rootEl.style.pointerEvents = 'none';
+    targetContainer.appendChild(rootEl);
+  }
+
+  return rootEl;
+};
+
+const TYPE_ICONS: Record<ToastType, React.ReactNode> = {
+  info: <Info className="text-blue-400" />,
+  success: <Check className="text-green-400" />,
+  error: <OctagonX className="text-red-400" />,
+  warning: <OctagonAlert className="text-yellow-400" />,
+};
+
+const Toast = ({
+  type,
+  title,
+  description,
+  icon,
+  closable = true,
+  action,
+  className,
+  onClose,
+}: Props) => {
+  return (
+    <div
+      role="status"
+      className={cn(
+        'pointer-events-auto flex w-80 items-start gap-3 rounded-lg',
+        'bg-background text-foreground border p-4 shadow-lg',
+        className,
+        //
+      )}
+    >
+      {(icon || type) && (
+        <div className="mt-0.5 shrink-0 [&_svg]:size-5">
+          {icon || (type && TYPE_ICONS[type])}
+        </div>
+      )}
+      <div className="flex-1 space-y-1">
+        <p className="text-sm font-medium">{title}</p>
+        {description && (
+          <p className="text-muted-foreground text-sm">{description}</p>
+        )}
+        {action && <div className="pt-1">{action}</div>}
+      </div>
+      {closable && (
+        <Button
+          type="text"
+          shape="circle"
+          size="small"
+          aria-label="Close"
+          icon={<X />}
+          onClick={onClose}
+        />
+      )}
+    </div>
+  );
+};
+
+const DEFAULT_DURATION = 4000;
+
+const StaticToast = ({
+  id,
+  duration = DEFAULT_DURATION,
+  container,
+  onClose,
+  ...props
+}: StaticProps) => {
+  const [visible, setVisible] = useState(true);
+
+  const close = () => {
+    onClose?.();
+    setVisible(false);
+    setTimeout(() => {
+      Toast.destroy(id);
+    }, 200);
+  };
+
+  useEffect(() => {
+    if (!duration) {
+      return;
+    }
+
+    const timer = setTimeout(close, duration);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [duration]);
+
+  if (!isBrowser) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className={cn(
+        'transition-all duration-200',
+        visible ? 'opacity-100' : 'translate-x-2 opacity-0',
+      )}
+    >
+      <Toast {...props} onClose={close} />
+    </div>,
+    createToastRoot(container)!,
+  );
+};
+
+const ToastStackRenderer = ({ container }: { container: HTMLElement }) => {
+  const [, forceUpdate] = useState({});
+
+  useEffect(() => {
+    const state = getContainerState(container);
+    state.update = () => forceUpdate({});
+    return () => {
+      state.update = null;
+    };
+  }, [container]);
+
+  const { stack } = getContainerState(container);
+
+  return (
+    <>
+      {stack.map(({ id, ...props }) => (
+        <StaticToast key={id} id={id} {...props} />
+      ))}
+    </>
+  );
+};
+
+const toastRoots = new Map<HTMLElement, Root>();
+
+const renderToast = (props: StaticProps) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  const targetContainer = props.container || document.body;
+  const rootElement = createToastRoot(targetContainer)!;
+
+  if (!toastRoots.has(targetContainer)) {
+    const root = createRoot(rootElement);
+    toastRoots.set(targetContainer, root);
+    root.render(<ToastStackRenderer container={targetContainer} />);
+  }
+
+  const state = getContainerState(targetContainer);
+  const id = props.id || uuid();
+  state.stack.push({ ...props, id });
+  state.update?.();
+
+  return id;
+};
+
+Toast.destroy = (id?: string) => {
+  if (!id) {
+    containerStates.forEach(state => {
+      state.stack = [];
+      state.update?.();
+    });
+    toastRoots.forEach(root => root.unmount());
+    toastRoots.clear();
+    containerStates.clear();
+    return;
+  }
+
+  containerStates.forEach((state, container) => {
+    if (!state.stack.some(toast => toast.id === id)) {
+      return;
+    }
+
+    state.stack = state.stack.filter(toast => toast.id !== id);
+    state.update?.();
+
+    if (!state.stack.length) {
+      toastRoots.get(container)?.unmount();
+      toastRoots.delete(container);
+      containerStates.delete(container);
+    }
+  });
+};
+
+Toast.destroyAll = () => {
+  Toast.destroy();
+};
+
+type TriggerOptions = Omit<StaticProps, 'type' | 'title'>;
+
+Toast.info = (title: React.ReactNode, props?: TriggerOptions) =>
+  renderToast({ type: 'info', title, ...props });
+Toast.success = (title: React.ReactNode, props?: TriggerOptions) =>
+  renderToast({ type: 'success', title, ...props });
+Toast.error = (title: React.ReactNode, props?: TriggerOptions) =>
+  renderToast({ type: 'error', title, ...props });
+Toast.warning = (title: React.ReactNode, props?: TriggerOptions) =>
+  renderToast({ type: 'warning', title, ...props });
+
+export default Toast;
+export type { StaticProps as ToastOptions };


### PR DESCRIPTION
## Summary
- Add `organisms/toast.tsx`: a shadcn/sonner-style notification card, implemented with ui-kit's own existing imperative stack+portal mechanism instead of the `sonner` package — mirrors `organisms/modal.tsx`'s `Modal.success()`/`.error()` pattern exactly
- Expose `Toast.info()`/`.success()`/`.error()`/`.warning()` trigger functions plus a plain `<Toast>` component for controlled/inline usage
- Register the export in `components/organisms/index.ts` and add a Storybook story covering both the controlled `Default` story and the imperative `StaticToast` story
- No new dependency added

## Test plan
- [x] `tsc -b`, `eslint`, `tsdown` build all pass
- [x] Confirmed `Toast` export present in the built bundle