### PR TITLE
♻️ refactor: Sider adopts useControllableState (#180)

### DIFF
--- a/.changeset/refactor-sider-controllable-state.md
+++ b/.changeset/refactor-sider-controllable-state.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add a controlled state to the Sider component, allowing users to customize the collapse behavior with the onCollapse prop.

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
+import { useControllableState } from '@jbpark/use-hooks';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 
 import { cn } from '@repo/ui/utils';
@@ -40,25 +41,20 @@ const Sider = ({
   collapsed: _collapsed,
   reverseArrow = false,
   trigger,
-  onCollapse: _onCollapse = () => {},
+  onCollapse,
   ...props
 }: Props) => {
   useRegisterSider();
 
   const contentId = useId();
-  const [uncontrolledCollapsed, setUncontrolledCollapsed] =
-    useState(defaultCollapsed);
+  const [collapsed, setCollapsed] = useControllableState<boolean>({
+    value: _collapsed,
+    defaultValue: defaultCollapsed,
+    onChange: onCollapse,
+  });
 
-  const controlled = _collapsed !== undefined;
-  const collapsed = controlled ? _collapsed : uncontrolledCollapsed;
-
-  const onCollapse = () => {
-    const next = !collapsed;
-
-    if (!controlled) {
-      setUncontrolledCollapsed(next);
-    }
-    _onCollapse(next);
+  const onTriggerClick = () => {
+    setCollapsed(!collapsed);
   };
 
   const TriggerIcon =
@@ -92,7 +88,7 @@ const Sider = ({
           aria-label={collapsed ? '펼치기' : '접기'}
           aria-expanded={!collapsed}
           aria-controls={contentId}
-          onClick={onCollapse}
+          onClick={onTriggerClick}
           className={cn(
             'flex w-full shrink-0 items-center justify-center py-2',
             'cursor-pointer transition-colors hover:bg-black/5',


### PR DESCRIPTION
## Summary
Next item from #180 — converts `Sider`'s collapsed-state handling from a hand-rolled controlled/uncontrolled branch to `@jbpark/use-hooks`'s `useControllableState`, matching the pattern already used elsewhere in this library (Switch, Checkbox, Radio, Dropdown, Menu, date-picker, color-picker, popover, upload).

No behavior change — same controlled/uncontrolled semantics, same `onCollapse` callback timing.

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output:
  - uncontrolled (`defaultCollapsed`) still renders the correct width/`aria-expanded`
  - controlled (`collapsed` prop) still renders the correct width/`aria-expanded`

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for controlled/uncontrolled Sider collapse state
- [ ] CI green