### PR TITLE
♿ fix: ui-kit#179 remaining accessibility items

### DIFF
--- a/.changeset/fix-organisms-a11y.md
+++ b/.changeset/fix-organisms-a11y.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add ARIA attributes to list items and toast notifications for improved accessibility.

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -131,15 +131,18 @@ const List = <T,>({
         {!data?.length && empty
           ? empty
           : data?.map((item, i) => (
-              <React.Fragment key={itemKey ? itemKey(item, i) : i}>
+              <div role="listitem" key={itemKey ? itemKey(item, i) : i}>
                 {renderItem(item, i)}
-              </React.Fragment>
+              </div>
             ))}
-        {scroll?.loading &&
-          (scroll?.loader ?? (
-            <Skeleton.Node count={10} gap={10} {...loaderProps} />
-          ))}
-        {scroll && <div ref={loaderRef} />}
+        {scroll?.loading && (
+          <div role="presentation">
+            {scroll?.loader ?? (
+              <Skeleton.Node count={10} gap={10} {...loaderProps} />
+            )}
+          </div>
+        )}
+        {scroll && <div ref={loaderRef} role="none" />}
       </div>
     </div>
   );

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -100,7 +100,7 @@ const Toast = ({
 }: Props) => {
   return (
     <div
-      role="status"
+      role={type === 'error' ? 'alert' : 'status'}
       className={cn(
         'pointer-events-auto flex w-80 items-start gap-3 rounded-lg',
         'bg-background text-foreground border p-4 shadow-lg',
@@ -153,7 +153,7 @@ const StaticToast = ({
     }, 200);
   };
 
-  useTimeout(close, duration || null);
+  const { reset, clear } = useTimeout(close, duration || null);
 
   if (!isBrowser) {
     return null;
@@ -165,6 +165,14 @@ const StaticToast = ({
         'transition-all duration-200',
         visible ? 'opacity-100' : 'translate-x-2 opacity-0',
       )}
+      // Without this, a toast with a closable/action button (or one the
+      // user is mid-read on) could auto-dismiss itself out from under
+      // them — hovering or focusing anything inside pauses the timer,
+      // moving away restarts it from the full duration.
+      onMouseEnter={clear}
+      onMouseLeave={reset}
+      onFocus={clear}
+      onBlur={reset}
     >
       <Toast {...props} onClose={close} />
     </div>,


### PR DESCRIPTION
## Summary

Closes out the two ♿ items from ui-kit#179.

- **Toast auto-dismiss now pauses on hover/focus** — the auto-dismiss timer ran regardless of user interaction, so a toast with a closable/action button (or one the user was mid-read on) could disappear out from under them. Hovering or focusing anything inside now pauses the timer (via `useTimeout`'s `reset`/`clear`), moving away restarts it from the full duration.
- **`type="error"` toasts use `role="alert"`** — every toast previously used `role="status"` (polite) regardless of type, so errors weren't announced immediately by screen readers.
- **List's `role="list"` now only has valid `listitem`/`none` children** — items rendered as bare `React.Fragment` (no DOM node, no role), and the loading skeleton / `IntersectionObserver` sentinel were direct children with no role at all. Items now wrapped in `role="listitem"` divs, the loading skeleton wrapped in `role="presentation"` (keeping `Skeleton.Node`'s own `role="status"` intact underneath), and the sentinel gets `role="none"`.

## Test plan
- [x] `pnpm --filter @repo/ui check-types` / `lint`
- [x] `pnpm build` (ui + docs + web, full monorepo)
- [x] Toast: verified via `renderToStaticMarkup` that `type="error"` renders `role="alert"`, other types keep `role="status"`
- [x] List: verified via `renderToStaticMarkup` — exactly one `role="listitem"` per data item, `presentation` wrapper around the loading skeleton, `role="none"` on the sentinel

## Out of scope (left for a follow-up)
🟢 maintainability items from ui-kit#179 — the shared `loading`-branch prop-loss pattern (tracked jointly with #177/#178, both now closed), Modal/Toast's duplicated imperative stack machinery, and missing `Props` exports for `modal`/`list`/`swiper` — are not included here.