### PR TITLE
♿ feat: Content asChild to override <main> landmark (#180)

### DIFF
--- a/.changeset/feat-content-aschild.md
+++ b/.changeset/feat-content-aschild.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for rendering a Content component as a child element, allowing for nested layouts and improved accessibility.

--- a/packages/ui/src/components/templates/layout/content.tsx
+++ b/packages/ui/src/components/templates/layout/content.tsx
@@ -1,10 +1,22 @@
+import { Slot } from '@radix-ui/react-slot';
+
 import { cn } from '@repo/ui/utils';
 
-export interface Props extends React.ComponentProps<'main'> {}
+export interface Props extends React.ComponentProps<'main'> {
+  asChild?: boolean;
+}
 
-const Content = ({ children, className, ...props }: Props) => {
+const Content = ({ children, className, asChild = false, ...props }: Props) => {
+  // Only one <main> landmark should exist per page — a Layout nested
+  // inside a page that already has its own <main> (or a Content nested
+  // inside another Content) needs a way to opt out of rendering a second
+  // one. asChild + Slot (same pattern as core/button.tsx and
+  // core/badge.tsx) merges these props/classes onto the caller's own
+  // element instead.
+  const Comp = asChild ? Slot : 'main';
+
   return (
-    <main
+    <Comp
       className={cn(
         'min-w-0 shrink grow basis-auto',
         // basis-auto (not basis-0) sizes Content from its actual content
@@ -21,7 +33,7 @@ const Content = ({ children, className, ...props }: Props) => {
       {...props}
     >
       {children}
-    </main>
+    </Comp>
   );
 };
 


### PR DESCRIPTION
## Summary
Next item from #180 — `Content` gains `asChild` (Radix `Slot`) so it doesn't force a second `<main>` landmark onto pages that already have one, or onto a `Content` nested inside another `Content`.

Same pattern already used by `core/button.tsx` and `core/badge.tsx`:
```tsx
<Layout.Content asChild>
  <div>...</div>
</Layout.Content>
```
merges `Content`'s classes/props onto the caller's own element instead of rendering `<main>`.

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output: default renders `<main class="...">`, `asChild` renders `<div class="...">` (classes merged, tag replaced) as expected

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for default vs asChild output
- [ ] CI green