### PR TITLE
🐛 fix: forward Input ref, fix Search disabled/onKeyDown/onClear

### DIFF
--- a/.changeset/pr-174.md
+++ b/.changeset/pr-174.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for ref to the Input component.

--- a/packages/ui/src/components/atoms/input/input.tsx
+++ b/packages/ui/src/components/atoms/input/input.tsx
@@ -2,8 +2,8 @@ import { input } from '@repo/ui/core';
 
 const { Input: Core } = input;
 
-const Input = ({ ...props }: React.ComponentPropsWithoutRef<'input'>) => {
-  return <Core {...props} />;
+const Input = ({ ref, ...props }: React.ComponentPropsWithRef<'input'>) => {
+  return <Core ref={ref} {...props} />;
 };
 
 export default Input;

--- a/packages/ui/src/components/atoms/input/search.tsx
+++ b/packages/ui/src/components/atoms/input/search.tsx
@@ -24,8 +24,10 @@ const Search = ({
   className,
   defaultValue,
   value,
+  disabled,
   allowClear = true,
   onChange,
+  onKeyDown: _onKeyDown,
   onSearch: _onSearch,
   ...props
 }: Props) => {
@@ -55,13 +57,13 @@ const Search = ({
       setUncontrolledHasValue(false);
     }
 
-    const event = {
-      target: { value: '' },
-    } as React.ChangeEvent<HTMLInputElement>;
-    onChange?.(event);
+    onChange?.({ target: { value: '' } });
   };
 
   const onSearch = () => {
+    if (disabled) {
+      return;
+    }
     if (inputRef.current) {
       _onSearch?.(inputRef.current.value);
     }
@@ -84,10 +86,12 @@ const Search = ({
         )}
       >
         <Core
+          {...props}
           ref={setRefs}
           inputMode="search"
           type="search"
           enterKeyHint="search"
+          disabled={disabled}
           className={cn(
             'rounded-r-none',
             '[&::-webkit-search-cancel-button]:hidden',
@@ -103,18 +107,20 @@ const Search = ({
             onChange?.(e);
           }}
           onKeyDown={e => {
+            _onKeyDown?.(e);
             if (e.key === 'Enter') {
               onSearch();
             }
           }}
-          {...props}
         />
         <button
           type="button"
           aria-label="지우기"
+          disabled={disabled}
           className={cn(
             'absolute right-2',
             'shrink-0 cursor-pointer',
+            'disabled:cursor-not-allowed disabled:opacity-50',
             (!allowClear || !hasValue) && 'hidden',
           )}
           onClick={onClear}
@@ -124,6 +130,7 @@ const Search = ({
       </div>
       <Button
         icon={<SearchOutlined />}
+        disabled={disabled}
         className={cn(
           'rounded-l-none',
           'size-9',


### PR DESCRIPTION
## 변경 사항

### Input
- `ComponentPropsWithoutRef<'input'>` → `ComponentPropsWithRef<'input'>`로 변경, `TextArea`와 동일한 패턴으로 ref forward 지원 (기존엔 focus/select 등 명령형 제어가 불가능했음)

### Input.Search
- `disabled`이 내부 `<input>`에만 적용되던 걸 clear 버튼 + search Button까지 전파, `onSearch`에도 disabled 가드 추가
- `{...props}`를 `<Core>` 맨 앞으로 옮겨 내부 `onChange`/`onKeyDown` 로직이 항상 우선하도록 정리, `onKeyDown`은 사용자가 넘긴 핸들러를 먼저 호출한 뒤 Enter-검색 로직을 이어서 실행하도록 합성 (사용자 `onKeyDown`이 조용히 무시되던 버그 수정)
- `onClear`이 만들던 가짜 `ChangeEvent` 캐스팅(`as React.ChangeEvent<...>`) 제거 — `Props.onChange` 타입이 이미 `{ target: { value: string } }` 형태를 유효한 대안으로 선언하고 있었는데 실제로는 거짓 캐스팅 중이었음. consumer가 `e.currentTarget`에 접근할 때 런타임 에러 나던 문제 해결

## 검증
- `pnpm build`/`lint` 통과
- `docs` 앱 `check-types` 통과

관련: #165 (action item 5, 6)