### PR TITLE
✨ feat: add Empty component (#180)

### DIFF
--- a/.changeset/feat-empty-component.md
+++ b/.changeset/feat-empty-component.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add a reusable Empty component for displaying placeholder content when no data is available.

--- a/packages/ui/src/components/templates/empty.tsx
+++ b/packages/ui/src/components/templates/empty.tsx
@@ -1,0 +1,47 @@
+import { Inbox } from 'lucide-react';
+
+import { cn } from '@repo/ui/utils';
+
+export interface Props extends Omit<React.ComponentProps<'div'>, 'title'> {
+  icon?: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+// The counterpart List's `empty` prop was asking for — List/Upload/Swiper
+// each render arbitrary content for their empty state today with nothing
+// in the library actually meant to go there. Pairs with Skeleton the same
+// way Skeleton pairs with real content: one placeholder for "nothing
+// loaded yet", one for "loaded, and there's nothing".
+const Empty = ({
+  icon,
+  title,
+  description = 'No data',
+  action,
+  className,
+  ...props
+}: Props) => {
+  return (
+    <div
+      role="status"
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 py-12 text-center',
+        className,
+        //
+      )}
+      {...props}
+    >
+      <div className="text-muted-foreground [&_svg]:size-12">
+        {icon ?? <Inbox />}
+      </div>
+      {title && <p className="text-sm font-medium">{title}</p>}
+      {description && (
+        <p className="text-muted-foreground text-sm">{description}</p>
+      )}
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  );
+};
+
+export default Empty;

--- a/packages/ui/src/components/templates/index.ts
+++ b/packages/ui/src/components/templates/index.ts
@@ -6,3 +6,5 @@ export type {
   HeaderProps,
   SiderProps,
 } from './layout';
+export { default as Empty } from './empty';
+export type { Props as EmptyProps } from './empty';


### PR DESCRIPTION
## Summary
Second of 5 new-component proposals from #180 (item F) — `Empty`.

> `List` 가 `empty?: React.ReactNode` prop 을 받는데 **정작 거기에 넣을 컴포넌트가 라이브러리에 없다.** 아이콘 + 설명 + 액션 버튼으로 구성된 `Empty` 를 추가하면 `List` / `Upload` / `Swiper` 의 빈 상태를 통일할 수 있다. `Skeleton`(로딩)과 짝이 되는 조각이다.

```tsx
<List data={[]} empty={<Empty description="No results found" action={<Button>Retry</Button>} />} />
```

- `icon` (default: `lucide-react`'s `Inbox`), `title`, `description` (default `"No data"`), `action` — all optional
- `title` conflicts with the native `<div title>` tooltip attribute, so `Props` `Omit`s it from `React.ComponentProps<'div'>` before redeclaring as `React.ReactNode`

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output: default (icon + "No data") and full (title/description/action) both render correctly

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for default and full-prop variants
- [ ] CI green