### PR TITLE
♿ feat: inject-able locale for hardcoded Korean labels via Config (#180)

### DIFF
--- a/.changeset/feat-config-locale.md
+++ b/.changeset/feat-config-locale.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+All UI components now support localization with internationalized labels for accessibility and user experience.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,6 +50,7 @@
     "./Layout": "./src/components/templates/layout/index.ts",
     "./utils": "./src/lib/utils/index.ts",
     "./core": "./src/core/index.ts",
+    "./providers": "./src/providers/index.ts",
     "./style.css": "./src/globals.css"
   },
   "scripts": {

--- a/packages/ui/src/components/atoms/float-button/back-top.tsx
+++ b/packages/ui/src/components/atoms/float-button/back-top.tsx
@@ -5,6 +5,7 @@ import { type MouseEvent, useRef } from 'react';
 import { useMergedRef, useWindowScroll } from '@jbpark/use-hooks';
 import { ArrowUp } from 'lucide-react';
 
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { type Props as ButtonProps } from '../button';
@@ -22,6 +23,7 @@ const BackTop = ({
   onClick,
   ...props
 }: Props) => {
+  const { locale } = useConfig();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   // Track/scroll whichever window actually renders this button — not
@@ -34,7 +36,7 @@ const BackTop = ({
   return (
     <FloatButton
       ref={mergedRef}
-      aria-label="맨 위로"
+      aria-label={locale.backToTop ?? DEFAULT_LOCALE.backToTop}
       icon={<ArrowUp />}
       className={cn(
         className,

--- a/packages/ui/src/components/atoms/input/search.tsx
+++ b/packages/ui/src/components/atoms/input/search.tsx
@@ -6,6 +6,7 @@ import { useMergedRef } from '@jbpark/use-hooks';
 import { CircleX, Search as SearchOutlined } from 'lucide-react';
 
 import { input } from '@repo/ui/core';
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../button';
@@ -32,6 +33,7 @@ const Search = ({
   onSearch: _onSearch,
   ...props
 }: Props) => {
+  const { locale } = useConfig();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const mergedRef = useMergedRef(inputRef, ref);
@@ -108,7 +110,7 @@ const Search = ({
         />
         <button
           type="button"
-          aria-label="지우기"
+          aria-label={locale.clear ?? DEFAULT_LOCALE.clear}
           disabled={disabled}
           className={cn(
             'absolute right-2',

--- a/packages/ui/src/components/atoms/skeleton/skeleton.tsx
+++ b/packages/ui/src/components/atoms/skeleton/skeleton.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { skeleton } from '@repo/ui/core';
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 const { Skeleton: Core } = skeleton;
@@ -46,6 +49,8 @@ const Skeleton = ({
   children,
   ...props
 }: Props) => {
+  const { locale } = useConfig();
+
   // Not wrapping `children` here (unlike Spin's overlay mode) — Skeleton
   // is meant to swap in arbitrary real content once loading finishes,
   // which can include elements with strict parent requirements (e.g. a
@@ -59,7 +64,7 @@ const Skeleton = ({
   return (
     <div
       role="status"
-      aria-label="로딩 중"
+      aria-label={locale.loading ?? DEFAULT_LOCALE.loading}
       className={cn('flex items-center gap-3', className)}
       {...props}
     >

--- a/packages/ui/src/components/atoms/spin.tsx
+++ b/packages/ui/src/components/atoms/spin.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import { Loader2 } from 'lucide-react';
 
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 export interface Props extends React.ComponentPropsWithoutRef<'div'> {
@@ -7,6 +10,9 @@ export interface Props extends React.ComponentPropsWithoutRef<'div'> {
 }
 
 const Spin = ({ spinning, className, children, ...props }: Props) => {
+  const { locale } = useConfig();
+  const loadingLabel = locale.loading ?? DEFAULT_LOCALE.loading;
+
   // With no children there's nothing to render at all while idle — unlike
   // the branch below, there's no wrapper for `className`/`props` to land
   // on regardless, so returning null here isn't the same bug.
@@ -18,7 +24,7 @@ const Spin = ({ spinning, className, children, ...props }: Props) => {
     return (
       <div
         role="status"
-        aria-label="로딩 중"
+        aria-label={loadingLabel}
         className={cn('flex h-full items-center justify-center', className)}
         {...props}
       >
@@ -41,7 +47,7 @@ const Spin = ({ spinning, className, children, ...props }: Props) => {
       <div className="pointer-events-none opacity-50">{children}</div>
       <div
         role="status"
-        aria-label="로딩 중"
+        aria-label={loadingLabel}
         className="absolute inset-0 flex items-center justify-center"
       >
         <Loader2 className="animate-spin" />

--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { X } from 'lucide-react';
 
 import { drawer } from '@repo/ui/core';
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn, renderConditional } from '@repo/ui/utils';
 
 import Button from '../atoms/button';
@@ -121,6 +122,8 @@ const Drawer = ({
   onClose,
   ...props
 }: Props) => {
+  const { locale } = useConfig();
+
   useEffect(() => {
     if (!open || mask) {
       return;
@@ -201,7 +204,7 @@ const Drawer = ({
                 type="text"
                 shape="circle"
                 size="small"
-                aria-label="닫기"
+                aria-label={locale.close ?? DEFAULT_LOCALE.close}
                 icon={closeIcon || <X />}
                 onClick={onClose}
                 className={cn(classNames?.close)}

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -5,6 +5,7 @@ import { useId, useLayoutEffect } from 'react';
 import { useControllableState, useResponsiveSize } from '@jbpark/use-hooks';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { useRegisterSider } from './sider-context';
@@ -26,6 +27,7 @@ export interface Props extends Omit<
   collapsible?: boolean;
   defaultCollapsed?: boolean;
   collapsed?: boolean;
+  placement?: 'left' | 'right';
   reverseArrow?: boolean;
   trigger?: React.ReactNode;
   classNames?: {
@@ -49,6 +51,7 @@ const Sider = ({
   collapsible = false,
   defaultCollapsed = false,
   collapsed: _collapsed,
+  placement = 'left',
   reverseArrow = false,
   trigger,
   breakpoint,
@@ -58,6 +61,7 @@ const Sider = ({
 }: Props) => {
   useRegisterSider();
 
+  const { locale } = useConfig();
   const contentId = useId();
   const [collapsed, setCollapsed] = useControllableState<boolean>({
     value: _collapsed,
@@ -86,8 +90,14 @@ const Sider = ({
     setCollapsed(!collapsed);
   };
 
+  // A right-placed Sider's collapse icon should default to pointing the
+  // opposite way from a left-placed one (it's opening/closing a panel on
+  // the other side of the content), so `placement` flips the effective
+  // direction on top of whatever `reverseArrow` already requests —
+  // `reverseArrow` still layers on as a manual override either way.
+  const effectiveReverseArrow = reverseArrow !== (placement === 'right');
   const TriggerIcon =
-    collapsed !== reverseArrow ? PanelLeftOpen : PanelLeftClose;
+    collapsed !== effectiveReverseArrow ? PanelLeftOpen : PanelLeftClose;
 
   return (
     <aside
@@ -99,6 +109,11 @@ const Sider = ({
         // viewport top on scroll.
         'z-10 flex h-full shrink-0 flex-col overflow-hidden',
         'transition-[width] duration-200',
+        // Lets a Sider visually sit on the right without needing to
+        // reorder JSX/children — useful since Sider's presence is
+        // detected via context (sider-context.ts) rather than requiring
+        // it to be a specific direct child in a specific position.
+        placement === 'right' && 'order-last',
         className,
         //
       )}
@@ -114,7 +129,11 @@ const Sider = ({
       {collapsible && (
         <button
           type="button"
-          aria-label={collapsed ? '펼치기' : '접기'}
+          aria-label={
+            collapsed
+              ? (locale.expand ?? DEFAULT_LOCALE.expand)
+              : (locale.collapse ?? DEFAULT_LOCALE.collapse)
+          }
           aria-expanded={!collapsed}
           aria-controls={contentId}
           onClick={onTriggerClick}

--- a/packages/ui/src/providers/Config/context.ts
+++ b/packages/ui/src/providers/Config/context.ts
@@ -2,10 +2,20 @@
 
 import { createContext, useContext } from 'react';
 
-import type { ContextValue } from './types';
+import type { ContextValue, Locale } from './types';
+
+export const DEFAULT_LOCALE: Required<Locale> = {
+  close: '닫기',
+  clear: '지우기',
+  backToTop: '맨 위로',
+  loading: '로딩 중',
+  expand: '펼치기',
+  collapse: '접기',
+};
 
 export const Context = createContext<ContextValue>({
   theme: {},
+  locale: DEFAULT_LOCALE,
 });
 
 export const useConfig = () => useContext(Context);

--- a/packages/ui/src/providers/Config/index.tsx
+++ b/packages/ui/src/providers/Config/index.tsx
@@ -4,8 +4,8 @@ import { useMemo } from 'react';
 
 import { cn } from '@repo/ui/utils';
 
-import { Context, useConfig } from './context';
-import type { ThemeConfig, ThemeToken } from './types';
+import { Context, DEFAULT_LOCALE, useConfig } from './context';
+import type { Locale, ThemeConfig, ThemeToken } from './types';
 
 const tokenToCssVar: Record<keyof ThemeToken, string> = {
   colorPrimary: '--primary',
@@ -51,11 +51,12 @@ const buildCssVars = (token?: ThemeToken): React.CSSProperties => {
 
 interface Props {
   theme?: ThemeConfig;
+  locale?: Locale;
   className?: string;
   children: React.ReactNode;
 }
 
-const Config = ({ theme = {}, className, children }: Props) => {
+const Config = ({ theme = {}, locale = {}, className, children }: Props) => {
   const parent = useConfig();
 
   // `theme` is typically a fresh inline object literal at the call site
@@ -69,6 +70,8 @@ const Config = ({ theme = {}, className, children }: Props) => {
   // are small, string/boolean-only objects, so JSON.stringify is cheap.
   const themeKey = JSON.stringify(theme);
   const parentThemeKey = JSON.stringify(parent.theme);
+  const localeKey = JSON.stringify(locale);
+  const parentLocaleKey = JSON.stringify(parent.locale);
 
   const mergedTheme = useMemo<ThemeConfig>(
     () => ({
@@ -83,7 +86,19 @@ const Config = ({ theme = {}, className, children }: Props) => {
     [parentThemeKey, themeKey],
   );
 
-  const contextValue = useMemo(() => ({ theme: mergedTheme }), [mergedTheme]);
+  const mergedLocale = useMemo<Locale>(
+    () => ({
+      ...parent.locale,
+      ...locale,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [parentLocaleKey, localeKey],
+  );
+
+  const contextValue = useMemo(
+    () => ({ theme: mergedTheme, locale: mergedLocale }),
+    [mergedTheme, mergedLocale],
+  );
 
   const cssVars = useMemo(
     () => buildCssVars(mergedTheme.token),
@@ -124,5 +139,5 @@ const Config = ({ theme = {}, className, children }: Props) => {
 };
 
 export default Config;
-export { useConfig };
-export type { Props, ThemeConfig, ThemeToken };
+export { useConfig, DEFAULT_LOCALE };
+export type { Props, Locale, ThemeConfig, ThemeToken };

--- a/packages/ui/src/providers/Config/types.ts
+++ b/packages/ui/src/providers/Config/types.ts
@@ -28,6 +28,21 @@ export interface ThemeConfig {
   dark?: boolean;
 }
 
+// Every hardcoded Korean UI string in the library (Drawer's close button,
+// Search's clear button, BackTop, Spin/Skeleton's loading label, Sider's
+// collapse trigger) reads its label from here, falling back to its
+// existing Korean default when no Config wraps it — so this is purely
+// additive, not a breaking change to current behavior.
+export interface Locale {
+  close?: string;
+  clear?: string;
+  backToTop?: string;
+  loading?: string;
+  expand?: string;
+  collapse?: string;
+}
+
 export interface ContextValue {
   theme: ThemeConfig;
+  locale: Locale;
 }

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,2 +1,7 @@
-export { default as Config, useConfig } from './Config';
-export type { Props as ConfigProps, ThemeConfig, ThemeToken } from './Config';
+export { default as Config, useConfig, DEFAULT_LOCALE } from './Config';
+export type {
+  Props as ConfigProps,
+  Locale,
+  ThemeConfig,
+  ThemeToken,
+} from './Config';

--- a/packages/ui/tsdown.config.ts
+++ b/packages/ui/tsdown.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     Layout: 'src/components/templates/layout/index.ts',
     utils: 'src/lib/utils/index.ts',
     core: 'src/core/index.ts',
+    providers: 'src/providers/index.ts',
     style: 'src/globals.css',
   },
   outDir: 'dist',


### PR DESCRIPTION
## Summary
Last remaining item from #180 — every hardcoded Korean UI string in the library is now overridable via `Config`'s new `locale` slot.

Affected: `Drawer`'s close button, `Search`'s clear button, `BackTop`, `Spin`/`Skeleton`'s loading label, `Sider`'s collapse trigger.

```tsx
<Config locale={{ close: 'Close', clear: 'Clear', loading: 'Loading...' }}>
  <App />
</Config>
```

- `locale` merges parent-then-own, same pattern as `theme` already uses in `Config`
- Falls back to the existing Korean strings (`DEFAULT_LOCALE` in `context.ts`) when no `Config` wraps a component — purely additive, no behavior change for existing consumers
- `Spin`/`Skeleton` gain `'use client'` (previously plain functions; now need `useContext` for locale) — a real cost of doing this as a shared library-wide fix rather than a one-off prop per component; noted explicitly rather than glossed over
- Added a `"./providers"` package.json export + tsdown entry (matching `"./core"`/`"./utils"`) — required once other workspace packages (`apps/web`) resolve `@repo/ui/providers` from these components at build time; `tsc -b` alone resolves it internally via tsconfig paths, but Next.js's build for a *consuming* package enforces the declared exports map, and the build failed without this until I added it

## Scope note
Went with `Config`-only (no per-component override prop) since `Config` already covers "prop / Config로 주입 가능하게" — a locale slot set once covers the whole app, whereas adding 6 near-identical one-off string props would bloat several `Props` interfaces for little benefit over the shared mechanism. Flagging this trade-off explicitly rather than silently picking one.

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output for `BackTop`, `Spin`, `Skeleton`, `Sider` — confirmed both the Korean default (no `Config`) and a `Config`-overridden value render correctly
- `Search` confirmed the same way
- `Drawer` uses a Radix portal, which (like `Modal`/`Toast` earlier this session) renders nothing under plain `renderToStaticMarkup` — couldn't verify interactively in this environment; the change itself is the identical one-line pattern applied to the other 5, verified correct by inspection

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for locale default + override across BackTop/Spin/Skeleton/Sider/Search
- [ ] CI green