### PR TITLE
♻️ chore: unify organisms maintenance items (#179)

### DIFF
--- a/.changeset/fix-organisms-maintenance.md
+++ b/.changeset/fix-organisms-maintenance.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Create a reusable imperative stack component for rendering and destroying container-scoped React roots, used by Modal and Toast components.

--- a/packages/ui/src/components/organisms/imperative-stack.tsx
+++ b/packages/ui/src/components/organisms/imperative-stack.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Root, createRoot } from 'react-dom/client';
+
+import { v4 as uuid } from 'uuid';
+
+// Shared machinery behind Modal.info/success/error/warning/confirm and
+// Toast.info/success/error/warning — both used to independently
+// reimplement ~120 near-identical lines of this (container-scoped stack,
+// a React root per container, imperative render/destroy). The only parts
+// that actually differ between the two are the DOM node their stack
+// mounts into (position/ARIA) and which component renders each stack
+// entry — everything else here is generic over that.
+
+export const isBrowser =
+  typeof window !== 'undefined' && typeof document !== 'undefined';
+
+type ContainerState<TProps> = {
+  stack: (TProps & { id: string })[];
+  update: (() => void) | null;
+};
+
+export interface ImperativeStack<
+  TProps extends { id?: string; container?: HTMLElement },
+> {
+  render: (props: TProps) => string | undefined;
+  destroy: (id?: string) => void;
+  getRootElement: (container?: HTMLElement) => HTMLElement | null;
+}
+
+export interface ImperativeStackOptions<
+  TProps extends { id?: string; container?: HTMLElement },
+> {
+  /** Creates the DOM node this stack's React root mounts into — not yet
+   * attached to the document; the factory appends it to the target
+   * container itself. Called once per distinct container. */
+  createRootElement: () => HTMLElement;
+  /** Renders one stack entry — typically each caller's "Static<Thing>"
+   * component, which owns its own createPortal(..., getRootElement()). */
+  StackItem: React.ComponentType<TProps & { id: string }>;
+}
+
+export function createImperativeStack<
+  TProps extends { id?: string; container?: HTMLElement },
+>({
+  createRootElement,
+  StackItem,
+}: ImperativeStackOptions<TProps>): ImperativeStack<TProps> {
+  const containerStates = new Map<HTMLElement, ContainerState<TProps>>();
+  const rootElements = new WeakMap<HTMLElement, HTMLElement>();
+  const reactRoots = new Map<HTMLElement, Root>();
+
+  const getContainerState = (
+    container: HTMLElement,
+  ): ContainerState<TProps> => {
+    let state = containerStates.get(container);
+
+    if (!state) {
+      state = { stack: [], update: null };
+      containerStates.set(container, state);
+    }
+
+    return state;
+  };
+
+  const getRootElement = (container?: HTMLElement): HTMLElement | null => {
+    if (!isBrowser) {
+      return null;
+    }
+
+    const targetContainer = container || document.body;
+    let rootEl = rootElements.get(targetContainer);
+
+    if (!rootEl) {
+      rootEl = createRootElement();
+      targetContainer.appendChild(rootEl);
+      rootElements.set(targetContainer, rootEl);
+    }
+
+    return rootEl;
+  };
+
+  const StackRenderer = ({ container }: { container: HTMLElement }) => {
+    const [, forceUpdate] = useState({});
+
+    useEffect(() => {
+      const state = getContainerState(container);
+      state.update = () => forceUpdate({});
+      return () => {
+        state.update = null;
+      };
+    }, [container]);
+
+    const { stack } = getContainerState(container);
+
+    return (
+      <>
+        {stack.map(({ id, ...props }) => (
+          <StackItem key={id} id={id} {...(props as TProps)} />
+        ))}
+      </>
+    );
+  };
+
+  const render = (props: TProps): string | undefined => {
+    if (!isBrowser) {
+      return;
+    }
+
+    const targetContainer = props.container || document.body;
+    const rootElement = getRootElement(targetContainer)!;
+
+    if (!reactRoots.has(targetContainer)) {
+      const root = createRoot(rootElement);
+      reactRoots.set(targetContainer, root);
+      root.render(<StackRenderer container={targetContainer} />);
+    }
+
+    const state = getContainerState(targetContainer);
+    const id = props.id || uuid();
+    state.stack.push({ ...props, id });
+    state.update?.();
+
+    return id;
+  };
+
+  const destroy = (id?: string) => {
+    if (!id) {
+      containerStates.forEach(state => {
+        state.stack = [];
+        state.update?.();
+      });
+      reactRoots.forEach((root, container) => {
+        root.unmount();
+        rootElements.get(container)?.remove();
+        rootElements.delete(container);
+      });
+      reactRoots.clear();
+      containerStates.clear();
+      return;
+    }
+
+    containerStates.forEach((state, container) => {
+      if (!state.stack.some(item => item.id === id)) {
+        return;
+      }
+
+      state.stack = state.stack.filter(item => item.id !== id);
+      state.update?.();
+
+      if (!state.stack.length) {
+        reactRoots.get(container)?.unmount();
+        reactRoots.delete(container);
+        containerStates.delete(container);
+        rootElements.get(container)?.remove();
+        rootElements.delete(container);
+      }
+    });
+  };
+
+  return { render, destroy, getRootElement };
+}

--- a/packages/ui/src/components/organisms/index.ts
+++ b/packages/ui/src/components/organisms/index.ts
@@ -1,7 +1,10 @@
 export { default as Drawer } from './drawer';
 export type { Props as DrawerProps } from './drawer';
 export { default as List } from './list';
+export type { ListProps } from './list';
 export { default as Modal } from './modal';
+export type { Props as ModalProps } from './modal';
 export { default as Swiper } from './swiper';
+export type { SwiperProps } from './swiper';
 export { default as Toast } from './toast';
 export type { ToastOptions } from './toast';

--- a/packages/ui/src/components/organisms/list/index.ts
+++ b/packages/ui/src/components/organisms/list/index.ts
@@ -8,3 +8,4 @@ const List = ListImpl as ListComponent;
 List.Item = Item;
 
 export default List;
+export type { Props as ListProps } from './list';

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -9,7 +9,7 @@ import { cn, renderConditional } from '@repo/ui/utils';
 import Skeleton from '../../atoms/skeleton';
 import { Title } from '../../atoms/typography';
 
-interface Props<T> extends Omit<
+export interface Props<T> extends Omit<
   React.ComponentPropsWithoutRef<'div'>,
   'title'
 > {

--- a/packages/ui/src/components/organisms/list/list.tsx
+++ b/packages/ui/src/components/organisms/list/list.tsx
@@ -92,17 +92,19 @@ const List = <T,>({
 
   if (loading) {
     return (
-      loader || (
-        <div className={cn(className)} {...props}>
-          <div className={cn(classNames?.title)}>{title && <Skeleton />}</div>
-          <div className={cn(classNames?.header)}>
-            {header && <Skeleton size="small" />}
-          </div>
-          <div className={cn('space-y-2', classNames?.body)}>
-            <Skeleton.Node count={10} gap={10} {...loaderProps} />
-          </div>
-        </div>
-      )
+      <div className={cn(className)} {...props}>
+        {loader ?? (
+          <>
+            <div className={cn(classNames?.title)}>{title && <Skeleton />}</div>
+            <div className={cn(classNames?.header)}>
+              {header && <Skeleton size="small" />}
+            </div>
+            <div className={cn('space-y-2', classNames?.body)}>
+              <Skeleton.Node count={10} gap={10} {...loaderProps} />
+            </div>
+          </>
+        )}
+      </div>
     );
   }
 

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Root, createRoot } from 'react-dom/client';
 
 import {
   Check,
@@ -11,12 +10,16 @@ import {
   OctagonAlert,
   OctagonX,
 } from 'lucide-react';
-import { v4 as uuid } from 'uuid';
 
 import { dialog } from '@repo/ui/core';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../atoms/button';
+import {
+  type ImperativeStack,
+  createImperativeStack,
+  isBrowser,
+} from './imperative-stack';
 
 const {
   Dialog,
@@ -62,54 +65,6 @@ interface StaticProps extends Props {
   icon?: React.ReactNode;
   container?: HTMLElement;
 }
-
-const isBrowser =
-  typeof window !== 'undefined' && typeof document !== 'undefined';
-
-type ContainerState = {
-  stack: StaticProps[];
-  update: (() => void) | null;
-};
-
-const containerStates = new Map<HTMLElement, ContainerState>();
-const modalRootElements = new WeakMap<HTMLElement, HTMLElement>();
-
-const getContainerState = (container: HTMLElement): ContainerState => {
-  let state = containerStates.get(container);
-
-  if (!state) {
-    state = { stack: [], update: null };
-    containerStates.set(container, state);
-  }
-
-  return state;
-};
-
-// No `role`/`aria-modal` here — this element is only a mount point for the
-// imperative stack, not the dialog itself. Radix already renders its own
-// `role="dialog"`/`aria-modal="true"` on the actual `DialogContent` via
-// portal once a modal is open. Setting it here as well would (a) leave
-// `aria-modal="true"` on the page permanently, even with zero modals open,
-// hiding the rest of the document from screen readers, and (b) duplicate
-// Radix's own dialog role once one is open.
-const createModalRoot = (container?: HTMLElement) => {
-  if (!isBrowser) {
-    return null;
-  }
-
-  const targetContainer = container || document.body;
-  let rootEl = modalRootElements.get(targetContainer);
-
-  if (!rootEl) {
-    rootEl = document.createElement('div');
-    rootEl.style.zIndex = '10000';
-    rootEl.style.position = 'absolute';
-    targetContainer.appendChild(rootEl);
-    modalRootElements.set(targetContainer, rootEl);
-  }
-
-  return rootEl;
-};
 
 const Modal = ({
   open = false,
@@ -209,25 +164,25 @@ const STATIC_ICONS = {
 };
 
 const StaticModal = ({
+  id,
   type,
   title,
   content,
   okText = 'OK',
   cancelText = 'Cancel',
-  id,
   container,
   icon,
   onOk,
   onCancel,
   ...props
-}: StaticProps) => {
+}: StaticProps & { id: string }): React.ReactPortal | null => {
   const [open, setOpen] = useState(true);
 
   const closeModal = (callback?: () => void) => {
     callback?.();
     setOpen(false);
     setTimeout(() => {
-      Modal.destroy(id);
+      modalStack.destroy(id);
     }, 200);
   };
 
@@ -297,101 +252,43 @@ const StaticModal = ({
     >
       {content}
     </Modal>,
-    createModalRoot(container)!,
+    modalStack.getRootElement(container)!,
   );
 };
 
-const ModalStackRenderer = ({ container }: { container: HTMLElement }) => {
-  const [, forceUpdate] = useState({});
-
-  useEffect(() => {
-    const state = getContainerState(container);
-    state.update = () => forceUpdate({});
-    return () => {
-      state.update = null;
-    };
-  }, [container]);
-
-  const { stack } = getContainerState(container);
-
-  return (
-    <>
-      {stack.map(({ id, ...props }) => (
-        <StaticModal key={id} id={id} {...props} />
-      ))}
-    </>
-  );
-};
-
-const modalRoots = new Map<HTMLElement, Root>();
-
-const renderModal = (props: StaticProps) => {
-  if (!isBrowser) {
-    return;
-  }
-
-  const targetContainer = props.container || document.body;
-  const rootElement = createModalRoot(targetContainer)!;
-
-  if (!modalRoots.has(targetContainer)) {
-    const root = createRoot(rootElement);
-    modalRoots.set(targetContainer, root);
-    root.render(<ModalStackRenderer container={targetContainer} />);
-  }
-
-  const state = getContainerState(targetContainer);
-  const id = props.id || uuid();
-  state.stack.push({ ...props, id });
-  state.update?.();
-
-  return id;
-};
-
-Modal.destroy = (id?: string) => {
-  if (!id) {
-    containerStates.forEach(state => {
-      state.stack = [];
-      state.update?.();
-    });
-    modalRoots.forEach((root, container) => {
-      root.unmount();
-      modalRootElements.get(container)?.remove();
-      modalRootElements.delete(container);
-    });
-    modalRoots.clear();
-    containerStates.clear();
-    return;
-  }
-
-  containerStates.forEach((state, container) => {
-    if (!state.stack.some(modal => modal.id === id)) {
-      return;
-    }
-
-    state.stack = state.stack.filter(modal => modal.id !== id);
-    state.update?.();
-
-    if (!state.stack.length) {
-      modalRoots.get(container)?.unmount();
-      modalRoots.delete(container);
-      containerStates.delete(container);
-      modalRootElements.get(container)?.remove();
-      modalRootElements.delete(container);
-    }
+// No `role`/`aria-modal` here — this element is only a mount point for the
+// imperative stack, not the dialog itself. Radix already renders its own
+// `role="dialog"`/`aria-modal="true"` on the actual `DialogContent` via
+// portal once a modal is open. Setting it here as well would (a) leave
+// `aria-modal="true"` on the page permanently, even with zero modals open,
+// hiding the rest of the document from screen readers, and (b) duplicate
+// Radix's own dialog role once one is open.
+const modalStack: ImperativeStack<StaticProps> =
+  createImperativeStack<StaticProps>({
+    createRootElement: () => {
+      const el = document.createElement('div');
+      el.style.zIndex = '10000';
+      el.style.position = 'absolute';
+      return el;
+    },
+    StackItem: StaticModal,
   });
-};
+
+Modal.destroy = modalStack.destroy;
 
 Modal.destroyAll = () => {
-  Modal.destroy();
+  modalStack.destroy();
 };
 
-Modal.info = (props: StaticProps) => renderModal({ type: 'info', ...props });
+Modal.info = (props: StaticProps) =>
+  modalStack.render({ type: 'info', ...props });
 Modal.success = (props: StaticProps) =>
-  renderModal({ type: 'success', ...props });
-Modal.error = (props: StaticProps) => renderModal({ type: 'error', ...props });
+  modalStack.render({ type: 'success', ...props });
+Modal.error = (props: StaticProps) =>
+  modalStack.render({ type: 'error', ...props });
 Modal.warning = (props: StaticProps) =>
-  renderModal({ type: 'warning', ...props });
+  modalStack.render({ type: 'warning', ...props });
 Modal.confirm = (props: StaticProps) =>
-  renderModal({ type: 'confirm', ...props });
+  modalStack.render({ type: 'confirm', ...props });
 
 export default Modal;

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -27,7 +27,7 @@ const {
   DialogTitle,
 } = dialog;
 
-interface Props {
+export interface Props {
   open?: boolean;
   maskClosable?: boolean;
   closable?:

--- a/packages/ui/src/components/organisms/swiper/index.ts
+++ b/packages/ui/src/components/organisms/swiper/index.ts
@@ -9,3 +9,4 @@ Swiper.Slide = Slide;
 
 export default Swiper;
 export { initialOptions };
+export type { Props as SwiperProps } from './swiper';

--- a/packages/ui/src/components/organisms/swiper/swiper.tsx
+++ b/packages/ui/src/components/organisms/swiper/swiper.tsx
@@ -60,14 +60,21 @@ const Swiper = <T,>({
   modules = [],
   data = [],
   style,
+  className,
   renderItem,
   loadingClassName,
   ...props
 }: Props<T>) => {
   if (loading) {
+    // `{...props}` isn't spread here (unlike the non-loading branch) —
+    // SwiperProps carries a lot of Swiper.js-specific config/callbacks
+    // (spaceBetween, slidesPerView, onSwiper, etc.) that aren't valid DOM
+    // attributes, so blindly spreading them onto a plain placeholder div
+    // would trigger React's unknown-DOM-attribute warnings. className/
+    // style are the two that actually matter for this div and are safe.
     return (
-      <div className={cn('h-32', loadingClassName)}>
-        {loader || <Spin spinning />}
+      <div className={cn('h-32', className, loadingClassName)} style={style}>
+        {loader ?? <Spin spinning />}
       </div>
     );
   }
@@ -78,6 +85,7 @@ const Swiper = <T,>({
       {...initialOptions}
       {...options}
       style={{ ...initialStyle, ...style }}
+      className={className}
       {...props}
     >
       {data.map((item: T, i) => {

--- a/packages/ui/src/components/organisms/swiper/swiper.tsx
+++ b/packages/ui/src/components/organisms/swiper/swiper.tsx
@@ -29,7 +29,7 @@ export const initialOptions: SwiperOptions = {
 
 const initialStyle = { width: '100%', maxWidth: '100vw', overflow: 'hidden' };
 
-interface Props<T> extends SwiperProps {
+export interface Props<T> extends SwiperProps {
   loading?: boolean;
   loader?: React.ReactNode;
   loadingClassName?: string;

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -1,16 +1,19 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Root, createRoot } from 'react-dom/client';
 
 import { useTimeout } from '@jbpark/use-hooks';
 import { Check, Info, OctagonAlert, OctagonX, X } from 'lucide-react';
-import { v4 as uuid } from 'uuid';
 
 import { cn } from '@repo/ui/utils';
 
 import Button from '../atoms/button';
+import {
+  type ImperativeStack,
+  createImperativeStack,
+  isBrowser,
+} from './imperative-stack';
 
 type ToastType = 'info' | 'success' | 'error' | 'warning';
 
@@ -30,56 +33,6 @@ interface StaticProps extends Props {
   duration?: number;
   container?: HTMLElement;
 }
-
-const isBrowser =
-  typeof window !== 'undefined' && typeof document !== 'undefined';
-
-type ContainerState = {
-  stack: StaticProps[];
-  update: (() => void) | null;
-};
-
-const containerStates = new Map<HTMLElement, ContainerState>();
-const toastRootElements = new WeakMap<HTMLElement, HTMLElement>();
-
-const getContainerState = (container: HTMLElement): ContainerState => {
-  let state = containerStates.get(container);
-
-  if (!state) {
-    state = { stack: [], update: null };
-    containerStates.set(container, state);
-  }
-
-  return state;
-};
-
-const createToastRoot = (container?: HTMLElement) => {
-  if (!isBrowser) {
-    return null;
-  }
-
-  const targetContainer = container || document.body;
-  let rootEl = toastRootElements.get(targetContainer);
-
-  if (!rootEl) {
-    rootEl = document.createElement('div');
-    rootEl.setAttribute('role', 'region');
-    rootEl.setAttribute('aria-label', 'Notifications');
-    rootEl.style.zIndex = '10000';
-    rootEl.style.position = 'fixed';
-    rootEl.style.right = '0';
-    rootEl.style.bottom = '0';
-    rootEl.style.display = 'flex';
-    rootEl.style.flexDirection = 'column-reverse';
-    rootEl.style.gap = '8px';
-    rootEl.style.padding = '16px';
-    rootEl.style.pointerEvents = 'none';
-    targetContainer.appendChild(rootEl);
-    toastRootElements.set(targetContainer, rootEl);
-  }
-
-  return rootEl;
-};
 
 const TYPE_ICONS: Record<ToastType, React.ReactNode> = {
   info: <Info className="text-blue-400" />,
@@ -142,14 +95,14 @@ const StaticToast = ({
   container,
   onClose,
   ...props
-}: StaticProps) => {
+}: StaticProps & { id: string }): React.ReactPortal | null => {
   const [visible, setVisible] = useState(true);
 
   const close = () => {
     onClose?.();
     setVisible(false);
     setTimeout(() => {
-      Toast.destroy(id);
+      toastStack.destroy(id);
     }, 200);
   };
 
@@ -176,104 +129,46 @@ const StaticToast = ({
     >
       <Toast {...props} onClose={close} />
     </div>,
-    createToastRoot(container)!,
+    toastStack.getRootElement(container)!,
   );
 };
 
-const ToastStackRenderer = ({ container }: { container: HTMLElement }) => {
-  const [, forceUpdate] = useState({});
-
-  useEffect(() => {
-    const state = getContainerState(container);
-    state.update = () => forceUpdate({});
-    return () => {
-      state.update = null;
-    };
-  }, [container]);
-
-  const { stack } = getContainerState(container);
-
-  return (
-    <>
-      {stack.map(({ id, ...props }) => (
-        <StaticToast key={id} id={id} {...props} />
-      ))}
-    </>
-  );
-};
-
-const toastRoots = new Map<HTMLElement, Root>();
-
-const renderToast = (props: StaticProps) => {
-  if (!isBrowser) {
-    return;
-  }
-
-  const targetContainer = props.container || document.body;
-  const rootElement = createToastRoot(targetContainer)!;
-
-  if (!toastRoots.has(targetContainer)) {
-    const root = createRoot(rootElement);
-    toastRoots.set(targetContainer, root);
-    root.render(<ToastStackRenderer container={targetContainer} />);
-  }
-
-  const state = getContainerState(targetContainer);
-  const id = props.id || uuid();
-  state.stack.push({ ...props, id });
-  state.update?.();
-
-  return id;
-};
-
-Toast.destroy = (id?: string) => {
-  if (!id) {
-    containerStates.forEach(state => {
-      state.stack = [];
-      state.update?.();
-    });
-    toastRoots.forEach((root, container) => {
-      root.unmount();
-      toastRootElements.get(container)?.remove();
-      toastRootElements.delete(container);
-    });
-    toastRoots.clear();
-    containerStates.clear();
-    return;
-  }
-
-  containerStates.forEach((state, container) => {
-    if (!state.stack.some(toast => toast.id === id)) {
-      return;
-    }
-
-    state.stack = state.stack.filter(toast => toast.id !== id);
-    state.update?.();
-
-    if (!state.stack.length) {
-      toastRoots.get(container)?.unmount();
-      toastRoots.delete(container);
-      containerStates.delete(container);
-      toastRootElements.get(container)?.remove();
-      toastRootElements.delete(container);
-    }
+const toastStack: ImperativeStack<StaticProps> =
+  createImperativeStack<StaticProps>({
+    createRootElement: () => {
+      const el = document.createElement('div');
+      el.setAttribute('role', 'region');
+      el.setAttribute('aria-label', 'Notifications');
+      el.style.zIndex = '10000';
+      el.style.position = 'fixed';
+      el.style.right = '0';
+      el.style.bottom = '0';
+      el.style.display = 'flex';
+      el.style.flexDirection = 'column-reverse';
+      el.style.gap = '8px';
+      el.style.padding = '16px';
+      el.style.pointerEvents = 'none';
+      return el;
+    },
+    StackItem: StaticToast,
   });
-};
+
+Toast.destroy = toastStack.destroy;
 
 Toast.destroyAll = () => {
-  Toast.destroy();
+  toastStack.destroy();
 };
 
 type TriggerOptions = Omit<StaticProps, 'type' | 'title'>;
 
 Toast.info = (title: React.ReactNode, props?: TriggerOptions) =>
-  renderToast({ type: 'info', title, ...props });
+  toastStack.render({ type: 'info', title, ...props });
 Toast.success = (title: React.ReactNode, props?: TriggerOptions) =>
-  renderToast({ type: 'success', title, ...props });
+  toastStack.render({ type: 'success', title, ...props });
 Toast.error = (title: React.ReactNode, props?: TriggerOptions) =>
-  renderToast({ type: 'error', title, ...props });
+  toastStack.render({ type: 'error', title, ...props });
 Toast.warning = (title: React.ReactNode, props?: TriggerOptions) =>
-  renderToast({ type: 'warning', title, ...props });
+  toastStack.render({ type: 'warning', title, ...props });
 
 export default Toast;
 export type { StaticProps as ToastOptions };


### PR DESCRIPTION
## Summary
Follow-up to #202 — implements the 3 remaining 🟢 maintenance items from #179, unifying patterns already applied in #177/#178.

- **List/Swiper loading-branch prop loss**: both components previously dropped `className`/`{...props}` entirely whenever a custom `loader` was passed (loading branch bypassed the wrapper). Now both always render through the same wrapper, matching the pattern already fixed in Spin (#177) and Space (#178). Swiper deliberately applies only `className`/`style` (not the full `{...props}` spread) since `SwiperProps` carries Swiper.js-specific config/callback fields that aren't valid DOM attributes.
- **Modal/Toast Props exports**: `ModalProps`, `ListProps`, `SwiperProps` are now exported from the organisms barrel, matching the existing `DrawerProps`/`ToastOptions` pattern.
- **Modal/Toast shared imperative-stack extraction**: both components independently reimplemented ~120 near-identical lines (container-scoped stack, per-container React root, imperative render/destroy). Extracted into a single generic `createImperativeStack<TProps>({ createRootElement, StackItem })` factory in `imperative-stack.tsx`. Public API unchanged (`Modal.info/success/error/warning/confirm/destroy/destroyAll`, `Toast.info/success/error/warning/destroy/destroyAll`).

## Verification note
`check-types`, `lint`, and `pnpm build` (packages/ui + apps/docs + apps/web) all pass. I could not get interactive browser automation working in this environment to click through `Modal.confirm()`/`Toast.info()` live in Storybook, so the Modal/Toast refactor was instead verified by a careful line-by-line `git diff main` review confirming the actual component bodies (including the earlier Modal.confirm Escape/onCancel fix and Toast hover/focus pause logic) are byte-for-byte unchanged — only the stack-machinery portions were replaced with calls into the shared factory.

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build` (root, all 3 packages)
- [ ] CI green