### PR TITLE
📝 docs: add migration note for Button htmlType default change

### DIFF
--- a/.changeset/docs-button-html-type-migration.md
+++ b/.changeset/docs-button-html-type-migration.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+**Migration note for 3.4.0:** `Button`'s `htmlType` now defaults to `'button'` instead of the browser's native default of `'submit'`. This was shipped in 3.4.0 without a migration note — if your `<Button>` was relying on the old implicit-submit behavior inside a `<form>` (i.e. you never passed `type`/`onClick` and expected clicking it to submit the form), add `htmlType="submit"` explicitly to restore that behavior.


### PR DESCRIPTION
## Summary
- 3.4.0 (commit 04d4848) changed `Button`'s `htmlType` default from the browser's native `'submit'` to `'button'` — a behavior change for any `<Button>` inside a `<form>` relying on implicit submit — but shipped without a migration note (ui-kit#177 R3).
- Adds one via a new changeset so it surfaces in the next release's CHANGELOG, rather than hand-editing the already-published 3.4.0 CHANGELOG.md section (changesets tooling has no mechanism to amend historical entries).

## Test plan
- N/A — changeset file only, no code changes.