### PR TITLE
♻️ refactor: extract shared OptionValue/normalizeOptions for Radio/Checkbox groups

### DIFF
--- a/.changeset/pr-170.md
+++ b/.changeset/pr-170.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for option groups to checkbox and radio components, enabling users to group related options together.

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -4,17 +4,16 @@ import { useControllableState } from '@jbpark/use-hooks';
 
 import { cn } from '@repo/ui/utils';
 
+import {
+  type Option,
+  type OptionGroupClassNames,
+  type OptionValue,
+  type Options,
+  normalizeOptions,
+} from '../option-group';
 import Checkbox from './checkbox';
 
-export type OptionValue = string | number | boolean;
-
-type Option = {
-  label: string;
-  value: OptionValue;
-  disabled?: boolean;
-};
-
-type Options = string[] | number[] | boolean[] | Option[];
+export type { OptionValue };
 
 export interface Props extends Omit<
   React.ComponentPropsWithoutRef<'ul'>,
@@ -23,7 +22,7 @@ export interface Props extends Omit<
   options?: Options;
   orientation?: 'vertical' | 'horizontal';
   placement?: 'left' | 'right';
-  classNames?: Record<string, string>;
+  classNames?: OptionGroupClassNames;
   defaultValue?: OptionValue[];
   value?: OptionValue[];
   onChange?: (values: OptionValue[]) => void;
@@ -46,14 +45,7 @@ const Group = ({
     onChange: _onChange,
   });
 
-  const options: Option[] = _options.map(item =>
-    typeof item === 'object'
-      ? item
-      : {
-          label: `${item}`,
-          value: item,
-        },
-  );
+  const options: Option[] = normalizeOptions(_options);
 
   const onChange = (checked: boolean, optionValue: OptionValue) => {
     const nextValue = checked

--- a/packages/ui/src/components/atoms/option-group.ts
+++ b/packages/ui/src/components/atoms/option-group.ts
@@ -1,0 +1,24 @@
+export type OptionValue = string | number | boolean;
+
+export interface Option {
+  label: string;
+  value: OptionValue;
+  disabled?: boolean;
+}
+
+export type Options = string[] | number[] | boolean[] | Option[];
+
+export interface OptionGroupClassNames {
+  wrapper?: string;
+  item?: string;
+}
+
+export const normalizeOptions = (options: Options): Option[] =>
+  options.map(item =>
+    typeof item === 'object'
+      ? item
+      : {
+          label: `${item}`,
+          value: item,
+        },
+  );

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -8,20 +8,19 @@ import { radio } from '@repo/ui/core';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../button';
+import {
+  type Option,
+  type OptionGroupClassNames,
+  type OptionValue,
+  type Options,
+  normalizeOptions,
+} from '../option-group';
 import { RadioGroupContext } from './context';
 import Radio from './radio';
 
 const { RadioGroup: Core } = radio;
 
-export type OptionValue = string | number | boolean;
-
-type Option = {
-  label: string;
-  value: OptionValue;
-  disabled?: boolean;
-};
-
-type Options = string[] | number[] | boolean[] | Option[];
+export type { OptionValue };
 
 export interface Props extends Omit<
   React.ComponentPropsWithoutRef<'ul'>,
@@ -30,7 +29,7 @@ export interface Props extends Omit<
   options?: Options;
   orientation?: 'vertical' | 'horizontal';
   placement?: 'left' | 'right';
-  classNames?: Record<string, string>;
+  classNames?: OptionGroupClassNames;
   defaultValue?: OptionValue;
   value?: OptionValue;
   optionType?: 'default' | 'button';
@@ -61,14 +60,7 @@ const RadioGroup = ({
     onChange: _onChange,
   });
 
-  const options: Option[] = _options.map(item =>
-    typeof item === 'object'
-      ? item
-      : {
-          label: `${item}`,
-          value: item,
-        },
-  );
+  const options: Option[] = normalizeOptions(_options);
 
   const isButton = optionType === 'button';
 


### PR DESCRIPTION
## 변경 사항
RadioGroup과 CheckboxGroup이 각자 손으로 중복 구현하던 부분 중 실제로 완전히 동일한 부분만 `atoms/option-group.ts`로 추출:
- `OptionValue`/`Option`/`Options` 타입
- 옵션 정규화 로직 (`string[]|number[]|boolean[]|Option[]` → `Option[]`)

선택 로직(RadioGroup의 단일선택 Radix root vs CheckboxGroup의 다중선택 배열)은 실제로 다른 로직이라 억지로 하나의 훅/컴포넌트로 합치지 않았음 — 과설계 방지.

부수적으로 두 Group의 `classNames?: Record<string, string>`를 실제 사용 중인 `{ wrapper?: string; item?: string }` 형태(`OptionGroupClassNames`)로 좁힘.

## 검증
- `pnpm build`/`lint` 통과
- `docs` 앱 `check-types` 통과
- public API/동작 변화 없음

관련: #159 (action item 6)