### PR TITLE
🐛 fix: use real value for Radio/Checkbox's Radix identity, support name

### DIFF
--- a/.changeset/pr-172.md
+++ b/.changeset/pr-172.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add native form field names to checkboxes and radios, enabling participation in FormData when set.

--- a/packages/ui/src/components/atoms/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/atoms/checkbox/checkbox.tsx
@@ -21,6 +21,8 @@ export interface Props extends Omit<
   defaultChecked?: boolean;
   checked?: boolean;
   value?: OptionValue;
+  /** Native form field name — participates in `FormData` when set. */
+  name?: string;
   disabled?: boolean;
   icons?: { checked: React.ReactNode; unchecked: React.ReactNode };
   children?: React.ReactNode;
@@ -36,6 +38,7 @@ const Checkbox = ({
   disabled,
   defaultChecked,
   checked: _checked,
+  name,
   onChange: _onChange = () => {},
   ...props
 }: Props) => {
@@ -46,6 +49,7 @@ const Checkbox = ({
   });
 
   const id = useId();
+  const itemValue = String(_value);
 
   const cursorClassName = disabled ? 'cursor-not-allowed' : 'cursor-pointer';
 
@@ -63,6 +67,8 @@ const Checkbox = ({
         id={id}
         hidden
         type="checkbox"
+        name={name}
+        value={itemValue}
         checked={checked}
         disabled={disabled}
         onChange={e => {
@@ -102,6 +108,8 @@ const Checkbox = ({
     <>
       <CoreCheckbox
         id={id}
+        name={name}
+        value={itemValue}
         checked={checked}
         disabled={disabled}
         className={cn(cursorClassName)}

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -25,6 +25,8 @@ export interface Props extends Omit<
   classNames?: OptionGroupClassNames;
   defaultValue?: OptionValue[];
   value?: OptionValue[];
+  /** Native form field name, shared across every option's checkbox. */
+  name?: string;
   onChange?: (values: OptionValue[]) => void;
 }
 
@@ -34,6 +36,7 @@ const Group = ({
   className,
   classNames = {},
   options: _options = [],
+  name,
   defaultValue,
   value: _value,
   onChange: _onChange = () => {},
@@ -74,6 +77,7 @@ const Group = ({
             <Checkbox
               placement={placement}
               className={cn(classNames?.item)}
+              name={name}
               value={item.value}
               checked={checked}
               disabled={item.disabled}

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -32,6 +32,8 @@ export interface Props extends Omit<
   classNames?: OptionGroupClassNames;
   defaultValue?: OptionValue;
   value?: OptionValue;
+  /** Native form field name — participates in `FormData` when set. */
+  name?: string;
   optionType?: 'default' | 'button';
   buttonStyle?: 'solid' | 'outlined';
   size?: 'small' | 'middle' | 'large';
@@ -45,6 +47,7 @@ const RadioGroup = ({
   className,
   classNames = {},
   options: _options = [],
+  name,
   optionType = 'default',
   buttonStyle = 'solid',
   size,
@@ -72,15 +75,15 @@ const RadioGroup = ({
   };
 
   // A single Radix radiogroup root owns every option so that arrow keys move
-  // focus across the whole group. Radix addresses items by string value, so
-  // each option gets a deterministic id derived from a stable base id.
+  // focus across the whole group. `id` stays index-derived (for DOM
+  // id/label pairing), but Radix itself now addresses/submits items by
+  // their real (stringified) `value` — see radio.tsx.
   const baseId = useId();
   const getOptionId = (index: number) => `${baseId}-${index}`;
-  const checkedIndex = options.findIndex(item => item.value === value);
-  const checkedId = checkedIndex === -1 ? '' : getOptionId(checkedIndex);
+  const checkedItemValue = value === undefined ? '' : String(value);
 
-  const onValueChange = (optionId: string) => {
-    const item = options.find((_, index) => getOptionId(index) === optionId);
+  const onValueChange = (itemValue: string) => {
+    const item = options.find(option => String(option.value) === itemValue);
 
     if (!item) {
       return;
@@ -149,7 +152,12 @@ const RadioGroup = ({
 
   return (
     <RadioGroupContext.Provider value={true}>
-      <Core className="block" value={checkedId} onValueChange={onValueChange}>
+      <Core
+        className="block"
+        name={name}
+        value={checkedItemValue}
+        onValueChange={onValueChange}
+      >
         {list}
       </Core>
     </RadioGroupContext.Provider>

--- a/packages/ui/src/components/atoms/radio/radio.tsx
+++ b/packages/ui/src/components/atoms/radio/radio.tsx
@@ -22,6 +22,8 @@ export interface Props extends Omit<
   defaultChecked?: boolean;
   checked?: boolean;
   value?: OptionValue;
+  /** Native form field name — participates in `FormData` when set. */
+  name?: string;
   disabled?: boolean;
   /**
    * Id shared by the underlying control and its label. Generated internally
@@ -43,6 +45,7 @@ const Radio = ({
   defaultChecked,
   checked: _checked,
   id: _id,
+  name,
   onChange: _onChange = () => {},
   ...props
 }: Props) => {
@@ -54,6 +57,10 @@ const Radio = ({
 
   const generatedId = useId();
   const id = _id ?? generatedId;
+  // Radix identifies/submits an item by its `value`, which is separate from
+  // `id` (used only for the DOM id/label pairing) — stringified since Radix
+  // requires a string, while `OptionValue` also allows number/boolean.
+  const itemValue = String(_value);
   const grouped = useContext(RadioGroupContext);
 
   const cursorClassName = disabled ? 'cursor-not-allowed' : 'cursor-pointer';
@@ -75,7 +82,7 @@ const Radio = ({
       className={cn('flex gap-2', placement === 'right' && 'flex-row-reverse')}
       data-disabled={disabled}
     >
-      <Item value={id} id={id} checked={checked} disabled={disabled} />
+      <Item value={itemValue} id={id} checked={checked} disabled={disabled} />
       <FieldLabel htmlFor={id} className={cursorClassName}>
         {children}
       </FieldLabel>
@@ -88,6 +95,8 @@ const Radio = ({
         id={id}
         hidden
         type="radio"
+        name={name}
+        value={itemValue}
         checked={checked}
         disabled={disabled}
         onChange={e => {
@@ -126,7 +135,11 @@ const Radio = ({
   ) : grouped ? (
     renderField
   ) : (
-    <Core value={checked ? id : ''} onValueChange={() => onChange(true)}>
+    <Core
+      name={name}
+      value={checked ? itemValue : ''}
+      onValueChange={() => onChange(true)}
+    >
       {renderField}
     </Core>
   );


### PR DESCRIPTION
## 변경 사항
- `Radio`: Radix `Item`의 내부 식별값으로 `useId()` 생성 id를 쓰고 있었고, 실제 `value` prop은 어디에도 쓰이지 않았음. `id`(DOM id/label 연결용)와 `itemValue`(Radix 식별 + native form 제출값, `String(value)`)를 분리
- `RadioGroup`: 그룹 내부 매칭도 index 기반 id 대신 stringify된 실제 값으로 전환
- `Checkbox`/`CheckboxGroup`: Radix `CheckboxPrimitive.Root`가 `name`/`value`를 직접 지원해서 전달만 추가
- 4개 컴포넌트(Radio, RadioGroup, Checkbox, CheckboxGroup) 모두 `name` prop 추가

이제 `<form>` 안에서 `FormData`로 값이 정상 수집됨.

## 검증
- `pnpm build`/`lint` 통과 (기존 `_value` unused-var warning 2건도 실제 사용하게 되면서 해소)
- `docs` 앱 `check-types` 통과
- live-editor 사용처 확인 결과 전부 `value` prop 없이 `checked`/`onChange`만 쓰는 boolean 토글 패턴이라 영향 없음

관련: #165 (action item 4)