### PR TITLE
🐛 fix: templates audit — 4 critical bugs (Layout/Header/Sider)

### DIFF
--- a/packages/ui/src/components/templates/layout/header.tsx
+++ b/packages/ui/src/components/templates/layout/header.tsx
@@ -7,6 +7,7 @@ const Header = ({ children, className, ...props }: Props) => {
     <header
       className={cn(
         'sticky top-0 z-50',
+        'bg-background',
         'flex h-16 w-full items-center px-5',
         className,
         //

--- a/packages/ui/src/components/templates/layout/layout.tsx
+++ b/packages/ui/src/components/templates/layout/layout.tsx
@@ -1,40 +1,76 @@
-import { Children, createContext, isValidElement, useContext } from 'react';
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 
 import { cn } from '@repo/ui/utils';
 
 import Sider from './sider';
+import { SiderRegistryContext } from './sider-context';
 
 export interface Props extends React.ComponentPropsWithoutRef<'div'> {}
 
 const LayoutNestedContext = createContext(false);
 
-const hasSiderChild = (children: React.ReactNode) =>
+// Effects (including the registry-based detection in sider-context.ts)
+// never run during SSR, so registry state alone would render flex-col on
+// the server and every first paint, then flip to flex-row after hydration
+// for even the common, non-wrapped case. This direct-children check seeds
+// the correct initial guess for that common case so it's right immediately;
+// the registry then stays authoritative for Fragment-wrapped/custom-wrapped
+// Siders it can't see, correcting the guess after mount if needed.
+const hasDirectSiderChild = (children: React.ReactNode) =>
   Children.toArray(children).some(
     child => isValidElement(child) && child.type === Sider,
   );
 
 const Layout = ({ children, className, ...props }: Props) => {
   const isNested = useContext(LayoutNestedContext);
-  const isRow = hasSiderChild(children);
+  const [siderIds] = useState(() => new Set<object>());
+  const [siderCount, setSiderCount] = useState(() =>
+    hasDirectSiderChild(children) ? 1 : 0,
+  );
+
+  const registry = useMemo(
+    () => ({
+      registerSider: (id: object) => {
+        siderIds.add(id);
+        setSiderCount(siderIds.size);
+      },
+      unregisterSider: (id: object) => {
+        siderIds.delete(id);
+        setSiderCount(siderIds.size);
+      },
+    }),
+    [siderIds],
+  );
+
+  const isRow = siderCount > 0;
 
   return (
     <LayoutNestedContext.Provider value>
-      <div
-        className={cn(
-          'flex w-full flex-1',
-          // A nested Layout (the Sider row wrapper) must stay free to
-          // shrink/grow inside its parent's flex column, so it keeps
-          // min-h-0. The outermost Layout has no ancestor to size against,
-          // so it needs its own height anchor or flex-1/grow are no-ops
-          // and Content collapses under Footer.
-          isNested ? 'min-h-0' : 'min-h-screen',
-          isRow ? 'flex-row' : 'flex-col',
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </div>
+      <SiderRegistryContext.Provider value={registry}>
+        <div
+          className={cn(
+            'flex w-full flex-1',
+            // A nested Layout (the Sider row wrapper) must stay free to
+            // shrink/grow inside its parent's flex column, so it keeps
+            // min-h-0. The outermost Layout has no ancestor to size against,
+            // so it needs its own height anchor or flex-1/grow are no-ops
+            // and Content collapses under Footer.
+            isNested ? 'min-h-0' : 'min-h-screen',
+            isRow ? 'flex-row' : 'flex-col',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </SiderRegistryContext.Provider>
     </LayoutNestedContext.Provider>
   );
 };

--- a/packages/ui/src/components/templates/layout/sider-context.ts
+++ b/packages/ui/src/components/templates/layout/sider-context.ts
@@ -1,0 +1,36 @@
+import { createContext, useContext, useLayoutEffect, useRef } from 'react';
+
+// `Layout` needs to know whether a `Sider` exists anywhere in its subtree
+// to decide flex-row vs flex-col — but `Children.toArray(children).some(...)`
+// only ever sees direct children, and doesn't flatten Fragments, so a
+// `Sider` wrapped in a Fragment (or a custom wrapper component) went
+// undetected. Registering presence via context instead survives any
+// amount of wrapping, since it's `Sider` itself reporting in, not `Layout`
+// inspecting its children's shape.
+export interface SiderRegistry {
+  registerSider: (id: object) => void;
+  unregisterSider: (id: object) => void;
+}
+
+export const SiderRegistryContext = createContext<SiderRegistry | null>(null);
+
+export const useRegisterSider = () => {
+  const registry = useContext(SiderRegistryContext);
+  const idRef = useRef({});
+
+  // `useLayoutEffect` (not `useEffect`) so the registration — and the
+  // resulting flex-row switch on `Layout` — commits before the browser
+  // paints, avoiding a flash of the flex-col fallback layout on mount.
+  useLayoutEffect(() => {
+    if (!registry) {
+      return;
+    }
+
+    const id = idRef.current;
+    registry.registerSider(id);
+
+    return () => {
+      registry.unregisterSider(id);
+    };
+  }, [registry]);
+};

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -95,7 +95,7 @@ const Sider = ({
             //
           )}
         >
-          {trigger ?? <TriggerIcon className="size-4" />}
+          {trigger === undefined ? <TriggerIcon className="size-4" /> : trigger}
         </button>
       )}
     </aside>

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -66,7 +66,12 @@ const Sider = ({
   return (
     <aside
       className={cn(
-        'z-100 flex h-full shrink-0 flex-col overflow-hidden',
+        // Below Header's z-50 (and every other floating/overlay primitive
+        // in this library, which all use z-50) — Sider is a static layout
+        // column, not floating chrome, and previously outranked Header
+        // with an arbitrary z-100, covering it once Header stuck to the
+        // viewport top on scroll.
+        'z-10 flex h-full shrink-0 flex-col overflow-hidden',
         'transition-[width] duration-200',
         className,
         //

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -6,6 +6,8 @@ import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 
 import { cn } from '@repo/ui/utils';
 
+import { useRegisterSider } from './sider-context';
+
 export interface Props extends Omit<
   React.ComponentPropsWithoutRef<'aside'>,
   'onCollapse'
@@ -41,6 +43,8 @@ const Sider = ({
   onCollapse: _onCollapse = () => {},
   ...props
 }: Props) => {
+  useRegisterSider();
+
   const [uncontrolledCollapsed, setUncontrolledCollapsed] =
     useState(defaultCollapsed);
 


### PR DESCRIPTION
## Summary

Fixes all 🔴 bugs from ui-kit#180 (templates component audit).

- **`Layout` never detected Fragment-wrapped/custom-wrapped `Sider`** — `hasSiderChild` checked `Children.toArray(children).some(child.type === Sider)`, which doesn't flatten Fragments and can't see through a custom wrapper component either. Either case permanently fell back to `flex-col`, stacking the sidebar above the content with no way to recover. Replaced with a context-based registration (`sider-context.ts`): `Sider` reports its own presence to the nearest `Layout` regardless of wrapping depth. Kept the direct-children check as an initial-render seed since effects don't run during SSR — verified via `renderToStaticMarkup` that the common non-wrapped case still renders `flex-row` immediately, with the wrapped case corrected client-side after mount (previously permanently broken, now just deferred to hydration).
- **`Header` had no background** — `sticky top-0` with zero background classes, so scrolled content showed through once it stuck. Added `bg-background`.
- **`Sider` (`z-100`) outranked sticky `Header` (`z-50`)** — scrolling far enough for `Header` to stick left it covered by `Sider`. Every other floating primitive in this library (Dialog/Drawer/Select/Popover/FloatButton/Header) uses `z-50`; `Sider` is static layout chrome, not an overlay, so lowered it to `z-10`.
- **`Sider`'s `trigger={null}` didn't hide the trigger** — `trigger ?? <TriggerIcon/>` falls through to the default for `null` too, so the standard "hide the built-in trigger, control collapse externally" idiom didn't work. Switched to an explicit `undefined` check. Verified via `renderToStaticMarkup` that `trigger={null}` no longer renders an `<svg>` while the button itself (for external control) stays.

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build` (ui + docs + web, full monorepo)
- [x] `Layout`: verified direct-child Sider still renders `flex-row` on SSR; Fragment-wrapped case renders `flex-col` on SSR (documented, corrects after client mount) instead of permanently
- [x] `Sider`: verified `trigger={null}` renders no `<svg>` while keeping the button

## Out of scope (left for a follow-up)
🟡 accessibility (`Sider` trigger `aria-expanded`/`aria-controls`, hardcoded Korean labels, `Content`'s hardcoded `<main>`), 🟢 consistency (no components forward refs, `Sider` still uses manual controlled/uncontrolled instead of `useControllableState`, `templates/index.ts` doesn't re-export layout types), and the ✨ new-component proposals (breakpoint/`Grid`/`Container`/`Empty`/`Result`/`PageHeader`) from ui-kit#180 are not included here.