### PR TITLE
🐛 fix: recognize any changeset file, not just pr-<PR#>*.md

### DIFF
--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -33,12 +33,25 @@ jobs:
           node-version: 24.x
 
       # Only draft once per PR — if a changeset already exists (hand-written
-      # or from an earlier run of this workflow on this PR), leave it alone
-      # rather than overwriting a human's edits on every subsequent push.
+      # under any filename, or from an earlier run of this workflow on this
+      # PR), leave it alone rather than overwriting a human's edits on
+      # every subsequent push. Checks for *any* changeset file, not just
+      # one named pr-<PR#>*.md — a hand-written one under a different name
+      # used to go unrecognized, so this kept re-drafting (and
+      # overwriting) it on every push.
       - name: Check for existing changeset
         id: existing
         run: |
-          if compgen -G ".changeset/pr-${{ github.event.pull_request.number }}*.md" > /dev/null; then
+          shopt -s nullglob
+          files=(.changeset/*.md)
+          shopt -u nullglob
+          count=0
+          for f in "${files[@]}"; do
+            if [[ "$(basename "$f")" != "README.md" ]]; then
+              count=$((count + 1))
+            fi
+          done
+          if [ "$count" -gt 0 ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 문제
"이미 changeset 있나" 체크가 `pr-<PR#>`로 시작하는 파일명만 확인해서, 다른 이름으로 손으로 쓴 changeset은 인식하지 못했음. use-hooks에서 오늘 실제로 두 번 겪은 문제(#127에서 수정) — 워크플로우가 매 푸시마다 AI 초안을 다시 만들어 덮어씀, 그것도 사실과 반대되는 내용으로.

## 변경 사항
`.changeset/*.md` 전체를 순회해서 `README.md`가 아닌 파일이 하나라도 있으면 "이미 존재"로 판단하도록 변경. 파일명 규칙에 무관하게 동작함. `grep -qv` 대신 순수 bash glob 루프 사용 — use-hooks#127에서 `-q`+`-v` 조합이 grep 구현체(ugrep)에 따라 일관되지 않게 동작하는 걸 확인해서 더 안전한 방식으로 작성.

## 검증
- YAML 문법 유효성 확인
- 로직은 use-hooks#127과 동일, 그쪽에서 이미 로컬 시뮬레이션으로 검증됨