### PR TITLE
🐛 fix: molecules audit — 6 critical bugs (Collapse/Reveals/Space/Marquees/Upload)

### DIFF
--- a/.changeset/pr-192.md
+++ b/.changeset/pr-192.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Upload component now generates unique IDs for uploaded files to prevent key collisions when removing files.

--- a/packages/ui/src/components/molecules/collapse.tsx
+++ b/packages/ui/src/components/molecules/collapse.tsx
@@ -67,7 +67,7 @@ const Collapse = ({
 
   return (
     <Accordion {...props} className={className} {...accordionProps}>
-      {items.map(({ label, children, disabled }, key) => (
+      {items.map(({ key, label, children, disabled }) => (
         <AccordionItem
           key={key}
           value={`${key}`}

--- a/packages/ui/src/components/molecules/marquees/item.tsx
+++ b/packages/ui/src/components/molecules/marquees/item.tsx
@@ -20,6 +20,15 @@ export interface Props
   width: string | number;
 }
 
+// `autoFill={true}` (the default on `Marquees`) needs *some* repeat count
+// before the item can be measured and the real count computed — this is
+// only ever visible for that one render, but rendering 100 copies (200
+// with the 2x loop duplication) up front was needlessly heavy for the
+// common case. A modest guess still avoids visible gaps for typical
+// item/container width ratios while cutting the worst-case default
+// render by ~90%.
+const INITIAL_AUTO_FILL_GUESS = 10;
+
 const Item = ({
   width: _width,
   speed = 100,
@@ -35,7 +44,11 @@ const Item = ({
   const [width, setWidth] = useState<string | number>(_width);
   const [pause, setPause] = useState(false);
   const [repeatCount, setRepeatCount] = useState(
-    autoFill ? (typeof autoFill === 'boolean' ? 100 : autoFill) : 0,
+    autoFill
+      ? typeof autoFill === 'boolean'
+        ? INITIAL_AUTO_FILL_GUESS
+        : autoFill
+      : 0,
   );
 
   const isPaused = _pause || pause;
@@ -130,7 +143,11 @@ const Item = ({
 
   useEffect(() => {
     setRepeatCount(
-      autoFill ? (typeof autoFill === 'boolean' ? 100 : autoFill) : 0,
+      autoFill
+        ? typeof autoFill === 'boolean'
+          ? INITIAL_AUTO_FILL_GUESS
+          : autoFill
+        : 0,
     );
   }, [autoFill]);
 

--- a/packages/ui/src/components/molecules/marquees/item.tsx
+++ b/packages/ui/src/components/molecules/marquees/item.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { useGSAP } from '@gsap/react';
-import { useEventListener } from '@jbpark/use-hooks';
 import { gsap } from 'gsap';
 
 export interface ItemProps {
@@ -150,18 +149,6 @@ const Item = ({
         : 0,
     );
   }, [autoFill]);
-
-  useEventListener('resize', () => {
-    if (!tweenRef.current || !containerRef.current) {
-      return;
-    }
-
-    if (isPaused) {
-      tweenRef.current.pause();
-    } else {
-      tweenRef.current.play();
-    }
-  });
 
   return (
     <div

--- a/packages/ui/src/components/molecules/reveals/reveals.tsx
+++ b/packages/ui/src/components/molecules/reveals/reveals.tsx
@@ -27,14 +27,24 @@ const Reveals = ({
   cascade = CASCADE,
   duration = DURATION,
   delay = DELAY,
+  effect,
+  once,
+  viewport,
+  variants,
+  transition,
   ...props
 }: Props) => {
   const renderItems = (items: ItemProps[]) =>
     items.map((item, index) => (
       <Item
         key={index}
+        effect={effect}
         duration={duration}
         delay={delay + cascade * index}
+        once={once}
+        viewport={viewport}
+        variants={variants}
+        transition={transition}
         {...item}
         className={cn(
           item.className,

--- a/packages/ui/src/components/molecules/space.tsx
+++ b/packages/ui/src/components/molecules/space.tsx
@@ -55,7 +55,15 @@ const Space = ({
   const count = Children.count(children);
 
   if (loading) {
-    return <div className={cn(className)}>{loader || <Skeleton />}</div>;
+    return (
+      <div
+        className={cn(hidden && 'hidden', className)}
+        style={style}
+        {...props}
+      >
+        {loader || <Skeleton />}
+      </div>
+    );
   }
 
   return (

--- a/packages/ui/src/components/molecules/upload.tsx
+++ b/packages/ui/src/components/molecules/upload.tsx
@@ -8,6 +8,7 @@ import {
   useFileToDataUrl,
 } from '@jbpark/use-hooks';
 import { Upload as UploadIcon, X } from 'lucide-react';
+import { v4 as uuid } from 'uuid';
 
 import { cn } from '@repo/ui/utils';
 
@@ -33,6 +34,11 @@ export interface Props {
     item?: string;
   };
   onChange?: (files: UploadFile[]) => void;
+  /**
+   * Called once per file that didn't make it in — either bumped by
+   * `maxCount` or failed to read.
+   */
+  onReject?: (info: { file: File; reason: 'max-count' | 'read-error' }) => void;
 }
 
 const isImage = (file: UploadFile) =>
@@ -49,6 +55,7 @@ const Upload = ({
   className,
   classNames,
   onChange: _onChange = () => {},
+  onReject,
 }: Props) => {
   const inputId = useId();
   const readAsDataUrl = useFileToDataUrl();
@@ -65,14 +72,39 @@ const Upload = ({
         : incoming.length;
 
     const accepted = incoming.slice(0, remaining);
+    const rejected = incoming.slice(remaining);
 
-    const uploaded = await Promise.all(
-      accepted.map(async file => ({
-        uid: `${file.name}-${file.lastModified}-${file.size}`,
-        name: file.name,
-        url: await readAsDataUrl(file),
-      })),
-    );
+    rejected.forEach(file => onReject?.({ file, reason: 'max-count' }));
+
+    if (accepted.length === 0) {
+      return;
+    }
+
+    const uploaded = (
+      await Promise.all(
+        accepted.map(async file => {
+          try {
+            return {
+              // `uuid()` guarantees uniqueness even for the same file
+              // added twice (identical name/lastModified/size), which
+              // name+lastModified+size alone can't — a collision there
+              // corrupted React's item keys and made removeFile's
+              // uid-based filter delete both copies at once.
+              uid: `${file.name}-${file.lastModified}-${file.size}-${uuid()}`,
+              name: file.name,
+              url: await readAsDataUrl(file),
+            };
+          } catch {
+            onReject?.({ file, reason: 'read-error' });
+            return null;
+          }
+        }),
+      )
+    ).filter((file): file is UploadFile => file !== null);
+
+    if (uploaded.length === 0) {
+      return;
+    }
 
     setFiles([...files, ...uploaded]);
   };


### PR DESCRIPTION
## Summary

Fixes all 🔴 bugs from ui-kit#178 (molecules component audit) that weren't already resolved.

- **`Collapse` ignored `items[].key`** — `map(({label, children, disabled}, key) => ...)` destructured the array *index* as `key`, so `activeKey`/`defaultActiveKey`/`onChange` all operated on index instead of the documented key. **Breaking**: apps working around the bug by passing indices need to switch to the real key.
- **`Reveals` dropped `effect`/`once`/`viewport`/`variants`/`transition`** — not destructured, so they fell into `...props` and leaked onto the root `<div>` (React warning for `once`) instead of reaching each `Item` — `effect` had no visual effect at all.
- **`Space` lost all props/style/`hidden` while loading** — the loading branch returned a bare `<div className={cn(className)}>`, dropping `id`/`data-*`/`style`/`hidden` (a `hidden` Space was visible on screen while loading).
- **`Marquees` rendered 202 children by default** — `repeatCount`'s initial guess for `autoFill={true}` (the default) was 100, doubled by 2x loop duplication, before the real count could be measured. Lowered to 10 (22 total), cutting the default-usage worst case by ~90%.
- **Dead Marquees resize listener removed** — the `useEventListener('resize', ...)` added earlier this session (use-hooks sweep) turned out to be a no-op duplicate of the effect right above it; removed rather than just rebinding it to the right window.
- **`Upload` uid collisions + silent failures** — same file added twice collided on uid, corrupting React keys and making `removeFile` delete both at once; `maxCount` overflow silently called `onChange` with a same-content array; a failed `readAsDataUrl` was an unhandled rejection that discarded the whole batch via `Promise.all`. Added a `uuid()` suffix, skip the no-op `onChange`, per-file try/catch, and an optional `onReject({file, reason})` callback.

## Already fixed
- Upload's drag-and-drop bypassing `accept` (issue item 6) was already fixed earlier today via `useFileDrop` in #185/#188.

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build` (ui + docs + web, full monorepo)
- [x] `Collapse`: verified via `renderToStaticMarkup` that `defaultActiveKey={['alpha']}` opens the panel whose declared key is `alpha`
- [x] `Reveals`: verified via `renderToStaticMarkup` that `effect="fadeIn"` changes the item's variant and no longer leaks to the DOM
- [x] `Space`: verified via `renderToStaticMarkup` that `id`/`data-*`/`style`/`hidden` survive the loading branch
- [x] `Marquees`: verified via `renderToStaticMarkup` that default `autoFill` now renders 22 items, down from 202

## Out of scope (left for a follow-up)
🟡 accessibility (Menu ARIA structure, Dropdown keyboard entry + stacking context) and 🟢 maintainability items (missing `Props` exports, remaining controlled/uncontrolled manual patterns, Menu dead code, Splitter index-based Fragment key) from ui-kit#178 are not included here.