### PR TITLE
🐛 fix: atoms regressions from 3.4.0 — Popover arrow, Skeleton size

### DIFF
--- a/.changeset/pr-190.md
+++ b/.changeset/pr-190.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Added support for customizing the appearance of skeleton elements with the `classNames` prop.

--- a/packages/ui/src/components/atoms/popover.tsx
+++ b/packages/ui/src/components/atoms/popover.tsx
@@ -91,48 +91,97 @@ const fillColorBySide: Record<Side, string> = {
   right: 'after:border-r-8 after:border-r-popover',
 };
 
-// `side` picks which edge of the content the arrow sits against; `align`
-// slides it along that edge. The offset axis (x for top/bottom, y for
-// left/right) is perpendicular to `side` — `align: 'center'` centers the
-// arrow with a translate, while `start`/`end` pin it 16px from that edge.
-const offsetAxisBySide: Record<Side, 'x' | 'y'> = {
-  top: 'x',
-  bottom: 'x',
-  left: 'y',
-  right: 'y',
+// Tailwind v4 only extracts class candidates that appear as *literal*
+// strings in source — none of these ever do if built via
+// `` `${side}-full` `` style interpolation, so they'd silently never make
+// it into the generated CSS. This table exists purely so every class the
+// arrow can need appears literally somewhere in this file.
+const POSITION_CLASSES: Record<
+  Side,
+  Record<Align, { wrapper: string; before: string; after: string }>
+> = {
+  top: {
+    start: {
+      wrapper: 'top-full left-4',
+      before: 'before:top-0 before:left-0',
+      after: 'after:-top-px after:left-px',
+    },
+    center: {
+      wrapper: 'top-full left-1/2 -translate-x-1/2',
+      before: 'before:top-0 before:left-1/2 before:-translate-x-1/2',
+      after: 'after:-top-px after:left-1/2 after:-translate-x-1/2',
+    },
+    end: {
+      wrapper: 'top-full right-4',
+      before: 'before:top-0 before:right-0',
+      after: 'after:-top-px after:right-px',
+    },
+  },
+  bottom: {
+    start: {
+      wrapper: 'bottom-full left-4',
+      before: 'before:bottom-0 before:left-0',
+      after: 'after:-bottom-px after:left-px',
+    },
+    center: {
+      wrapper: 'bottom-full left-1/2 -translate-x-1/2',
+      before: 'before:bottom-0 before:left-1/2 before:-translate-x-1/2',
+      after: 'after:-bottom-px after:left-1/2 after:-translate-x-1/2',
+    },
+    end: {
+      wrapper: 'bottom-full right-4',
+      before: 'before:bottom-0 before:right-0',
+      after: 'after:-bottom-px after:right-px',
+    },
+  },
+  left: {
+    start: {
+      wrapper: 'left-full top-4',
+      before: 'before:left-0 before:top-0',
+      after: 'after:-left-px after:top-px',
+    },
+    center: {
+      wrapper: 'left-full top-1/2 -translate-y-1/2',
+      before: 'before:left-0 before:top-1/2 before:-translate-y-1/2',
+      after: 'after:-left-px after:top-1/2 after:-translate-y-1/2',
+    },
+    end: {
+      wrapper: 'left-full bottom-4',
+      before: 'before:left-0 before:bottom-0',
+      after: 'after:-left-px after:bottom-px',
+    },
+  },
+  right: {
+    start: {
+      wrapper: 'right-full top-4',
+      before: 'before:right-0 before:top-0',
+      after: 'after:-right-px after:top-px',
+    },
+    center: {
+      wrapper: 'right-full top-1/2 -translate-y-1/2',
+      before: 'before:right-0 before:top-1/2 before:-translate-y-1/2',
+      after: 'after:-right-px after:top-1/2 after:-translate-y-1/2',
+    },
+    end: {
+      wrapper: 'right-full bottom-4',
+      before: 'before:right-0 before:bottom-0',
+      after: 'after:-right-px after:bottom-px',
+    },
+  },
 };
-const startEdgeByAxis = { x: 'left', y: 'top' } as const;
-const endEdgeByAxis = { x: 'right', y: 'bottom' } as const;
 
 const getArrowClassName = (side: Side, align: Align) => {
-  const axis = offsetAxisBySide[side];
-  const alignEdge =
-    align === 'start'
-      ? startEdgeByAxis[axis]
-      : align === 'end'
-        ? endEdgeByAxis[axis]
-        : null;
-
-  const positionAlign = alignEdge
-    ? `${alignEdge}-4`
-    : `${startEdgeByAxis[axis]}-1/2 -translate-${axis}-1/2`;
-  const beforeAlign = alignEdge
-    ? `before:${alignEdge}-0`
-    : `before:${startEdgeByAxis[axis]}-1/2 before:-translate-${axis}-1/2`;
-  const afterAlign = alignEdge
-    ? `after:${alignEdge}-px`
-    : `after:${startEdgeByAxis[axis]}-1/2 after:-translate-${axis}-1/2`;
+  const { wrapper, before, after } = POSITION_CLASSES[side][align];
 
   return cn(
-    `absolute ${positionAlign} ${side}-full`,
+    'absolute',
+    wrapper,
     beforeBase,
-    `before:${side}-0`,
-    beforeAlign,
+    before,
     borderShapeBySide[side],
     borderColorBySide[side],
     afterBase,
-    `after:-${side}-px`,
-    afterAlign,
+    after,
     fillShapeBySide[side],
     fillColorBySide[side],
   );

--- a/packages/ui/src/components/atoms/skeleton/button.tsx
+++ b/packages/ui/src/components/atoms/skeleton/button.tsx
@@ -2,16 +2,19 @@ import { cn } from '@repo/ui/utils';
 
 import Skeleton, { type Props as SkeletonProps } from './skeleton';
 
-const Button = ({ className, ...props }: SkeletonProps) => {
+const Button = ({ classNames, ...props }: SkeletonProps) => {
   return (
     <Skeleton
       {...props}
-      className={cn(
-        'h-9 w-15',
-        'rounded-2xl',
-        className,
-        //
-      )}
+      classNames={{
+        ...classNames,
+        item: cn(
+          'h-9 w-15',
+          'rounded-2xl',
+          classNames?.item,
+          //
+        ),
+      }}
     />
   );
 };

--- a/packages/ui/src/components/atoms/skeleton/node.tsx
+++ b/packages/ui/src/components/atoms/skeleton/node.tsx
@@ -2,17 +2,20 @@ import { cn } from '@repo/ui/utils';
 
 import Skeleton, { type Props as SkeletonProps } from './skeleton';
 
-const Node = ({ className, ...props }: SkeletonProps) => {
+const Node = ({ classNames, ...props }: SkeletonProps) => {
   return (
     <Skeleton
       {...props}
       avatar={false}
-      className={cn(
-        'h-50 w-full min-w-80',
-        'rounded-3xl',
-        className,
-        //
-      )}
+      classNames={{
+        ...classNames,
+        item: cn(
+          'h-50 w-full min-w-80',
+          'rounded-3xl',
+          classNames?.item,
+          //
+        ),
+      }}
     />
   );
 };


### PR DESCRIPTION
## Summary

Fixes the two 🔴 regressions from ui-kit#177 that shipped in `@jbpark/ui-kit@3.4.0`.

- **Popover arrow completely broken** — `getArrowClassName` built position/offset classes via runtime string interpolation (`` `${side}-full` ``, `` `before:${side}-0` ``, etc.). Tailwind v4 only extracts class candidates that appear as literal strings in source, so none of these ever made it into the generated CSS — 32 positioning classes lost across all 12 placements, arrow rendered bunched in the content's top-left corner. Replaced with a literal side×align lookup table; verified all 12 combinations' classes now appear in `packages/ui/dist/style.css`.
- **`Skeleton.Button`/`Skeleton.Node` size props silently ignored** — `skeleton.tsx` moved `className` from the placeholder item to the wrapper `<div>`, but `Button`/`Node` pass their sizing (`h-9 w-15`, `h-50 w-full min-w-80`, etc.) via `className` specifically to size the item — so the bar stayed default-sized and overflowed its (correctly-sized) wrapper. `style` was still applying to the item, so `className`/`style` targeted different elements. Switched `Button`/`Node` to set `classNames.item` instead, matching `style`'s target. Verified via `renderToStaticMarkup` that sizing now lands on the `data-slot="skeleton"` item.

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build` (ui + docs + web, full monorepo)
- [x] verified all 12 Popover arrow class combinations present in generated CSS
- [x] verified Skeleton.Button/Node sizing lands on the item via `renderToStaticMarkup`

## Out of scope (left for a follow-up)
R3 (Button `htmlType` breaking-change changelog note), I4–I6 (Spin/Skeleton wrapper policy, ColorPicker controlled open, Radio/Checkbox.Group duplicate key) from ui-kit#177 are not included here.