### PR TITLE
🐛 fix: organisms audit — 9 critical bugs (Modal/Toast/List/Swiper/Drawer)

### DIFF
--- a/.changeset/pr-189.md
+++ b/.changeset/pr-189.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Added support for multiple mask-less overlays opening at once, improved accessibility for modals and toasts, and fixed issues with list rendering and swiper slide detection.

--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -18,13 +18,27 @@ const {
   DrawerTitle,
 } = drawer;
 
-// `document.body.style.pointerEvents` is global state, so several mask-less
-// overlays opening at once would otherwise race: each instance would capture
-// whatever the previous one had already written and the last cleanup would
-// restore a stale value. Reference counting makes only the first instance
-// capture the original value and only the last one restore it.
-let maskLessOverlayCount = 0;
-let originalBodyPointerEvents: string | null = null;
+// `body.style.pointerEvents` is global state (per document), so several
+// mask-less overlays opening at once would otherwise race: each instance
+// would capture whatever the previous one had already written and the
+// last cleanup would restore a stale value. Reference counting makes only
+// the first instance capture the original value and only the last one
+// restore it. Keyed by document (not a single module-level counter) so
+// drawers portaled into different documents — e.g. live-editor's iframe
+// Renderer — don't share state with the host document.
+type MaskLessState = { count: number; originalPointerEvents: string | null };
+const maskLessStates = new WeakMap<Document, MaskLessState>();
+
+const getMaskLessState = (doc: Document): MaskLessState => {
+  let state = maskLessStates.get(doc);
+
+  if (!state) {
+    state = { count: 0, originalPointerEvents: null };
+    maskLessStates.set(doc, state);
+  }
+
+  return state;
+};
 
 export interface Props {
   open: boolean;
@@ -112,25 +126,30 @@ const Drawer = ({
       return;
     }
 
-    if (maskLessOverlayCount === 0) {
-      originalBodyPointerEvents = document.body.style.pointerEvents;
-    }
-    maskLessOverlayCount += 1;
+    const targetDocument = container?.ownerDocument ?? document;
+    const targetWindow = targetDocument.defaultView ?? window;
+    const body = targetDocument.body;
+    const state = getMaskLessState(targetDocument);
 
-    const raf = window.requestAnimationFrame(() => {
-      document.body.style.pointerEvents = 'auto';
+    if (state.count === 0) {
+      state.originalPointerEvents = body.style.pointerEvents;
+    }
+    state.count += 1;
+
+    const raf = targetWindow.requestAnimationFrame(() => {
+      body.style.pointerEvents = 'auto';
     });
 
     return () => {
-      window.cancelAnimationFrame(raf);
-      maskLessOverlayCount -= 1;
+      targetWindow.cancelAnimationFrame(raf);
+      state.count -= 1;
 
-      if (maskLessOverlayCount === 0) {
-        document.body.style.pointerEvents = originalBodyPointerEvents ?? '';
-        originalBodyPointerEvents = null;
+      if (state.count === 0) {
+        body.style.pointerEvents = state.originalPointerEvents ?? '';
+        state.originalPointerEvents = null;
       }
     };
-  }, [open, mask]);
+  }, [open, mask, container]);
 
   return (
     <DrawerCore

--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -65,6 +65,15 @@ const SIZES: Record<string, string> = {
   full: '90%',
 };
 
+// Rounds the edge facing into the viewport — the opposite edge from
+// whichever side the drawer is anchored to.
+const ROUNDED_CLASSES: Record<'top' | 'bottom' | 'left' | 'right', string> = {
+  top: 'rounded-b-[30px]!',
+  bottom: 'rounded-t-[30px]!',
+  left: 'rounded-r-[30px]!',
+  right: 'rounded-l-[30px]!',
+};
+
 const getSizeStyles = (
   direction: 'top' | 'bottom' | 'left' | 'right',
   size: string,
@@ -139,7 +148,7 @@ const Drawer = ({
       <DrawerContent
         className={cn(
           'border-none outline-none',
-          rounded ? 'rounded-t-[30px]!' : 'rounded-none!',
+          rounded ? ROUNDED_CLASSES[direction] : 'rounded-none!',
           classNames?.content,
           className,
           //

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -130,15 +130,11 @@ const List = <T,>({
       <div role="list" className={cn('space-y-2', classNames?.body)}>
         {!data?.length && empty
           ? empty
-          : data?.map((item, i) =>
-              itemKey ? (
-                <React.Fragment key={itemKey(item, i)}>
-                  {renderItem(item, i)}
-                </React.Fragment>
-              ) : (
-                renderItem(item, i)
-              ),
-            )}
+          : data?.map((item, i) => (
+              <React.Fragment key={itemKey ? itemKey(item, i) : i}>
+                {renderItem(item, i)}
+              </React.Fragment>
+            ))}
         {scroll?.loading &&
           (scroll?.loader ?? (
             <Skeleton.Node count={10} gap={10} {...loaderProps} />

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -106,14 +106,6 @@ const List = <T,>({
     );
   }
 
-  if (!data?.length && empty) {
-    return (
-      <div className={cn(className)} {...props}>
-        {empty}
-      </div>
-    );
-  }
-
   return (
     <div
       className={cn(
@@ -136,15 +128,17 @@ const List = <T,>({
       ))}
       <div className={cn(classNames?.header)}>{header}</div>
       <div role="list" className={cn('space-y-2', classNames?.body)}>
-        {data?.map((item, i) =>
-          itemKey ? (
-            <React.Fragment key={itemKey(item, i)}>
-              {renderItem(item, i)}
-            </React.Fragment>
-          ) : (
-            renderItem(item, i)
-          ),
-        )}
+        {!data?.length && empty
+          ? empty
+          : data?.map((item, i) =>
+              itemKey ? (
+                <React.Fragment key={itemKey(item, i)}>
+                  {renderItem(item, i)}
+                </React.Fragment>
+              ) : (
+                renderItem(item, i)
+              ),
+            )}
         {scroll?.loading &&
           (scroll?.loader ?? (
             <Skeleton.Node count={10} gap={10} {...loaderProps} />

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -285,7 +285,7 @@ const StaticModal = ({
         </p>
       }
       container={container}
-      onCancel={() => closeModal(onOk)}
+      onCancel={() => closeModal(onCancel)}
       {...props}
     >
       {content}

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -120,6 +120,7 @@ const Modal = ({
   classNames,
   style,
   title,
+  content,
   footer,
   container,
   children,
@@ -177,7 +178,9 @@ const Modal = ({
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription className="hidden" />
         </DialogHeader>
-        <div className={cn('break-all', classNames?.body)}>{children}</div>
+        <div className={cn('break-all', classNames?.body)}>
+          {children ?? content}
+        </div>
         {footer !== null && (
           <DialogFooter
             className={cn('flex-row justify-end gap-x-2', classNames?.footer)}

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -72,6 +72,7 @@ type ContainerState = {
 };
 
 const containerStates = new Map<HTMLElement, ContainerState>();
+const modalRootElements = new WeakMap<HTMLElement, HTMLElement>();
 
 const getContainerState = (container: HTMLElement): ContainerState => {
   let state = containerStates.get(container);
@@ -84,24 +85,27 @@ const getContainerState = (container: HTMLElement): ContainerState => {
   return state;
 };
 
+// No `role`/`aria-modal` here — this element is only a mount point for the
+// imperative stack, not the dialog itself. Radix already renders its own
+// `role="dialog"`/`aria-modal="true"` on the actual `DialogContent` via
+// portal once a modal is open. Setting it here as well would (a) leave
+// `aria-modal="true"` on the page permanently, even with zero modals open,
+// hiding the rest of the document from screen readers, and (b) duplicate
+// Radix's own dialog role once one is open.
 const createModalRoot = (container?: HTMLElement) => {
   if (!isBrowser) {
     return null;
   }
 
   const targetContainer = container || document.body;
-  let rootEl = targetContainer.querySelector(
-    '#modal-root',
-  ) as HTMLElement | null;
+  let rootEl = modalRootElements.get(targetContainer);
 
   if (!rootEl) {
     rootEl = document.createElement('div');
-    rootEl.setAttribute('id', 'modal-root');
-    rootEl.setAttribute('role', 'dialog');
-    rootEl.setAttribute('aria-modal', 'true');
     rootEl.style.zIndex = '10000';
     rootEl.style.position = 'absolute';
     targetContainer.appendChild(rootEl);
+    modalRootElements.set(targetContainer, rootEl);
   }
 
   return rootEl;
@@ -346,7 +350,11 @@ Modal.destroy = (id?: string) => {
       state.stack = [];
       state.update?.();
     });
-    modalRoots.forEach(root => root.unmount());
+    modalRoots.forEach((root, container) => {
+      root.unmount();
+      modalRootElements.get(container)?.remove();
+      modalRootElements.delete(container);
+    });
     modalRoots.clear();
     containerStates.clear();
     return;
@@ -364,6 +372,8 @@ Modal.destroy = (id?: string) => {
       modalRoots.get(container)?.unmount();
       modalRoots.delete(container);
       containerStates.delete(container);
+      modalRootElements.get(container)?.remove();
+      modalRootElements.delete(container);
     }
   });
 };

--- a/packages/ui/src/components/organisms/swiper/swiper.tsx
+++ b/packages/ui/src/components/organisms/swiper/swiper.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { cloneElement, isValidElement } from 'react';
+
 import { Swiper as SwiperCore, SwiperProps } from 'swiper/react';
 import { SwiperModule, SwiperOptions } from 'swiper/types';
 
@@ -78,7 +80,16 @@ const Swiper = <T,>({
       style={{ ...initialStyle, ...style }}
       {...props}
     >
-      {data.map((item: T, i) => renderItem(item, i))}
+      {data.map((item: T, i) => {
+        const node = renderItem(item, i);
+        // Fall back to an index key only when the consumer's renderItem
+        // didn't already set one — cloning (rather than wrapping in a
+        // Fragment) keeps the returned element a direct child of
+        // SwiperCore, which swiper/react's slide detection relies on.
+        return isValidElement(node) && node.key == null
+          ? cloneElement(node, { key: i })
+          : node;
+      })}
     </SwiperCore>
   );
 };

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -40,6 +40,7 @@ type ContainerState = {
 };
 
 const containerStates = new Map<HTMLElement, ContainerState>();
+const toastRootElements = new WeakMap<HTMLElement, HTMLElement>();
 
 const getContainerState = (container: HTMLElement): ContainerState => {
   let state = containerStates.get(container);
@@ -58,13 +59,10 @@ const createToastRoot = (container?: HTMLElement) => {
   }
 
   const targetContainer = container || document.body;
-  let rootEl = targetContainer.querySelector(
-    '#toast-root',
-  ) as HTMLElement | null;
+  let rootEl = toastRootElements.get(targetContainer);
 
   if (!rootEl) {
     rootEl = document.createElement('div');
-    rootEl.setAttribute('id', 'toast-root');
     rootEl.setAttribute('role', 'region');
     rootEl.setAttribute('aria-label', 'Notifications');
     rootEl.style.zIndex = '10000';
@@ -77,6 +75,7 @@ const createToastRoot = (container?: HTMLElement) => {
     rootEl.style.padding = '16px';
     rootEl.style.pointerEvents = 'none';
     targetContainer.appendChild(rootEl);
+    toastRootElements.set(targetContainer, rootEl);
   }
 
   return rootEl;
@@ -225,7 +224,11 @@ Toast.destroy = (id?: string) => {
       state.stack = [];
       state.update?.();
     });
-    toastRoots.forEach(root => root.unmount());
+    toastRoots.forEach((root, container) => {
+      root.unmount();
+      toastRootElements.get(container)?.remove();
+      toastRootElements.delete(container);
+    });
     toastRoots.clear();
     containerStates.clear();
     return;
@@ -243,6 +246,8 @@ Toast.destroy = (id?: string) => {
       toastRoots.get(container)?.unmount();
       toastRoots.delete(container);
       containerStates.delete(container);
+      toastRootElements.get(container)?.remove();
+      toastRootElements.delete(container);
     }
   });
 };


### PR DESCRIPTION
## Summary

Fixes all 9 🔴 bugs from ui-kit#179 (organisms component audit).

- **`Modal.confirm` Escape/mask-click ran the confirm callback instead of cancel** — the most dangerous item: dismissing a destructive confirm dialog with Escape (a habitual "cancel" gesture) actually confirmed it
- `Modal.destroy`/`Toast.destroy` left the root `<div>` in the DOM forever, permanently leaking `aria-modal="true"` on an empty node even with zero modals open; also fixed duplicate DOM `id` when multiple containers are used (switched to a `WeakMap`-based lookup)
- `<Modal content>` prop was silently dropped (never destructured, fell through onto Radix's Dialog Root)
- `List`'s `empty` branch replaced the entire `role="list"` container, killing the `IntersectionObserver` sentinel — screens that start empty and rely on scroll to load their first page never called `next()`
- `List`/`Swiper` rendered items without a `key` when no `itemKey`/explicit key was given
- `Drawer`'s `rounded` prop always rounded the top edge regardless of `direction`
- `Drawer`'s mask-less pointer-events workaround hardcoded `document.body` and a single module-global counter, breaking (and cross-contaminating) when portaled into another document via `container` (e.g. live-editor's iframe)

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build` (ui + docs + web, full monorepo)
- [x] verified Drawer's 4 direction-based rounded classes are all present in the generated CSS (not the dynamic-class-extraction bug from #177)

## Out of scope (left for a follow-up)
🟡 accessibility (Toast auto-dismiss not pausing on hover/focus + `role="alert"` for errors, `List`'s `role="list"` non-`listitem` children) and 🟢 maintainability items (Modal/Toast's ~120 lines of duplicated imperative stack machinery, `loading`-branch prop-loss pattern shared with #177/#178, missing `Props` exports) from ui-kit#179 are not included here.