### PR TITLE
✨ feat: Sider placement: 'left' | 'right' (#180)

### DIFF
--- a/.changeset/feat-sider-placement.md
+++ b/.changeset/feat-sider-placement.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for placing a sider on the right side of the layout.

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -26,6 +26,7 @@ export interface Props extends Omit<
   collapsible?: boolean;
   defaultCollapsed?: boolean;
   collapsed?: boolean;
+  placement?: 'left' | 'right';
   reverseArrow?: boolean;
   trigger?: React.ReactNode;
   classNames?: {
@@ -49,6 +50,7 @@ const Sider = ({
   collapsible = false,
   defaultCollapsed = false,
   collapsed: _collapsed,
+  placement = 'left',
   reverseArrow = false,
   trigger,
   breakpoint,
@@ -86,8 +88,14 @@ const Sider = ({
     setCollapsed(!collapsed);
   };
 
+  // A right-placed Sider's collapse icon should default to pointing the
+  // opposite way from a left-placed one (it's opening/closing a panel on
+  // the other side of the content), so `placement` flips the effective
+  // direction on top of whatever `reverseArrow` already requests —
+  // `reverseArrow` still layers on as a manual override either way.
+  const effectiveReverseArrow = reverseArrow !== (placement === 'right');
   const TriggerIcon =
-    collapsed !== reverseArrow ? PanelLeftOpen : PanelLeftClose;
+    collapsed !== effectiveReverseArrow ? PanelLeftOpen : PanelLeftClose;
 
   return (
     <aside
@@ -99,6 +107,11 @@ const Sider = ({
         // viewport top on scroll.
         'z-10 flex h-full shrink-0 flex-col overflow-hidden',
         'transition-[width] duration-200',
+        // Lets a Sider visually sit on the right without needing to
+        // reorder JSX/children — useful since Sider's presence is
+        // detected via context (sider-context.ts) rather than requiring
+        // it to be a specific direct child in a specific position.
+        placement === 'right' && 'order-last',
         className,
         //
       )}


### PR DESCRIPTION
## Summary
Next item from #180 — `Sider` gains `placement?: 'left' | 'right'` (default `'left'`, unchanged behavior).

- `'right'` applies `order-last` so `Sider` visually sits on the right without requiring JSX reordering — consistent with how `Sider`'s presence is already detected via context (`sider-context.ts`) rather than requiring it to be a specific direct child in a specific position
- Also flips the default collapse-trigger icon direction on `'right'` (a right-placed `Sider` opens/closes toward the opposite side from a left one); `reverseArrow` still layers on top as a manual override either way

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output:
  - `placement="left"` (default): no `order-last` class, trigger icon unchanged
  - `placement="right"`: `order-last` present, trigger icon direction flipped

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for placement=left/right (order class + icon direction)
- [ ] CI green