### PR TITLE
🐛 fix: export missing atom Props, tighten icons/disabled/onChange gaps

### DIFF
--- a/.changeset/pr-173.md
+++ b/.changeset/pr-173.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for disabled state to checkbox and radio components, and color picker and select components.

--- a/packages/ui/src/components/atoms/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/atoms/checkbox/checkbox.tsx
@@ -24,7 +24,7 @@ export interface Props extends Omit<
   /** Native form field name — participates in `FormData` when set. */
   name?: string;
   disabled?: boolean;
-  icons?: { checked: React.ReactNode; unchecked: React.ReactNode };
+  icons?: Partial<{ checked: React.ReactNode; unchecked: React.ReactNode }>;
   children?: React.ReactNode;
   onChange?: (checked: boolean) => void;
 }

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -27,6 +27,7 @@ export interface Props extends Omit<
   value?: OptionValue[];
   /** Native form field name, shared across every option's checkbox. */
   name?: string;
+  disabled?: boolean;
   onChange?: (values: OptionValue[]) => void;
 }
 
@@ -37,6 +38,7 @@ const Group = ({
   classNames = {},
   options: _options = [],
   name,
+  disabled,
   defaultValue,
   value: _value,
   onChange: _onChange = () => {},
@@ -80,7 +82,7 @@ const Group = ({
               name={name}
               value={item.value}
               checked={checked}
-              disabled={item.disabled}
+              disabled={disabled || item.disabled}
               onChange={checked => onChange(checked, item.value)}
             >
               {item.label}

--- a/packages/ui/src/components/atoms/color-picker.tsx
+++ b/packages/ui/src/components/atoms/color-picker.tsx
@@ -8,7 +8,10 @@ import { cn } from '@repo/ui/utils';
 
 import Popover from './popover';
 
-interface Props {
+export interface Props extends Omit<
+  React.ComponentPropsWithoutRef<'div'>,
+  'onChange' | 'defaultValue' | 'value' | 'onClick' | 'onKeyDown'
+> {
   defaultValue?: string;
   value?: string;
   showText?: boolean;
@@ -21,7 +24,9 @@ const ColorPicker = ({
   value: _value,
   showText,
   disabled,
+  className,
   onChange: _onChange = () => {},
+  ...props
 }: Props) => {
   const [value, setValue] = useControllableState<string>({
     value: _value,
@@ -49,7 +54,9 @@ const ColorPicker = ({
           'inline-flex items-center',
           'rounded border p-0.5',
           disabled && 'cursor-not-allowed opacity-50',
+          className,
         )}
+        {...props}
         onClick={e => {
           if (disabled) {
             e.preventDefault();

--- a/packages/ui/src/components/atoms/radio/radio.tsx
+++ b/packages/ui/src/components/atoms/radio/radio.tsx
@@ -31,7 +31,7 @@ export interface Props extends Omit<
    * single Radix root can address each option.
    */
   id?: string;
-  icons?: { checked: React.ReactNode; unchecked: React.ReactNode };
+  icons?: Partial<{ checked: React.ReactNode; unchecked: React.ReactNode }>;
   onChange?: (checked: boolean) => void;
 }
 

--- a/packages/ui/src/components/atoms/select.tsx
+++ b/packages/ui/src/components/atoms/select.tsx
@@ -27,7 +27,10 @@ const isGroup = (option: Option | OptionGroup): option is OptionGroup => {
   return 'options' in option && Array.isArray(option.options);
 };
 
-interface Props extends React.ComponentProps<typeof Core> {
+export interface Props extends Omit<
+  React.ComponentProps<typeof Core>,
+  'onValueChange'
+> {
   placeholder?: string;
   className?: string;
   options?: (Option | OptionGroup)[];

--- a/packages/ui/src/components/atoms/switch.tsx
+++ b/packages/ui/src/components/atoms/switch.tsx
@@ -30,7 +30,7 @@ const sizeConfig = {
   },
 };
 
-interface Props extends Omit<
+export interface Props extends Omit<
   React.ComponentPropsWithoutRef<'button'>,
   'onChange'
 > {


### PR DESCRIPTION
## 변경 사항
- `ColorPicker`/`Select`/`Switch`의 `Props` 타입 export 추가 (다른 atom들과 통일)
- `ColorPicker`: `className`/rest props 전달 지원 (스타일 확장 가능). `onClick`/`onKeyDown`은 내부 disabled 가드가 필수라 여전히 타입에서 제외해 override 불가
- `Radio`/`Checkbox`의 `icons` prop 타입을 필수 `{checked, unchecked}`에서 `Partial<{...}>`로 수정 — 구현(`icons.checked ?? <기본아이콘>`)과 실제 타입 불일치 해소
- `CheckboxGroup`에 그룹 `disabled` 추가, `disabled || item.disabled`로 전파 (RadioGroup과 동일 패턴)
- (보너스) `select.tsx`: `Props`가 Core의 `onValueChange`를 그대로 상속해서 사용자가 넘기면 내부 `onChange` 콜백이 조용히 무시되던 버그도 같은 파일 손보는 김에 `Omit`으로 차단

## 검증
- `pnpm build`/`lint` 통과 (warning 0건)
- `docs` 앱 `check-types` 통과

관련: #165 (action item 6, 8, 9)