### PR TITLE
✨ feat: add Container component (#180)

### DIFF
--- a/.changeset/feat-container-component.md
+++ b/.changeset/feat-container-component.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Use the reusable Container component to standardize the mx-auto max-w-7xl px-4 wrapper for app content.

--- a/packages/ui/src/components/templates/container.tsx
+++ b/packages/ui/src/components/templates/container.tsx
@@ -1,0 +1,72 @@
+import { Slot } from '@radix-ui/react-slot';
+
+import { cn } from '@repo/ui/utils';
+
+type MaxWidth =
+  | '3xs'
+  | '2xs'
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | '2xl'
+  | '3xl'
+  | '4xl'
+  | '5xl'
+  | '6xl'
+  | '7xl'
+  | 'full'
+  | 'none';
+
+const MAX_WIDTH_CLASSES: Record<MaxWidth, string> = {
+  '3xs': 'max-w-3xs',
+  '2xs': 'max-w-2xs',
+  xs: 'max-w-xs',
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+  '2xl': 'max-w-2xl',
+  '3xl': 'max-w-3xl',
+  '4xl': 'max-w-4xl',
+  '5xl': 'max-w-5xl',
+  '6xl': 'max-w-6xl',
+  '7xl': 'max-w-7xl',
+  full: 'max-w-full',
+  none: 'max-w-none',
+};
+
+export interface Props extends React.ComponentProps<'div'> {
+  maxWidth?: MaxWidth;
+  padded?: boolean;
+  asChild?: boolean;
+}
+
+// Standardizes the `mx-auto max-w-7xl px-4` wrapper every app in this
+// monorepo was rewriting by hand inside Content — one place to change the
+// page's content width/gutters instead of N call sites.
+const Container = ({
+  className,
+  maxWidth = '7xl',
+  padded = true,
+  asChild = false,
+  ...props
+}: Props) => {
+  const Comp = asChild ? Slot : 'div';
+
+  return (
+    <Comp
+      className={cn(
+        'mx-auto w-full',
+        MAX_WIDTH_CLASSES[maxWidth],
+        padded && 'px-4 sm:px-6 lg:px-8',
+        className,
+        //
+      )}
+      {...props}
+    />
+  );
+};
+
+export default Container;

--- a/packages/ui/src/components/templates/index.ts
+++ b/packages/ui/src/components/templates/index.ts
@@ -6,3 +6,5 @@ export type {
   HeaderProps,
   SiderProps,
 } from './layout';
+export { default as Container } from './container';
+export type { Props as ContainerProps } from './container';


### PR DESCRIPTION
## Summary
First of 5 new-component proposals from #180 (item E) — `Container`.

> `max-width` + 가운데 정렬 + breakpoint 별 패딩을 표준화하는 래퍼. 지금은 `Content` 안에서 각 앱이 매번 `mx-auto max-w-7xl px-4` 를 반복해야 한다.

- `maxWidth` spans Tailwind's full container scale (`3xs`..`7xl`, `full`, `none`), default `'7xl'` — the exact value the audit called out
- `padded` (default `true`) adds the standard responsive gutters `px-4 sm:px-6 lg:px-8`
- `asChild` (Radix `Slot`, same pattern as `Content`/`Button`/`Badge`) lets callers render as a different element (e.g. `<section>`) instead of `<div>`

Exported from `templates` alongside `Layout`/`Content`/etc., available via `@repo/ui`.

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- `check-dynamic-classes` guard passes (maxWidth→class lookup is a static `Record`, not interpolated)
- SSR-rendered via `react-dom/server` against the built output: default, `maxWidth="lg" padded={false}`, and `asChild` all produce the expected classes/tag

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm --filter @repo/ui check-dynamic-classes`
- [x] `pnpm build`
- [x] SSR render check for default/maxWidth/padded/asChild variants
- [ ] CI green