### PR TITLE
🐛 fix: track/scroll the correct window in BackTop

### DIFF
--- a/.changeset/pr-166.md
+++ b/.changeset/pr-166.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+The BackTop component now correctly tracks and scrolls the window that renders it, even when portaled into an iframe.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
-    "@jbpark/use-hooks": "^2.6.0",
+    "@jbpark/use-hooks": "^2.8.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/ui/src/components/atoms/float-button/back-top.tsx
+++ b/packages/ui/src/components/atoms/float-button/back-top.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MouseEvent } from 'react';
+import { type MouseEvent, useRef } from 'react';
 
 import { useWindowScroll } from '@jbpark/use-hooks';
 import { ArrowUp } from 'lucide-react';
@@ -16,15 +16,32 @@ export interface Props extends ButtonProps {
 }
 
 const BackTop = ({
+  ref,
   visibilityHeight = 450,
   className,
   onClick,
   ...props
 }: Props) => {
-  const { y } = useWindowScroll();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Track/scroll whichever window actually renders this button — not
+  // necessarily the host `window`, since this can be portaled into an
+  // iframe (e.g. live-editor's Renderer).
+  const { y } = useWindowScroll(buttonRef);
+
+  const setRefs = (node: HTMLButtonElement | null) => {
+    buttonRef.current = node;
+
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (ref) {
+      ref.current = node;
+    }
+  };
 
   return (
     <FloatButton
+      ref={setRefs}
       aria-label="맨 위로"
       icon={<ArrowUp />}
       className={cn(
@@ -33,7 +50,8 @@ const BackTop = ({
         //
       )}
       onClick={e => {
-        window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
+        const view = buttonRef.current?.ownerDocument.defaultView ?? window;
+        view.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
         onClick?.(e);
       }}
       {...props}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.3)
       '@jbpark/use-hooks':
-        specifier: ^2.6.0
-        version: 2.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -324,6 +324,10 @@ packages:
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.28.6':
     resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
@@ -370,6 +374,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@8.0.0-rc.1':
     resolution: {integrity: sha512-I4YnARytXC2RzkLNVnf5qFNFMzp679qZpmtw/V3Jt2uGnWiIxyJtaukjG7R8pSx8nG2NamICpGfljQsogj+FbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -394,6 +402,10 @@ packages:
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -868,8 +880,8 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@jbpark/use-hooks@2.6.0':
-    resolution: {integrity: sha512-OofmeebAYntUcPnSKp8BdBVkeksg6bk7Dcu6ZIJmn/2aY+9rtAgWw+HoJyYzlk/xTfdbSxJ6olcSdgH/GbryNw==}
+  '@jbpark/use-hooks@2.8.0':
+    resolution: {integrity: sha512-O/HSPI/tBydAA4NBWm0cnuy5gvlB6PKeZezSvZ8RXryRNc3SdCeC9pOUWBRVP7wAhcIDslgLRDyML7JM8DhccQ==}
     peerDependencies:
       react: ^19.1.1
       react-dom: ^19.1.1
@@ -4945,6 +4957,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.28.6': {}
 
   '@babel/core@7.28.6':
@@ -5016,6 +5034,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-identifier@8.0.0-rc.1': {}
 
   '@babel/helper-validator-option@7.27.1': {}
@@ -5034,6 +5054,8 @@ snapshots:
       '@babel/types': 8.0.0-rc.1
 
   '@babel/runtime@7.28.6': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5500,7 +5522,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@jbpark/use-hooks@2.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@jbpark/use-hooks@2.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -6688,8 +6710,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.28.6
-      '@babel/runtime': 7.28.6
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16


### PR DESCRIPTION
## 배경

이슈 #159의 1번 항목 마지막 부분: `BackTop`이 `window.scrollTo`/`useWindowScroll()` 둘 다 전역 `window`를 하드코딩하고 있어서, live-editor처럼 iframe(`createPortal`)에 렌더링되는 환경에서는 호스트 페이지를 스크롤/추적해버리는 문제.

## 변경 사항

- `@jbpark/use-hooks`를 `^2.8.0`으로 업데이트 (target-ref를 받는 새 `useWindowScroll` 포함)
- `BackTop`이 자기 버튼의 ref를 `useWindowScroll`에 전달하고, 클릭 시에도 `buttonRef.current.ownerDocument.defaultView`를 사용하도록 변경
- 인자 없이 쓰는 다른 곳(top-level 렌더링)은 동작 그대로 유지 (하위 호환)

## 관련 이슈

closes 일부 #159 (BackTop window 항목)