### PR TITLE
🐛 fix: add Button htmlType and block clicks while loading

### DIFF
--- a/.changeset/pr-169.md
+++ b/.changeset/pr-169.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for antd-style visual presets and native button types to the Button component.

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -29,8 +29,19 @@ export interface Props extends Omit<ButtonProps, 'size' | 'variant' | 'type'> {
   danger?: boolean;
   disabled?: boolean;
   size?: 'small' | 'middle' | 'large';
+  /**
+   * antd-style visual preset. Maps to a `variant` internally — passing
+   * both `type` and `variant` lets `variant` win, so it can override the
+   * preset for one-off cases without needing every value duplicated here.
+   */
   type?: 'primary' | 'default' | 'dashed' | 'text' | 'link';
   variant?: 'solid' | 'outlined' | 'dashed' | 'filled' | 'text' | 'link';
+  /**
+   * Native `<button>` `type` (`button`/`submit`/`reset`), kept separate
+   * from the antd-style `type` above. Defaults to `'button'` so a Button
+   * placed inside a `<form>` doesn't submit it unless explicitly opted in.
+   */
+  htmlType?: 'button' | 'submit' | 'reset';
   shape?: 'default' | 'circle' | 'round';
   color?: PresetColors | 'default' | 'primary' | 'danger';
   loading?: boolean | { icon: React.ReactNode };
@@ -88,6 +99,7 @@ const Button = ({
   className,
   type = 'default',
   variant,
+  htmlType = 'button',
   size = 'middle',
   color = 'default',
   shape = 'default',
@@ -103,6 +115,7 @@ const Button = ({
   const computedColor = danger ? 'danger' : color;
   const colored = computedColor && computedColor !== 'default';
   const resolvedVariant = variant ?? typeToVariant[type] ?? 'solid';
+  const isLoading = !!loading;
 
   const displayIcon = loading ? (
     typeof loading === 'object' ? (
@@ -116,7 +129,9 @@ const Button = ({
 
   return (
     <Core
-      disabled={disabled}
+      type={htmlType}
+      disabled={disabled || isLoading}
+      aria-busy={isLoading}
       variant="default"
       data-color={computedColor}
       className={cn(


### PR DESCRIPTION
## 변경 사항
- `htmlType?: 'button'|'submit'|'reset'` prop 추가, 기본값 `'button'` — antd 스타일 `type`이 native `<button type>`을 가려서 폼 안에서 항상 submit되던 버그 수정
- `loading`일 때 `disabled` + `aria-busy` 반영 — 로딩 중 중복 클릭/제출 차단
- `type`/`variant` 이중 네이밍: 실사용 확인 결과(ui-kit 내부 variant 13곳/type 3곳, live-editor type 3곳) 둘 다 활발히 쓰여서 유지, `variant`가 `type`보다 우선한다는 동작만 JSDoc으로 문서화

## 검증
- `pnpm build` 통과
- `pnpm lint` 통과 (기존 무관 warning 2건 제외 이상 없음)
- `docs` 앱 `check-types` 통과
- 저장소 전체(`ui-kit`/`live-editor`/docs/web)에 `<form>` 사용처가 없어서 `htmlType` 기본값 변경으로 인한 breaking change 없음

관련: #165 (action item 1, 2), #159 (action item 3 방향 결정)