### PR TITLE
✨ feat: add Popover controlled open API, close DatePicker on select

### DIFF
--- a/.changeset/pr-171.md
+++ b/.changeset/pr-171.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+The DatePicker component now supports a controlled open state, allowing users to customize the display of the date picker.

--- a/packages/ui/src/components/atoms/date-picker.tsx
+++ b/packages/ui/src/components/atoms/date-picker.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import { useControllableState } from '@jbpark/use-hooks';
 import { format } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
@@ -34,11 +36,23 @@ const DatePicker = ({
     defaultValue,
     onChange: _onChange,
   });
+  const [open, setOpen] = useState(false);
 
   return (
     <Popover
       placement="bottomLeft"
-      content={<Calendar mode="single" selected={value} onSelect={onChange} />}
+      open={open}
+      onOpenChange={setOpen}
+      content={
+        <Calendar
+          mode="single"
+          selected={value}
+          onSelect={date => {
+            onChange(date);
+            setOpen(false);
+          }}
+        />
+      }
     >
       <Button
         type="default"

--- a/packages/ui/src/components/atoms/popover.tsx
+++ b/packages/ui/src/components/atoms/popover.tsx
@@ -1,3 +1,5 @@
+import { useControllableState } from '@jbpark/use-hooks';
+
 import { popover } from '@repo/ui/core';
 import { cn, renderConditional } from '@repo/ui/utils';
 
@@ -19,65 +21,35 @@ type Placement =
   | 'rightTop'
   | 'rightBottom';
 
-interface Props extends Omit<
+export interface Props extends Omit<
   React.ComponentPropsWithoutRef<'div'>,
   'title' | 'content'
 > {
   title?: React.ReactNode;
   placement?: Placement;
   content: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-const placementMap = {
-  top: {
-    side: 'top',
-    align: 'center',
-  },
-  left: {
-    side: 'left',
-    align: 'center',
-  },
-  right: {
-    side: 'right',
-    align: 'center',
-  },
-  bottom: {
-    side: 'bottom',
-    align: 'center',
-  },
-  topLeft: {
-    side: 'top',
-    align: 'start',
-  },
-  topRight: {
-    side: 'top',
-    align: 'end',
-  },
-  bottomLeft: {
-    side: 'bottom',
-    align: 'start',
-  },
-  bottomRight: {
-    side: 'bottom',
-    align: 'end',
-  },
-  leftTop: {
-    side: 'left',
-    align: 'start',
-  },
-  leftBottom: {
-    side: 'left',
-    align: 'end',
-  },
-  rightTop: {
-    side: 'right',
-    align: 'start',
-  },
-  rightBottom: {
-    side: 'right',
-    align: 'end',
-  },
-} as const;
+type Side = 'top' | 'bottom' | 'left' | 'right';
+type Align = 'start' | 'center' | 'end';
+
+const placementMap: Record<Placement, { side: Side; align: Align }> = {
+  top: { side: 'top', align: 'center' },
+  left: { side: 'left', align: 'center' },
+  right: { side: 'right', align: 'center' },
+  bottom: { side: 'bottom', align: 'center' },
+  topLeft: { side: 'top', align: 'start' },
+  topRight: { side: 'top', align: 'end' },
+  bottomLeft: { side: 'bottom', align: 'start' },
+  bottomRight: { side: 'bottom', align: 'end' },
+  leftTop: { side: 'left', align: 'start' },
+  leftBottom: { side: 'left', align: 'end' },
+  rightTop: { side: 'right', align: 'start' },
+  rightBottom: { side: 'right', align: 'end' },
+};
 
 const beforeBase = 'before:content-[""] before:absolute before:h-0 before:w-0';
 const afterBase = 'after:content-[""] after:absolute after:h-0 after:w-0';
@@ -91,148 +63,79 @@ const vFillShape =
 const hFillShape =
   'after:border-t-8 after:border-b-8 after:border-t-transparent after:border-b-transparent';
 
-const topBorder = 'before:border-t-[9px] before:border-t-border';
-const bottomBorder = 'before:border-b-[9px] before:border-b-border';
-const leftBorder = 'before:border-l-[9px] before:border-l-border';
-const rightBorder = 'before:border-r-[9px] before:border-r-border';
-const topFill = 'after:border-t-8 after:border-t-popover';
-const bottomFill = 'after:border-b-8 after:border-b-popover';
-const leftFill = 'after:border-l-8 after:border-l-popover';
-const rightFill = 'after:border-r-8 after:border-r-popover';
+// Top/bottom placements draw a vertical-edge triangle (border-l/border-r) —
+// the arrow points up/down, so its left/right edges form the point. Left/
+// right placements draw the horizontal-edge equivalent.
+const borderShapeBySide: Record<Side, string> = {
+  top: vBorderShape,
+  bottom: vBorderShape,
+  left: hBorderShape,
+  right: hBorderShape,
+};
+const fillShapeBySide: Record<Side, string> = {
+  top: vFillShape,
+  bottom: vFillShape,
+  left: hFillShape,
+  right: hFillShape,
+};
+const borderColorBySide: Record<Side, string> = {
+  top: 'before:border-t-[9px] before:border-t-border',
+  bottom: 'before:border-b-[9px] before:border-b-border',
+  left: 'before:border-l-[9px] before:border-l-border',
+  right: 'before:border-r-[9px] before:border-r-border',
+};
+const fillColorBySide: Record<Side, string> = {
+  top: 'after:border-t-8 after:border-t-popover',
+  bottom: 'after:border-b-8 after:border-b-popover',
+  left: 'after:border-l-8 after:border-l-popover',
+  right: 'after:border-r-8 after:border-r-popover',
+};
 
-const arrowStyles: Record<Placement, string> = {
-  top: [
-    'absolute left-1/2 -translate-x-1/2 top-full',
+// `side` picks which edge of the content the arrow sits against; `align`
+// slides it along that edge. The offset axis (x for top/bottom, y for
+// left/right) is perpendicular to `side` — `align: 'center'` centers the
+// arrow with a translate, while `start`/`end` pin it 16px from that edge.
+const offsetAxisBySide: Record<Side, 'x' | 'y'> = {
+  top: 'x',
+  bottom: 'x',
+  left: 'y',
+  right: 'y',
+};
+const startEdgeByAxis = { x: 'left', y: 'top' } as const;
+const endEdgeByAxis = { x: 'right', y: 'bottom' } as const;
+
+const getArrowClassName = (side: Side, align: Align) => {
+  const axis = offsetAxisBySide[side];
+  const alignEdge =
+    align === 'start'
+      ? startEdgeByAxis[axis]
+      : align === 'end'
+        ? endEdgeByAxis[axis]
+        : null;
+
+  const positionAlign = alignEdge
+    ? `${alignEdge}-4`
+    : `${startEdgeByAxis[axis]}-1/2 -translate-${axis}-1/2`;
+  const beforeAlign = alignEdge
+    ? `before:${alignEdge}-0`
+    : `before:${startEdgeByAxis[axis]}-1/2 before:-translate-${axis}-1/2`;
+  const afterAlign = alignEdge
+    ? `after:${alignEdge}-px`
+    : `after:${startEdgeByAxis[axis]}-1/2 after:-translate-${axis}-1/2`;
+
+  return cn(
+    `absolute ${positionAlign} ${side}-full`,
     beforeBase,
-    'before:top-0 before:left-1/2 before:-translate-x-1/2',
-    vBorderShape,
-    topBorder,
+    `before:${side}-0`,
+    beforeAlign,
+    borderShapeBySide[side],
+    borderColorBySide[side],
     afterBase,
-    'after:-top-px after:left-1/2 after:-translate-x-1/2',
-    vFillShape,
-    topFill,
-  ].join(' '),
-  topLeft: [
-    'absolute left-4 top-full',
-    beforeBase,
-    'before:top-0 before:left-0',
-    vBorderShape,
-    topBorder,
-    afterBase,
-    'after:-top-px after:left-px',
-    vFillShape,
-    topFill,
-  ].join(' '),
-  topRight: [
-    'absolute right-4 top-full',
-    beforeBase,
-    'before:top-0 before:right-0',
-    vBorderShape,
-    topBorder,
-    afterBase,
-    'after:-top-px after:right-px',
-    vFillShape,
-    topFill,
-  ].join(' '),
-  bottom: [
-    'absolute left-1/2 -translate-x-1/2 bottom-full',
-    beforeBase,
-    'before:bottom-0 before:left-1/2 before:-translate-x-1/2',
-    vBorderShape,
-    bottomBorder,
-    afterBase,
-    'after:-bottom-px after:left-1/2 after:-translate-x-1/2',
-    vFillShape,
-    bottomFill,
-  ].join(' '),
-  bottomLeft: [
-    'absolute left-4 bottom-full',
-    beforeBase,
-    'before:bottom-0 before:left-0',
-    vBorderShape,
-    bottomBorder,
-    afterBase,
-    'after:-bottom-px after:left-px',
-    vFillShape,
-    bottomFill,
-  ].join(' '),
-  bottomRight: [
-    'absolute right-4 bottom-full',
-    beforeBase,
-    'before:bottom-0 before:right-0',
-    vBorderShape,
-    bottomBorder,
-    afterBase,
-    'after:-bottom-px after:right-px',
-    vFillShape,
-    bottomFill,
-  ].join(' '),
-  left: [
-    'absolute top-1/2 -translate-y-1/2 left-full',
-    beforeBase,
-    'before:left-0 before:top-1/2 before:-translate-y-1/2',
-    hBorderShape,
-    leftBorder,
-    afterBase,
-    'after:-left-px after:top-1/2 after:-translate-y-1/2',
-    hFillShape,
-    leftFill,
-  ].join(' '),
-  leftTop: [
-    'absolute top-4 left-full',
-    beforeBase,
-    'before:left-0 before:top-0',
-    hBorderShape,
-    leftBorder,
-    afterBase,
-    'after:-left-px after:top-px',
-    hFillShape,
-    leftFill,
-  ].join(' '),
-  leftBottom: [
-    'absolute bottom-4 left-full',
-    beforeBase,
-    'before:left-0 before:bottom-0',
-    hBorderShape,
-    leftBorder,
-    afterBase,
-    'after:-left-px after:bottom-px',
-    hFillShape,
-    leftFill,
-  ].join(' '),
-  right: [
-    'absolute top-1/2 -translate-y-1/2 right-full',
-    beforeBase,
-    'before:right-0 before:top-1/2 before:-translate-y-1/2',
-    hBorderShape,
-    rightBorder,
-    afterBase,
-    'after:-right-px after:top-1/2 after:-translate-y-1/2',
-    hFillShape,
-    rightFill,
-  ].join(' '),
-  rightTop: [
-    'absolute top-4 right-full',
-    beforeBase,
-    'before:right-0 before:top-0',
-    hBorderShape,
-    rightBorder,
-    afterBase,
-    'after:-right-px after:top-px',
-    hFillShape,
-    rightFill,
-  ].join(' '),
-  rightBottom: [
-    'absolute bottom-4 right-full',
-    beforeBase,
-    'before:right-0 before:bottom-0',
-    hBorderShape,
-    rightBorder,
-    afterBase,
-    'after:-right-px after:bottom-px',
-    hFillShape,
-    rightFill,
-  ].join(' '),
+    `after:-${side}-px`,
+    afterAlign,
+    fillShapeBySide[side],
+    fillColorBySide[side],
+  );
 };
 
 const Popover = ({
@@ -241,15 +144,26 @@ const Popover = ({
   className,
   content,
   children,
+  open: _open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }: Props) => {
+  const [open, setOpen] = useControllableState<boolean>({
+    value: _open,
+    defaultValue: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  const { side, align } = placementMap[placement];
+
   return (
-    <CorePopover>
+    <CorePopover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent
         {...props}
-        align={placementMap[placement].align}
-        side={placementMap[placement].side}
+        align={align}
+        side={side}
         sideOffset={16}
         className={cn('relative w-auto', className)}
       >
@@ -257,7 +171,7 @@ const Popover = ({
           <Typography.Title level={6}>{v}</Typography.Title>
         ))}
         {content}
-        <div className={cn(arrowStyles[placement])} />
+        <div className={getArrowClassName(side, align)} />
       </PopoverContent>
     </CorePopover>
   );


### PR DESCRIPTION
## 변경 사항

### Popover
- `open`/`defaultOpen`/`onOpenChange` controlled API 추가 (`useControllableState` 사용 — 다른 atom들과 일관된 패턴)
- 12개 placement 하드코딩 화살표 스타일 테이블(~150줄)을 `side`/`align` 기반 계산 함수(`getArrowClassName`)로 대체
- `Props` 타입 export 추가 (다른 atom들과 동일하게)

### DatePicker
- 로컬 `open` state를 Popover에 연결하고 `Calendar onSelect`에서 `setOpen(false)` 호출
- 기존엔 날짜 선택이 content 내부 클릭이라 outside-click으로도 안 닫혀서 선택 후 캘린더가 계속 떠 있던 버그였음

## 검증
- `pnpm build`/`lint` 통과
- `docs` 앱 `check-types` 통과
- 화살표 스타일 리팩터링은 별도 스크립트로 생성된 클래스가 기존 12개 placement 값과 토큰 단위로 완전히 일치함을 사전 검증
- Storybook 비주얼 확인은 브라우저 샌드박스 환경 제약으로 스킵 (코드 이슈 아님)

관련: #159 (action item 7), #165 (action item 3, item 9 일부)