### PR TITLE
✨ feat: add disabled prop to DatePicker and ColorPicker

### DIFF
--- a/.changeset/pr-163.md
+++ b/.changeset/pr-163.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Color picker and date picker components now support a disabled state, preventing user interaction and visual changes to indicate the component is not interactive.

--- a/packages/ui/src/components/atoms/color-picker.tsx
+++ b/packages/ui/src/components/atoms/color-picker.tsx
@@ -11,6 +11,7 @@ interface Props {
   defaultValue?: string;
   value?: string;
   showText?: boolean;
+  disabled?: boolean;
   onChange?: (color: string) => void;
 }
 
@@ -18,6 +19,7 @@ const ColorPicker = ({
   defaultValue,
   value: _value,
   showText,
+  disabled,
   onChange: _onChange = () => {},
 }: Props) => {
   const [uncontrolledValue, setUncontrolledValue] = useState<string>(
@@ -28,6 +30,9 @@ const ColorPicker = ({
   const value = controlled ? _value : uncontrolledValue;
 
   const onChange = (color: string) => {
+    if (disabled) {
+      return;
+    }
     if (!controlled) {
       setUncontrolledValue(color);
     }
@@ -41,13 +46,22 @@ const ColorPicker = ({
     >
       <div
         role="button"
-        tabIndex={0}
+        tabIndex={disabled ? -1 : 0}
+        aria-disabled={disabled}
         className={cn(
           'inline-flex items-center',
           'rounded border p-0.5',
-          //
+          disabled && 'cursor-not-allowed opacity-50',
         )}
+        onClick={e => {
+          if (disabled) {
+            e.preventDefault();
+          }
+        }}
         onKeyDown={e => {
+          if (disabled) {
+            return;
+          }
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             e.currentTarget.click();
@@ -56,9 +70,9 @@ const ColorPicker = ({
       >
         <div
           className={cn(
-            'size-6 cursor-pointer rounded border',
+            'size-6 rounded border',
             'shadow-sm',
-            //
+            disabled ? 'cursor-not-allowed' : 'cursor-pointer',
           )}
           style={{ backgroundColor: value }}
         />

--- a/packages/ui/src/components/atoms/date-picker.tsx
+++ b/packages/ui/src/components/atoms/date-picker.tsx
@@ -18,6 +18,7 @@ interface Props {
   value?: Date;
   placeholder?: string;
   className?: string;
+  disabled?: boolean;
   onChange?: (date: Date | undefined) => void;
 }
 
@@ -26,6 +27,7 @@ const DatePicker = ({
   value: _value,
   placeholder = 'Pick a date',
   className,
+  disabled,
   onChange: _onChange = () => {},
 }: Props) => {
   const [uncontrolledValue, setUncontrolledValue] = useState<Date | undefined>(
@@ -51,6 +53,7 @@ const DatePicker = ({
         type="default"
         icon={<CalendarIcon />}
         data-empty={!value}
+        disabled={disabled}
         className={cn(
           'w-full justify-start text-left font-normal',
           'data-[empty=true]:text-muted-foreground',


### PR DESCRIPTION
## 배경

이슈 #159의 4번 항목: `DatePicker`/`ColorPicker`가 형제 atom(Radio/Checkbox/Switch/RadioGroup)과 달리 `disabled` prop을 지원하지 않던 API 일관성 문제.

## 변경 사항

- `DatePicker`: `disabled`를 트리거인 `Button`에 그대로 전달 (Button이 이미 네이티브 disabled 처리, popover 오픈도 자동 차단)
- `ColorPicker`: 트리거가 plain `div`라 네이티브 disabled가 없으므로 `aria-disabled`/`tabIndex=-1`/클릭 `preventDefault`로 popover 오픈 차단 + `onChange` 콜백 가드 추가

## 관련 이슈

closes 일부 #159 (disabled prop 항목)