### PR TITLE
✨ feat: Sider breakpoint/onBreakpoint auto-collapse (#180)

### DIFF
--- a/.changeset/feat-sider-breakpoint.md
+++ b/.changeset/feat-sider-breakpoint.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for responsive sider component with customizable breakpoint.

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -1,13 +1,21 @@
 'use client';
 
-import { useId } from 'react';
+import { useId, useLayoutEffect } from 'react';
 
-import { useControllableState } from '@jbpark/use-hooks';
+import { useControllableState, useResponsiveSize } from '@jbpark/use-hooks';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 
 import { cn } from '@repo/ui/utils';
 
 import { useRegisterSider } from './sider-context';
+
+type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+// Order matters here, not the values — used to compare the current
+// viewport tier against the configured `breakpoint` ordinally, since
+// `useResponsiveSize` reports which named tier the viewport is currently
+// in rather than a raw pixel width.
+const BREAKPOINT_ORDER: Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'];
 
 export interface Props extends Omit<
   React.ComponentProps<'aside'>,
@@ -23,7 +31,9 @@ export interface Props extends Omit<
   classNames?: {
     trigger?: string;
   };
+  breakpoint?: Breakpoint;
   onCollapse?: (collapsed: boolean) => void;
+  onBreakpoint?: (broken: boolean) => void;
 }
 
 const toCssSize = (value: number | string) =>
@@ -41,7 +51,9 @@ const Sider = ({
   collapsed: _collapsed,
   reverseArrow = false,
   trigger,
+  breakpoint,
   onCollapse,
+  onBreakpoint,
   ...props
 }: Props) => {
   useRegisterSider();
@@ -52,6 +64,23 @@ const Sider = ({
     defaultValue: defaultCollapsed,
     onChange: onCollapse,
   });
+
+  const { breakpoint: viewportBreakpoint } = useResponsiveSize({
+    viewport: true,
+  });
+  const broken = breakpoint
+    ? BREAKPOINT_ORDER.indexOf(viewportBreakpoint.current) <
+      BREAKPOINT_ORDER.indexOf(breakpoint)
+    : false;
+
+  useLayoutEffect(() => {
+    if (!breakpoint) {
+      return;
+    }
+
+    setCollapsed(broken);
+    onBreakpoint?.(broken);
+  }, [broken, breakpoint, setCollapsed, onBreakpoint]);
 
   const onTriggerClick = () => {
     setCollapsed(!collapsed);


### PR DESCRIPTION
## Summary
Next item from #180 — `Sider` gains `breakpoint`/`onBreakpoint` for responsive auto-collapse, matching Ant Design's `Layout.Sider`.

- `breakpoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'` — when the viewport tier drops below this, `Sider` auto-collapses; re-expands once back above it
- `onBreakpoint?: (broken: boolean) => void` — fires on every crossing, either direction
- Backed by `@jbpark/use-hooks`'s `useResponsiveSize({ viewport: true })`; the sync effect uses `useLayoutEffect` (not `useEffect`) to commit before paint, consistent with this file's existing Sider-registration effect, to avoid a flash of the wrong collapsed state
- `collapsedWidth={0}` — turned out to already work with zero code changes (a JS default parameter only kicks in for `undefined`, not `0`); verified via SSR render rather than left as a TODO

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output:
  - `collapsedWidth={0}` renders `width:0px`
  - `breakpoint="md"` on SSR (no window, hook's initial state) renders expanded, as expected — the breakpoint effect only runs client-side after mount via `useLayoutEffect`, so there's no SSR/hydration mismatch, just an initial best-guess that corrects before first paint on the client
- Could not exercise an actual window resize interactively in this environment (no browser automation available) — reasoned through the hook's resize-listener + tier-comparison logic instead

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for collapsedWidth=0 and breakpoint prop
- [ ] CI green