### PR TITLE
⬆️ chore: bump @jbpark/use-hooks to 2.11.0

### DIFF
--- a/.changeset/pr-167.md
+++ b/.changeset/pr-167.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Update @jbpark/use-hooks to version 2.11.0.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
-    "@jbpark/use-hooks": "^2.8.0",
+    "@jbpark/use-hooks": "^2.11.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.3)
       '@jbpark/use-hooks':
-        specifier: ^2.8.0
-        version: 2.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.11.0
+        version: 2.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -880,8 +880,8 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@jbpark/use-hooks@2.8.0':
-    resolution: {integrity: sha512-O/HSPI/tBydAA4NBWm0cnuy5gvlB6PKeZezSvZ8RXryRNc3SdCeC9pOUWBRVP7wAhcIDslgLRDyML7JM8DhccQ==}
+  '@jbpark/use-hooks@2.11.0':
+    resolution: {integrity: sha512-9bqfkOqgxjcud0NB/i5hShGiCfihkNhc5fQD9yTjVnN/I+YEvsO646QVS/quP2E6B6ca8pBZ+l0fQwv1rIB0VA==}
     peerDependencies:
       react: ^19.1.1
       react-dom: ^19.1.1
@@ -5522,7 +5522,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@jbpark/use-hooks@2.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@jbpark/use-hooks@2.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## 변경 사항
- `@jbpark/use-hooks` `^2.8.0` → `^2.11.0`

## 확인 내용
ui-kit이 실제로 사용 중인 훅 중 이번 버전업(#78~#91 배치)으로 변경된 것은 두 개:
- `useResponsiveSize` (`marquees.tsx`)
- `useWindowScroll` (`back-top.tsx`)

두 사용처 모두 새 API와 호환되어 코드 수정 없이 반영됨.

## 검증
- `pnpm build` 통과
- `pnpm lint` 통과 (기존 무관 warning 2건 제외 이상 없음)