### PR TITLE
✨ fix: ui-kit#177 remaining items — Group dup keys, Spin policy, ColorPicker open, dynamic-class CI check

### DIFF
--- a/.changeset/fix-group-duplicate-value.md
+++ b/.changeset/fix-group-duplicate-value.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add a new feature to check for dynamically-constructed class strings in cn() calls, and warn when duplicate option values are found in Radio.Group and Checkbox.Group components.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Type check
         run: pnpm run check-types
 
+      - name: Check for dynamically-constructed Tailwind classes
+        run: pnpm run check-dynamic-classes
+
       - name: Build
         run: pnpm exec turbo run build

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",
+    "check-dynamic-classes": "turbo run check-dynamic-classes",
     "prepare": "husky",
     "publish-ui": "cd packages/ui && npm publish"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
   "scripts": {
     "build": "tsdown",
     "lint": "eslint .",
+    "check-dynamic-classes": "node scripts/check-dynamic-tailwind-classes.mjs",
     "generate:component": "turbo gen react-component",
     "check-types": "tsc -b",
     "prepublishOnly": "node scripts/prepare-publish.mjs",

--- a/packages/ui/scripts/check-dynamic-tailwind-classes.mjs
+++ b/packages/ui/scripts/check-dynamic-tailwind-classes.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Flags template literals with `${...}` interpolation used inside `cn(...)`
+// calls under src/. Tailwind v4 only extracts class candidates that appear
+// as literal strings in source — anything built via string interpolation
+// (e.g. `` `before:${side}-0` ``) silently never makes it into the
+// generated CSS. This bit ui-kit#177 (Popover's arrow classes) once
+// already; this is a lightweight heuristic tripwire against it recurring,
+// not a full parser — false positives are possible on unusual code, in
+// which case just fix the flagged spot to use a literal lookup table
+// instead (see popover.tsx/drawer.tsx for the pattern) or, if it's
+// genuinely not a Tailwind class, ignore this script's finding.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SRC_DIR = path.join(__dirname, '..', 'src');
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (/\.(tsx?|jsx?)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Scans one file's raw text for backtick template literals that (a)
+// contain `${` and (b) sit inside a `cn(...)` call, however deeply
+// nested (e.g. inside a conditional or another function call within the
+// cn() argument list). Skips over line/block comments and '...'/"..."
+// strings so unbalanced brackets in them don't throw off paren tracking.
+function findFindings(filePath, content) {
+  const findings = [];
+  const stack = []; // one entry per open paren: { isCn: boolean }
+  const len = content.length;
+  let i = 0;
+
+  const isInsideCn = () => stack.some(frame => frame.isCn);
+  const lineAt = index => content.slice(0, index).split('\n').length;
+
+  while (i < len) {
+    const ch = content[i];
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      const end = content.indexOf('\n', i);
+      i = end === -1 ? len : end;
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      const end = content.indexOf('*/', i + 2);
+      i = end === -1 ? len : end + 2;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      let j = i + 1;
+      while (j < len && content[j] !== quote) {
+        j += content[j] === '\\' ? 2 : 1;
+      }
+      i = j + 1;
+      continue;
+    }
+
+    if (ch === '`') {
+      const start = i;
+      let j = i + 1;
+      let hasInterpolation = false;
+
+      while (j < len && content[j] !== '`') {
+        if (content[j] === '\\') {
+          j += 2;
+          continue;
+        }
+        if (content[j] === '$' && content[j + 1] === '{') {
+          hasInterpolation = true;
+          let braceDepth = 1;
+          j += 2;
+          while (j < len && braceDepth > 0) {
+            if (content[j] === '{') braceDepth++;
+            else if (content[j] === '}') braceDepth--;
+            j++;
+          }
+          continue;
+        }
+        j++;
+      }
+      j++; // closing backtick
+
+      if (hasInterpolation && isInsideCn()) {
+        findings.push({
+          file: filePath,
+          line: lineAt(start),
+          snippet: content.slice(start, j).replace(/\s+/g, ' ').slice(0, 100),
+        });
+      }
+
+      i = j;
+      continue;
+    }
+
+    if (ch === '(') {
+      const before = content.slice(Math.max(0, i - 2), i);
+      const beforeThat = content[i - 3];
+      const isCnCall =
+        before === 'cn' && !/[a-zA-Z0-9_$]/.test(beforeThat ?? '');
+      stack.push({ isCn: isCnCall });
+      i++;
+      continue;
+    }
+
+    if (ch === ')') {
+      stack.pop();
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return findings;
+}
+
+const files = walk(SRC_DIR);
+const allFindings = files.flatMap(file =>
+  findFindings(file, fs.readFileSync(file, 'utf8')),
+);
+
+if (allFindings.length === 0) {
+  console.log(
+    `✓ No dynamically-constructed class strings found in cn() calls (${files.length} files scanned).`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `✗ Found ${allFindings.length} template literal(s) with interpolation inside cn() calls — Tailwind won't generate CSS for these unless the interpolated parts happen to appear as literal strings elsewhere in source:\n`,
+);
+for (const { file, line, snippet } of allFindings) {
+  console.error(`  ${path.relative(process.cwd(), file)}:${line}`);
+  console.error(`    ${snippet}\n`);
+}
+console.error(
+  'Replace with a literal lookup table instead (see popover.tsx getArrowClassName / drawer.tsx ROUNDED_CLASSES for the pattern).',
+);
+process.exit(1);

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -10,6 +10,7 @@ import {
   type OptionValue,
   type Options,
   normalizeOptions,
+  warnOnDuplicateOptionValues,
 } from '../option-group';
 import Checkbox from './checkbox';
 
@@ -51,6 +52,7 @@ const Group = ({
   });
 
   const options: Option[] = normalizeOptions(_options);
+  warnOnDuplicateOptionValues(options, 'Checkbox.Group');
 
   const onChange = (checked: boolean, optionValue: OptionValue) => {
     const nextValue = checked
@@ -68,12 +70,12 @@ const Group = ({
         className,
       )}
     >
-      {options.map((item: Option) => {
+      {options.map((item: Option, index) => {
         const checked = value.includes(item.value);
 
         return (
           <li
-            key={String(item.value)}
+            key={`${index}-${String(item.value)}`}
             className={cn('flex', classNames?.wrapper)}
           >
             <Checkbox

--- a/packages/ui/src/components/atoms/color-picker.tsx
+++ b/packages/ui/src/components/atoms/color-picker.tsx
@@ -10,13 +10,16 @@ import Popover from './popover';
 
 export interface Props extends Omit<
   React.ComponentPropsWithoutRef<'div'>,
-  'onChange' | 'defaultValue' | 'value' | 'onClick' | 'onKeyDown'
+  'onChange' | 'defaultValue' | 'value' | 'onClick' | 'onKeyDown' | 'open'
 > {
   defaultValue?: string;
   value?: string;
   showText?: boolean;
   disabled?: boolean;
   onChange?: (color: string) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const ColorPicker = ({
@@ -26,12 +29,20 @@ const ColorPicker = ({
   disabled,
   className,
   onChange: _onChange = () => {},
+  open: _open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }: Props) => {
   const [value, setValue] = useControllableState<string>({
     value: _value,
     defaultValue: defaultValue ?? '#fff',
     onChange: _onChange,
+  });
+  const [open, setOpen] = useControllableState<boolean>({
+    value: _open,
+    defaultValue: defaultOpen ?? false,
+    onChange: onOpenChange,
   });
 
   const onChange = (color: string) => {
@@ -44,6 +55,8 @@ const ColorPicker = ({
   return (
     <Popover
       placement="bottomLeft"
+      open={open}
+      onOpenChange={setOpen}
       content={<HexColorPicker color={value} onChange={onChange} />}
     >
       <div

--- a/packages/ui/src/components/atoms/option-group.ts
+++ b/packages/ui/src/components/atoms/option-group.ts
@@ -22,3 +22,39 @@ export const normalizeOptions = (options: Options): Option[] =>
           value: item,
         },
   );
+
+// Radio.Group/Checkbox.Group both key selection off `value` (Radix's
+// RadioGroup matches items by it, and Checkbox.Group tests membership via
+// `value.includes(...)`), so two options sharing a value aren't just a
+// React list-key collision — they become indistinguishable to the
+// component's own selection logic, e.g. both rendering aria-checked=true
+// together. A duplicate is virtually always a caller mistake (two radios
+// for the "same" value can't be meaningfully different choices), so warn
+// instead of silently accepting it.
+export const warnOnDuplicateOptionValues = (
+  options: Option[],
+  componentName: string,
+) => {
+  const nodeEnv = (globalThis as { process?: { env?: { NODE_ENV?: string } } })
+    .process?.env?.NODE_ENV;
+
+  if (nodeEnv === 'production') {
+    return;
+  }
+
+  const seen = new Set<OptionValue>();
+  const duplicates = new Set<OptionValue>();
+
+  for (const option of options) {
+    if (seen.has(option.value)) {
+      duplicates.add(option.value);
+    }
+    seen.add(option.value);
+  }
+
+  if (duplicates.size > 0) {
+    console.warn(
+      `${componentName}: duplicate option value(s) [${[...duplicates].map(v => JSON.stringify(v)).join(', ')}] — options sharing a value render as if selecting one selects all of them, since selection is matched by value.`,
+    );
+  }
+};

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -14,6 +14,7 @@ import {
   type OptionValue,
   type Options,
   normalizeOptions,
+  warnOnDuplicateOptionValues,
 } from '../option-group';
 import { RadioGroupContext } from './context';
 import Radio from './radio';
@@ -64,6 +65,7 @@ const RadioGroup = ({
   });
 
   const options: Option[] = normalizeOptions(_options);
+  warnOnDuplicateOptionValues(options, 'Radio.Group');
 
   const isButton = optionType === 'button';
 
@@ -107,7 +109,7 @@ const RadioGroup = ({
 
         return (
           <li
-            key={String(item.value)}
+            key={`${index}-${String(item.value)}`}
             className={cn('flex', classNames?.wrapper)}
           >
             {isButton ? (

--- a/packages/ui/src/components/atoms/spin.tsx
+++ b/packages/ui/src/components/atoms/spin.tsx
@@ -27,23 +27,25 @@ const Spin = ({ spinning, className, children, ...props }: Props) => {
     );
   }
 
-  // `className`/rest props always land on this one wrapper regardless of
-  // `spinning`, instead of applying to the icon in one branch and being
-  // dropped entirely in another.
+  // Idle: return children as-is rather than inserting a wrapper div, same
+  // policy Skeleton follows and for the same reason — a wrapper here could
+  // produce invalid markup (e.g. inside a <tr>/<li>) or break flex/grid
+  // child layout. className/props only ever describe the spinning overlay
+  // below, so there's nothing for them to apply to while idle.
+  if (!spinning) {
+    return children;
+  }
+
   return (
     <div className={cn('relative', className)} {...props}>
-      <div className={cn(spinning && 'pointer-events-none opacity-50')}>
-        {children}
+      <div className="pointer-events-none opacity-50">{children}</div>
+      <div
+        role="status"
+        aria-label="로딩 중"
+        className="absolute inset-0 flex items-center justify-center"
+      >
+        <Loader2 className="animate-spin" />
       </div>
-      {spinning && (
-        <div
-          role="status"
-          aria-label="로딩 중"
-          className="absolute inset-0 flex items-center justify-center"
-        >
-          <Loader2 className="animate-spin" />
-        </div>
-      )}
     </div>
   );
 };

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,9 @@
     "check-types": {
       "dependsOn": ["^check-types"]
     },
+    "check-dynamic-classes": {
+      "dependsOn": ["^check-dynamic-classes"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary

Closes out the remaining (non-🔴) items from ui-kit#177.

- **Radio.Group/Checkbox.Group duplicate value warning** — both match selection by `value` (Radix's RadioGroup compares by it, Checkbox.Group tests `value.includes(...)`), so duplicate-value options aren't just a React key collision, they're indistinguishable to the selection logic itself (both render `aria-checked=true` together). Fixed the immediate key collision with an index-combined key, and added a dev-mode-only warning naming the offending value(s).
- **Spin/Skeleton wrapper policy unified** — Spin always wrapped in `<div class="relative">` even while idle, unlike Skeleton which deliberately avoids wrapping (invalid markup risk inside `<tr>`/`<li>`, broken flex/grid child layout). Spin now returns children as-is while idle, matching Skeleton.
- **ColorPicker gains a controlled open API** — mirrors Popover's own `open`/`defaultOpen`/`onOpenChange` (which DatePicker already uses internally, but ColorPicker never got). Doesn't auto-close on color change like DatePicker does on date select, since `HexColorPicker`'s `onChange` fires continuously while dragging — closing is left to the caller.
- **New CI check for dynamically-constructed Tailwind classes** — a lightweight scanner (`packages/ui/scripts/check-dynamic-tailwind-classes.mjs`) flags template literals with `${}` interpolation inside `cn(...)` calls, the exact pattern that caused the Popover arrow bug fixed in #190. Scoped to `cn()` call arguments via paren-depth tracking to avoid false positives elsewhere.

## Test plan
- [x] `pnpm --filter @repo/ui check-types` / `lint`
- [x] `pnpm build` (ui + docs + web, full monorepo)
- [x] Group: verified via `renderToStaticMarkup` that the duplicate-value warning fires only for duplicates, not clean options
- [x] Spin: verified idle renders bare children with no wrapper div
- [x] ColorPicker: verified `open`/`defaultOpen` correctly drive the popover's `data-state`
- [x] Dynamic-class scanner: verified it flags the real bug pattern and doesn't false-positive on an unrelated interpolated template literal outside `cn()`
- [x] New `check-dynamic-classes` turbo task runs correctly scoped to `@repo/ui` only