### PR TITLE
♻️ refactor: replace duplicated controlled/uncontrolled state with useControllableState

### DIFF
--- a/.changeset/pr-168.md
+++ b/.changeset/pr-168.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Updated checkbox, radio, and switch components to use useControllableState for controlled and uncontrolled state management.

--- a/packages/ui/src/components/atoms/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/atoms/checkbox/checkbox.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
+import { useControllableState } from '@jbpark/use-hooks';
 import { Square, SquareCheck } from 'lucide-react';
 
 import { checkbox, label } from '@repo/ui/core';
@@ -38,13 +39,13 @@ const Checkbox = ({
   onChange: _onChange = () => {},
   ...props
 }: Props) => {
-  const [uncontrolledChecked, setUncontrolledChecked] = useState<boolean>(
-    defaultChecked || false,
-  );
+  const [checked, setChecked] = useControllableState<boolean>({
+    value: _checked,
+    defaultValue: defaultChecked ?? false,
+    onChange: _onChange,
+  });
 
   const id = useId();
-  const controlled = _checked !== undefined;
-  const checked = controlled ? _checked : uncontrolledChecked;
 
   const cursorClassName = disabled ? 'cursor-not-allowed' : 'cursor-pointer';
 
@@ -53,10 +54,7 @@ const Checkbox = ({
       return;
     }
 
-    if (!controlled) {
-      setUncontrolledChecked(next);
-    }
-    _onChange(next);
+    setChecked(next);
   };
 
   const renderContent = icons ? (

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useControllableState } from '@jbpark/use-hooks';
 
 import { cn } from '@repo/ui/utils';
 
@@ -40,12 +40,11 @@ const Group = ({
   onChange: _onChange = () => {},
   ...props
 }: Props) => {
-  const [uncontrolledValue, setUncontrolledValue] = useState<OptionValue[]>(
-    defaultValue || [],
-  );
-
-  const controlled = _value !== undefined;
-  const value = controlled ? _value : uncontrolledValue;
+  const [value, setValue] = useControllableState<OptionValue[]>({
+    value: _value,
+    defaultValue: defaultValue ?? [],
+    onChange: _onChange,
+  });
 
   const options: Option[] = _options.map(item =>
     typeof item === 'object'
@@ -61,10 +60,7 @@ const Group = ({
       ? [...value, optionValue]
       : value.filter(v => v !== optionValue);
 
-    if (!controlled) {
-      setUncontrolledValue(nextValue);
-    }
-    _onChange(nextValue);
+    setValue(nextValue);
   };
 
   return (

--- a/packages/ui/src/components/atoms/color-picker.tsx
+++ b/packages/ui/src/components/atoms/color-picker.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
 import { HexColorPicker } from 'react-colorful';
+
+import { useControllableState } from '@jbpark/use-hooks';
 
 import { cn } from '@repo/ui/utils';
 
@@ -22,21 +23,17 @@ const ColorPicker = ({
   disabled,
   onChange: _onChange = () => {},
 }: Props) => {
-  const [uncontrolledValue, setUncontrolledValue] = useState<string>(
-    defaultValue || '#fff',
-  );
-
-  const controlled = _value !== undefined;
-  const value = controlled ? _value : uncontrolledValue;
+  const [value, setValue] = useControllableState<string>({
+    value: _value,
+    defaultValue: defaultValue ?? '#fff',
+    onChange: _onChange,
+  });
 
   const onChange = (color: string) => {
     if (disabled) {
       return;
     }
-    if (!controlled) {
-      setUncontrolledValue(color);
-    }
-    _onChange(color);
+    setValue(color);
   };
 
   return (

--- a/packages/ui/src/components/atoms/date-picker.tsx
+++ b/packages/ui/src/components/atoms/date-picker.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-
+import { useControllableState } from '@jbpark/use-hooks';
 import { format } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
 
@@ -30,19 +29,11 @@ const DatePicker = ({
   disabled,
   onChange: _onChange = () => {},
 }: Props) => {
-  const [uncontrolledValue, setUncontrolledValue] = useState<Date | undefined>(
+  const [value, onChange] = useControllableState<Date | undefined>({
+    value: _value,
     defaultValue,
-  );
-
-  const controlled = _value !== undefined;
-  const value = controlled ? _value : uncontrolledValue;
-
-  const onChange = (date: Date | undefined) => {
-    if (!controlled) {
-      setUncontrolledValue(date);
-    }
-    _onChange(date);
-  };
+    onChange: _onChange,
+  });
 
   return (
     <Popover

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useId } from 'react';
+
+import { useControllableState } from '@jbpark/use-hooks';
 
 import { radio } from '@repo/ui/core';
 import { cn } from '@repo/ui/utils';
@@ -53,12 +55,11 @@ const RadioGroup = ({
   onChange: _onChange = () => {},
   ...props
 }: Props) => {
-  const [uncontrolledValue, setUncontrolledValue] = useState<
-    OptionValue | undefined
-  >(defaultValue);
-
-  const controlled = _value !== undefined;
-  const value = controlled ? _value : uncontrolledValue;
+  const [value, setValue] = useControllableState<OptionValue>({
+    value: _value,
+    defaultValue,
+    onChange: _onChange,
+  });
 
   const options: Option[] = _options.map(item =>
     typeof item === 'object'
@@ -75,10 +76,7 @@ const RadioGroup = ({
     if (!checked) {
       return;
     }
-    if (!controlled) {
-      setUncontrolledValue(optionValue);
-    }
-    _onChange(optionValue);
+    setValue(optionValue);
   };
 
   // A single Radix radiogroup root owns every option so that arrow keys move

--- a/packages/ui/src/components/atoms/radio/radio.tsx
+++ b/packages/ui/src/components/atoms/radio/radio.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useContext, useId, useState } from 'react';
+import { useContext, useId } from 'react';
 
+import { useControllableState } from '@jbpark/use-hooks';
 import { Circle, CircleCheck } from 'lucide-react';
 
 import { field, radio } from '@repo/ui/core';
@@ -45,15 +46,15 @@ const Radio = ({
   onChange: _onChange = () => {},
   ...props
 }: Props) => {
-  const [uncontrolledChecked, setUncontrolledChecked] = useState<boolean>(
-    defaultChecked || false,
-  );
+  const [checked, setChecked] = useControllableState<boolean>({
+    value: _checked,
+    defaultValue: defaultChecked ?? false,
+    onChange: _onChange,
+  });
 
   const generatedId = useId();
   const id = _id ?? generatedId;
   const grouped = useContext(RadioGroupContext);
-  const controlled = _checked !== undefined;
-  const checked = controlled ? _checked : uncontrolledChecked;
 
   const cursorClassName = disabled ? 'cursor-not-allowed' : 'cursor-pointer';
 
@@ -62,10 +63,7 @@ const Radio = ({
       return;
     }
 
-    if (!controlled) {
-      setUncontrolledChecked(next);
-    }
-    _onChange(next);
+    setChecked(next);
   };
 
   // When rendered inside a `RadioGroup`, the group owns the single shared

--- a/packages/ui/src/components/atoms/switch.tsx
+++ b/packages/ui/src/components/atoms/switch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useControllableState } from '@jbpark/use-hooks';
 
 import { switchComponent } from '@repo/ui/core';
 import { cn } from '@repo/ui/utils';
@@ -58,19 +58,11 @@ const Switch = ({
   unCheckedChildren,
   ...props
 }: Props) => {
-  const [uncontrolledChecked, setUncontrolledChecked] = useState<boolean>(
-    defaultChecked || false,
-  );
-
-  const controlled = _checked !== undefined;
-  const checked = controlled ? _checked : uncontrolledChecked;
-
-  const onChange = (next: boolean) => {
-    if (!controlled) {
-      setUncontrolledChecked(next);
-    }
-    _onChange(next);
-  };
+  const [checked, onChange] = useControllableState<boolean>({
+    value: _checked,
+    defaultValue: defaultChecked ?? false,
+    onChange: _onChange,
+  });
 
   const hasChildren = !!(checkedChildren || unCheckedChildren);
   const config = sizeConfig[size];


### PR DESCRIPTION
## 변경 사항
Radio, RadioGroup, Checkbox, CheckboxGroup, Switch, ColorPicker, DatePicker에서 각자 손으로 구현하던 controlled/uncontrolled 패턴(`useState` + `controlled ? _x : uncontrolled` 삼항 + 수동 `_onChange` 호출)을 `@jbpark/use-hooks`의 `useControllableState`로 교체.

- public API/동작 변화 없음 (순수 리팩터링)
- dev 모드에서 controlled↔uncontrolled 전환 시 경고 로그를 추가로 얻음
- `Search`는 제외 — `value`/`defaultValue`를 네이티브 `<input>`에 그대로 넘기고 파생된 `hasValue` boolean만 추적하는 구조라 이 패턴과 맞지 않음

## 검증
- `pnpm build` 통과
- `pnpm lint` 통과 (기존 무관 warning 2건 제외 이상 없음)
- `docs` 앱 `check-types` 통과 (Storybook 스토리 포함)

관련: #159 (action item 5 완료. Button type/variant, RadioGroup/CheckboxGroup 통합, Popover 리팩터링은 별도 작업으로 남아있음)