### PR TITLE
📝 docs: add missing changesets for PR #194, #195

### DIFF
--- a/.changeset/pr-194.md
+++ b/.changeset/pr-194.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fixed four Layout bugs: `Sider` wrapped in a Fragment or a custom component is now detected so the layout switches to a row correctly, `Header` now has a default background so scrolled content no longer shows through it, `Sider`'s z-index no longer outranks a sticky `Header`, and `Sider`'s `trigger={null}` now actually hides the built-in trigger icon.

--- a/.changeset/pr-195.md
+++ b/.changeset/pr-195.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+`Config`'s wrapper element now uses `display: contents` so it no longer breaks flex/grid layouts or height chains in the wrapped subtree, and its theme memoization is now keyed off the serialized theme value instead of object identity, fixing unnecessary re-renders of every `useConfig()` consumer whenever an ancestor re-rendered.


### PR DESCRIPTION
## Summary
- \`changeset-draft.yml\`'s existing-changeset check saw the still-open #193 (Version Packages) PR's \`pr-192.md\` and skipped drafting changesets for #194 and #195 (same bug as the earlier #186/#188 case) — adding them manually so those PRs' fixes aren't lost from the next version bump.

## Test plan
- N/A — changeset files only, no code changes.