### PR TITLE
🐛 fix: providers audit — Config layout/re-render bugs

### DIFF
--- a/packages/ui/src/providers/Config/index.tsx
+++ b/packages/ui/src/providers/Config/index.tsx
@@ -58,6 +58,18 @@ interface Props {
 const Config = ({ theme = {}, className, children }: Props) => {
   const parent = useConfig();
 
+  // `theme` is typically a fresh inline object literal at the call site
+  // (and `parent.theme` inherits the same problem from its own Config
+  // ancestor), so depending on them directly meant mergedTheme/contextValue
+  // got a new identity on every render regardless of whether the actual
+  // values changed — every useConfig() consumer in the tree re-rendered on
+  // every render of whatever's above this Config, which for the common
+  // app-root usage is everything. Depend on a serialized key instead so
+  // the memo only invalidates when the content actually changes; these
+  // are small, string/boolean-only objects, so JSON.stringify is cheap.
+  const themeKey = JSON.stringify(theme);
+  const parentThemeKey = JSON.stringify(parent.theme);
+
   const mergedTheme = useMemo<ThemeConfig>(
     () => ({
       ...parent.theme,
@@ -67,7 +79,8 @@ const Config = ({ theme = {}, className, children }: Props) => {
         ...theme.token,
       },
     }),
-    [parent.theme, theme],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [parentThemeKey, themeKey],
   );
 
   const contextValue = useMemo(() => ({ theme: mergedTheme }), [mergedTheme]);
@@ -86,7 +99,20 @@ const Config = ({ theme = {}, className, children }: Props) => {
       {needsWrapper ? (
         <div
           className={cn(mergedTheme.dark && 'dark', className)}
-          style={hasCssVars ? cssVars : undefined}
+          style={{
+            ...(hasCssVars ? cssVars : undefined),
+            // Keeps this element out of the layout box tree — so it
+            // doesn't intercept flex/grid child relationships or break
+            // height chains like min-h-screen — while custom properties
+            // and the `dark` class selector still cascade to children
+            // normally (inheritance and box generation are separate
+            // mechanisms in CSS). Note this means className shouldn't be
+            // used here for anything that needs a real box (padding,
+            // background, borders); Config's className is meant for
+            // theming hooks (the `dark` class, arbitrary selector hooks),
+            // not layout.
+            display: 'contents',
+          }}
         >
           {children}
         </div>


### PR DESCRIPTION
## Summary

Fixes 2 of the 3 🔴 bugs from ui-kit#181 (providers audit). The third (portal theming) is deferred — see below.

- **`Config`'s wrapper `<div>` broke layout** — `needsWrapper` is true whenever token/dark mode is set, which is the common case, so an unstyled box silently intercepted flex/grid child relationships and height chains (`min-h-screen` etc.) for any app partially wrapping its tree in `<Config>`. Added `display: contents` to the wrapper — it stays out of the layout box tree while CSS custom properties and the `.dark` class selector still cascade to children normally (inheritance and box generation are separate mechanisms in CSS). Verified via `renderToStaticMarkup` that the dark class/vars/`display:contents` all still apply.
- **`Config`'s `useMemo` never actually memoized** — `theme = {}` default (and typical inline-literal usage) means `theme`/`parent.theme` are fresh objects every render, so `mergedTheme`/`contextValue` got new identities on every render of whatever's above `Config` — for the common app-root usage, that's the whole app, so every `useConfig()` consumer re-rendered on every root render. Switched the memo deps to a serialized (`JSON.stringify`) key so it only invalidates when the theme's actual content changes.

## Deferred: portal-rendered components don't receive theme (issue item 1)

`Config` injects tokens via inline style/class on its wrapper, but Radix portals (`Dialog`/`Drawer`/`Popover`/`Select`) render to `document.body`, becoming siblings of that wrapper rather than descendants — so a themed app's modals/dropdowns/toasts silently keep the default theme.

I looked at two ways to fix this and both have a real cost, so I'm not shipping either without a decision:
- **Apply tokens to `document.documentElement` instead** — portaled content is still a descendant of `<html>`, so this actually reaches it. But this only works from a client-side effect (there's no `document` during SSR), so every themed app would flash unthemed/default styling until that effect runs after hydration — trading this bug for a new, more visible one on every page load.
- **Thread a portal-container context through every core primitive** (the `getContainer`/F2 feature already proposed in ui-kit#181) — the actually-correct fix, but it touches `dialog.tsx`/`drawer.tsx`/`popover.tsx`/`select.tsx`/`toast.tsx`/`modal.tsx` and is a real feature addition, not a bug-fix-sized change.

Left as a follow-up rather than picking a tradeoff unilaterally.

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build` (ui + docs + web, full monorepo)
- [x] verified via `renderToStaticMarkup` that dark class/CSS vars/`display:contents` all apply correctly on the wrapper

## Out of scope (left for a follow-up)
📁 naming (`Config` folder → kebab-case, split `index.tsx`'s implementation into a named file), 🟡 improvements (`ThemeToken` coverage gaps, `dark` as boolean-only, missing `style` prop, no way to detect a missing provider), and ✨ new features (`locale`, `getContainer`, `componentSize`, per-component default props, RTL, dark-only tokens) from ui-kit#181 are not included here.