### PR TITLE
🐛 fix: key changeset drafting off branch slug, not any-file-exists

### DIFF
--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// Drafts .changeset/pr-<number>[-<suffix>].md file(s) by asking an LLM
+// Drafts .changeset/<branch-slug>[-<suffix>].md file(s) by asking an LLM
 // to summarize this PR's diff to each tracked package as a semver
 // bump + one-paragraph description, in changesets' own file format. Runs
 // once per PR (the calling workflow skips this script entirely if any
-// changeset file for this PR already exists), so it never overwrites
+// changeset file for this branch already exists), so it never overwrites
 // something a human already wrote or edited. One file is written per
 // package that actually changed, since each needs its own bump + summary.
 //
@@ -17,8 +17,8 @@ const MODEL = process.env.NVIDIA_MODEL || 'meta/llama-3.1-8b-instruct';
 const API_URL = 'https://integrate.api.nvidia.com/v1/chat/completions';
 const MAX_DIFF_CHARS = 12000;
 
-// `fileSuffix: ''` for @repo/ui keeps its existing `pr-<number>.md`
-// filename unchanged, since that's the one publish.yml/release notes
+// `fileSuffix: ''` for @repo/ui keeps its filename as just the branch
+// slug (`<slug>.md`), since that's the one publish.yml/release notes
 // actually key off of.
 const PACKAGES = [
   {
@@ -95,7 +95,7 @@ function diffBetween(base, head, dir) {
   });
 }
 
-async function draftFor(pkg, { apiKey, baseSha, headSha, prNumber }) {
+async function draftFor(pkg, { apiKey, baseSha, headSha, branchSlug }) {
   let diff;
   try {
     diff = diffBetween(baseSha, headSha, pkg.dir);
@@ -190,7 +190,7 @@ async function draftFor(pkg, { apiKey, baseSha, headSha, prNumber }) {
     return;
   }
 
-  const filePath = `.changeset/pr-${prNumber}${pkg.fileSuffix}.md`;
+  const filePath = `.changeset/${branchSlug}${pkg.fileSuffix}.md`;
   const fileContent = [
     '---',
     `'${pkg.name}': ${result.bump}`,
@@ -208,10 +208,10 @@ async function main() {
   const apiKey = requireEnv('NVIDIA_API_KEY');
   const baseSha = requireEnv('BASE_SHA');
   const headSha = requireEnv('HEAD_SHA');
-  const prNumber = requireEnv('PR_NUMBER');
+  const branchSlug = requireEnv('BRANCH_SLUG');
 
   for (const pkg of PACKAGES) {
-    await draftFor(pkg, { apiKey, baseSha, headSha, prNumber });
+    await draftFor(pkg, { apiKey, baseSha, headSha, branchSlug });
   }
 }
 

--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -32,26 +32,33 @@ jobs:
         with:
           node-version: 24.x
 
-      # Only draft once per PR — if a changeset already exists (hand-written
-      # under any filename, or from an earlier run of this workflow on this
-      # PR), leave it alone rather than overwriting a human's edits on
-      # every subsequent push. Checks for *any* changeset file, not just
-      # one named pr-<PR#>*.md — a hand-written one under a different name
-      # used to go unrecognized, so this kept re-drafting (and
-      # overwriting) it on every push.
+      # Only draft once per PR — if a changeset already exists for *this
+      # branch* (hand-written, or from an earlier run of this workflow on
+      # this PR), leave it alone rather than overwriting a human's edits on
+      # every subsequent push. Keyed off the branch name (slugified: `/`
+      # and other unsafe characters become `-`) rather than PR number so
+      # the check itself doubles as a human-readable filename — but the
+      # important part is that it's scoped to *this* branch specifically.
+      # An earlier version of this check looked for *any* changeset file
+      # anywhere in .changeset/, which falsely treated an older, still-
+      # unconsumed PR's changeset (one that just hadn't been released yet)
+      # as "this PR already has one" and silently skipped drafting for
+      # every PR merged after it until the next release. Scoping to this
+      # branch's own slug avoids that false positive the same way the
+      # original pr-<PR#>.md-specific check did, without losing this
+      # check's recognition of hand-written changesets under any name for
+      # *this* branch.
       - name: Check for existing changeset
         id: existing
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
         run: |
+          slug=$(printf '%s' "$BRANCH_REF" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
           shopt -s nullglob
-          files=(.changeset/*.md)
+          files=(".changeset/${slug}"*.md)
           shopt -u nullglob
-          count=0
-          for f in "${files[@]}"; do
-            if [[ "$(basename "$f")" != "README.md" ]]; then
-              count=$((count + 1))
-            fi
-          done
-          if [ "$count" -gt 0 ]; then
+          if [ "${#files[@]}" -gt 0 ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -63,7 +70,7 @@ jobs:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_SLUG: ${{ steps.existing.outputs.slug }}
         run: node .github/scripts/draft-changeset.mjs
 
       - name: Commit and push changeset


### PR DESCRIPTION
## Summary

Root-cause fix for the "existing changeset" false positive that hit #188, #194, and #195 today (each needed a changeset added by hand after the fact).

- \`changeset-draft.yml\`'s existing-changeset check was changed in #184 from "does a changeset for this PR's number exist" to "does any changeset file exist in \`.changeset/\` at all". That was meant to recognize hand-written changesets under arbitrary names, but it also means any older, still-unreleased PR's changeset (normal — it just hasn't been consumed by a Version Packages merge yet) makes every PR merged afterward silently skip drafting its own, until the next release.
- Now checks for a file matching **this branch's own slugified name** (\`/\` and other unsafe characters → \`-\`) instead — scoped the same way the original PR-number check was (so it can't be confused by an unrelated branch's pending changeset), while still recognizing a hand-written changeset under that name for *this* branch. Filenames are now human-readable (\`fix-organisms-audit.md\`) instead of \`pr-189.md\`.

## Test plan
- [x] Verified the slug + glob logic locally (`printf | tr` sanitization, then three scenarios: no file, this branch's file present, an unrelated branch's file present and correctly ignored)
- [x] This PR's own \`Changeset Draft\` run is a live test: it should produce \`.changeset/fix-changeset-branch-slug.md\` (this change touches only workflow/script files under \`.github/\`, not \`packages/ui\`/\`apps/*\`, so the drafting script may legitimately find nothing to summarize and skip — that's expected either way, not a failure)