### PR TITLE
♿ fix: give optionType="button" RadioGroup real radio semantics

### DIFF
--- a/.changeset/pr-175.md
+++ b/.changeset/pr-175.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+RadioGroup components now support rendering Button elements as radio buttons, enabling real radio semantics and improved accessibility.

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -18,7 +18,7 @@ import {
 import { RadioGroupContext } from './context';
 import Radio from './radio';
 
-const { RadioGroup: Core } = radio;
+const { RadioGroup: Core, RadioGroupItem: Item } = radio;
 
 export type { OptionValue };
 
@@ -111,20 +111,29 @@ const RadioGroup = ({
             className={cn('flex', classNames?.wrapper)}
           >
             {isButton ? (
-              <Button
-                variant={checked ? buttonStyle : 'outlined'}
-                size={size}
-                className={cn(
-                  'rounded-none',
-                  index === 0 && 'rounded-l-lg',
-                  index === options.length - 1 && 'rounded-r-lg',
-                  checked && buttonStyle === 'outlined' && 'border-primary',
-                )}
+              // `asChild` gives the Button real radio semantics (role,
+              // aria-checked, roving tabindex, arrow-key nav, click/keyboard
+              // selection via the shared Core's onValueChange below) instead
+              // of a plain list of buttons with none of that.
+              <Item
+                asChild
+                value={String(item.value)}
                 disabled={disabled || item.disabled}
-                onClick={() => onChange(true, item.value)}
               >
-                {item.label}
-              </Button>
+                <Button
+                  variant={checked ? buttonStyle : 'outlined'}
+                  size={size}
+                  disabled={disabled || item.disabled}
+                  className={cn(
+                    'rounded-none',
+                    index === 0 && 'rounded-l-lg',
+                    index === options.length - 1 && 'rounded-r-lg',
+                    checked && buttonStyle === 'outlined' && 'border-primary',
+                  )}
+                >
+                  {item.label}
+                </Button>
+              </Item>
             ) : (
               <Radio
                 id={getOptionId(index)}
@@ -143,12 +152,6 @@ const RadioGroup = ({
       })}
     </ul>
   );
-
-  // `optionType='button'` renders `Button`s instead of radios, so it keeps the
-  // plain list and stays out of the Radix radiogroup entirely.
-  if (isButton) {
-    return list;
-  }
 
   return (
     <RadioGroupContext.Provider value={true}>

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -126,8 +126,14 @@ const RadioGroup = ({
                   disabled={disabled || item.disabled}
                   className={cn(
                     'rounded-none',
-                    index === 0 && 'rounded-l-lg',
-                    index === options.length - 1 && 'rounded-r-lg',
+                    index === 0 &&
+                      (orientation === 'vertical'
+                        ? 'rounded-t-lg'
+                        : 'rounded-l-lg'),
+                    index === options.length - 1 &&
+                      (orientation === 'vertical'
+                        ? 'rounded-b-lg'
+                        : 'rounded-r-lg'),
                     checked && buttonStyle === 'outlined' && 'border-primary',
                   )}
                 >

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -125,7 +125,16 @@ const RadioGroup = ({
                   size={size}
                   disabled={disabled || item.disabled}
                   className={cn(
-                    'rounded-none',
+                    // The `solid` variant (the checked item, by default)
+                    // renders no border at all while `outlined` (every
+                    // unchecked item) renders a 1px one — reserving the
+                    // border unconditionally keeps every option's box the
+                    // same size regardless of which variant it's in.
+                    'rounded-none border',
+                    checked &&
+                      (buttonStyle === 'outlined'
+                        ? 'border-primary'
+                        : 'border-transparent'),
                     index === 0 &&
                       (orientation === 'vertical'
                         ? 'rounded-t-lg'
@@ -134,7 +143,6 @@ const RadioGroup = ({
                       (orientation === 'vertical'
                         ? 'rounded-b-lg'
                         : 'rounded-r-lg'),
-                    checked && buttonStyle === 'outlined' && 'border-primary',
                   )}
                 >
                   {item.label}

--- a/packages/ui/src/core/radio-group.tsx
+++ b/packages/ui/src/core/radio-group.tsx
@@ -22,8 +22,24 @@ function RadioGroup({
 
 function RadioGroupItem({
   className,
+  asChild,
+  children,
   ...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item> & {
+  asChild?: boolean;
+}) {
+  // `asChild` hands the rendered element to `children` entirely (e.g. a
+  // `Button`), so the default dot indicator doesn't apply — Radix clones
+  // its own role/aria-checked/keyboard handling onto that single child
+  // instead of onto its own `<button>`.
+  if (asChild) {
+    return (
+      <RadioGroupPrimitive.Item asChild data-slot="radio-group-item" {...props}>
+        {children}
+      </RadioGroupPrimitive.Item>
+    );
+  }
+
   return (
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"


### PR DESCRIPTION
## 변경 사항
`optionType="button"` 모드가 Radix radiogroup root에 도달하기 전에 `<ul><Button>` 리스트를 조기 반환하고 있어서 `role="radiogroup"`, `aria-checked`, roving tabindex, 화살표 키 네비게이션이 전부 빠져있었음 (스크린리더에는 그냥 버튼 목록으로만 노출).

- `core/radio-group.tsx`의 `RadioGroupItem`에 `asChild` 지원 추가 — 기본 dot indicator 렌더링을 건너뛰고 Radix의 role/aria/키보드 핸들링을 단일 자식(`Button`)에 직접 클론
- `atoms/radio/group.tsx`: 버튼모드도 `<Item asChild value={...}><Button/></Item>`로 감싸서 default 모드와 동일한 `<Core>` radiogroup 안에 통합. 기존 조기 반환 분기 제거 — 두 모드 다 동일한 `onValueChange`로 선택 처리 (버튼의 수동 `onClick`은 Radix가 대신 처리하므로 제거)

## 검증
- `pnpm build`/`lint` 통과
- `docs` 앱 `check-types` 통과
- Radix `asChild` 합성 + 키보드 상호작용이 핵심이라 브라우저 인터랙티브 테스트가 이상적이지만, 샌드박스 환경 제약으로 Storybook 실사용 확인은 못 함 — 로직상 Radix 표준 패턴을 따르지만, 병합 후 `RadioGroup` 스토리의 `optionType=button`으로 화살표 키 네비게이션 수동 확인 권장

관련: #165 (action item 7)