### PR TITLE
🐛 fix: unify Spin/Skeleton className target and prop precedence

### DIFF
--- a/.changeset/pr-176.md
+++ b/.changeset/pr-176.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Skeleton and Spin components now support custom class names and styles.

--- a/packages/ui/src/components/atoms/skeleton/button.tsx
+++ b/packages/ui/src/components/atoms/skeleton/button.tsx
@@ -5,13 +5,13 @@ import Skeleton, { type Props as SkeletonProps } from './skeleton';
 const Button = ({ className, ...props }: SkeletonProps) => {
   return (
     <Skeleton
+      {...props}
       className={cn(
         'h-9 w-15',
         'rounded-2xl',
         className,
         //
       )}
-      {...props}
     />
   );
 };

--- a/packages/ui/src/components/atoms/skeleton/skeleton.tsx
+++ b/packages/ui/src/components/atoms/skeleton/skeleton.tsx
@@ -46,6 +46,12 @@ const Skeleton = ({
   children,
   ...props
 }: Props) => {
+  // Not wrapping `children` here (unlike Spin's overlay mode) — Skeleton
+  // is meant to swap in arbitrary real content once loading finishes,
+  // which can include elements with strict parent requirements (e.g. a
+  // `<tr>`), so adding a wrapper div could produce invalid markup.
+  // `className`/`style`/rest props only ever describe the skeleton's own
+  // placeholder markup, so there's nothing for them to apply to here.
   if (!loading) {
     return children ?? null;
   }
@@ -54,10 +60,7 @@ const Skeleton = ({
     <div
       role="status"
       aria-label="로딩 중"
-      className={cn(
-        'flex items-center gap-3',
-        //
-      )}
+      className={cn('flex items-center gap-3', className)}
       {...props}
     >
       {avatar && (
@@ -91,7 +94,6 @@ const Skeleton = ({
                 'rounded-md',
                 !active && 'animate-none',
                 SIZES[size],
-                className,
                 classNames.item,
                 //
               )}

--- a/packages/ui/src/components/atoms/spin.tsx
+++ b/packages/ui/src/components/atoms/spin.tsx
@@ -7,49 +7,43 @@ export interface Props extends React.ComponentPropsWithoutRef<'div'> {
 }
 
 const Spin = ({ spinning, className, children, ...props }: Props) => {
-  if (!spinning) {
-    return children ?? null;
-  }
-
+  // With no children there's nothing to render at all while idle — unlike
+  // the branch below, there's no wrapper for `className`/`props` to land
+  // on regardless, so returning null here isn't the same bug.
   if (!children) {
+    if (!spinning) {
+      return null;
+    }
+
     return (
       <div
         role="status"
         aria-label="로딩 중"
-        className={cn(
-          'flex h-full items-center justify-center',
-          //
-        )}
+        className={cn('flex h-full items-center justify-center', className)}
         {...props}
       >
-        <Loader2
-          className={cn(
-            'animate-spin',
-            className,
-            //
-          )}
-        />
+        <Loader2 className="animate-spin" />
       </div>
     );
   }
 
+  // `className`/rest props always land on this one wrapper regardless of
+  // `spinning`, instead of applying to the icon in one branch and being
+  // dropped entirely in another.
   return (
-    <div
-      className={cn(
-        'relative',
-        className,
-        //
-      )}
-      {...props}
-    >
-      <div className="pointer-events-none opacity-50">{children}</div>
-      <div
-        role="status"
-        aria-label="로딩 중"
-        className="absolute inset-0 flex items-center justify-center"
-      >
-        <Loader2 className="animate-spin" />
+    <div className={cn('relative', className)} {...props}>
+      <div className={cn(spinning && 'pointer-events-none opacity-50')}>
+        {children}
       </div>
+      {spinning && (
+        <div
+          role="status"
+          aria-label="로딩 중"
+          className="absolute inset-0 flex items-center justify-center"
+        >
+          <Loader2 className="animate-spin" />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 변경 사항

### Spin
- `spinning=false`일 때 `className`/rest props를 전부 버리던 것, `spinning=true`일 때도 children 유무에 따라 `className`이 아이콘/wrapper로 다르게 적용되던 것을 모두 같은 wrapper `<div>`에 일관되게 적용되도록 정리

### Skeleton
- 최상위 `className`이 `classNames.item`과 섞여 각 스켈레톤 바에 적용되던 걸 wrapper `<div>`로 이동 (기존 `classNames.wrapper`/`classNames.item`/`classNames.avatar` 체계와 일관되게)
- `!loading`일 때 children을 그대로 반환하는 동작은 유지 — `<tr>` 같은 구조 제약이 있는 실제 콘텐츠로 교체되는 용도라 wrapper를 씌우면 잘못된 마크업이 될 수 있음 (이유를 주석으로 명시)

### Skeleton.Button
- `{...props}`가 `className` 뒤에 있어서 `Skeleton.Node`(반대 순서)와 override 가능 여부가 서로 달랐던 걸 `Node`와 동일하게 `{...props}`를 먼저 두도록 통일

## 검증
- `pnpm build`/`lint` 통과
- `docs` 앱 `check-types` 통과

관련: #165 (마지막 action item) — 이걸로 #165 전체 완료