### PR TITLE
⬆️ chore: bump @jbpark/use-hooks to 3.0.0

### DIFF
--- a/.changeset/pr-186.md
+++ b/.changeset/pr-186.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Update @jbpark/use-hooks to version 3.0.0 and rename `isIntersecting` to `isIntersecting` in the `useIntersectionObserver` hook.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
-    "@jbpark/use-hooks": "^2.11.0",
+    "@jbpark/use-hooks": "^3.0.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -60,7 +60,7 @@ const List = <T,>({
   itemKey,
   ...props
 }: Props<T>) => {
-  const [loaderRef, entry] = useIntersectionObserver({
+  const [loaderRef, { isIntersecting }] = useIntersectionObserver({
     threshold: 0,
     root: null,
     rootMargin: '0px',
@@ -84,11 +84,11 @@ const List = <T,>({
       return;
     }
 
-    if (entry?.isIntersecting && scroll.hasMore && !fetchingRef.current) {
+    if (isIntersecting && scroll.hasMore && !fetchingRef.current) {
       fetchingRef.current = true;
       scroll.next();
     }
-  }, [entry, scroll]);
+  }, [isIntersecting, scroll]);
 
   if (loading) {
     return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.3)
       '@jbpark/use-hooks':
-        specifier: ^2.11.0
-        version: 2.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^3.0.0
+        version: 3.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -880,8 +880,8 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@jbpark/use-hooks@2.11.0':
-    resolution: {integrity: sha512-9bqfkOqgxjcud0NB/i5hShGiCfihkNhc5fQD9yTjVnN/I+YEvsO646QVS/quP2E6B6ca8pBZ+l0fQwv1rIB0VA==}
+  '@jbpark/use-hooks@3.0.0':
+    resolution: {integrity: sha512-anqXEbjtzPgmUss2o6+AueEU7aMs0/5qGFUJScEuyLZ7auEP/PpkrFmwh287qa2/HLB+wHDjqJeQAAUKbiS49Q==}
     peerDependencies:
       react: ^19.1.1
       react-dom: ^19.1.1
@@ -5522,7 +5522,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@jbpark/use-hooks@2.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@jbpark/use-hooks@3.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## Summary
- Bump `@jbpark/use-hooks` to `^3.0.0`
- Update `useIntersectionObserver` destructuring in `List` for the v3 breaking change (`[ref, entry]` → `[ref, { entry, isIntersecting }]`)

Part of ui-kit#185 (item 5).