### PR TITLE
✨ feat: add Result component (#180)

### DIFF
--- a/.changeset/feat-result-component.md
+++ b/.changeset/feat-result-component.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add a Result component for full-page success/failure/404/403 state screens.

--- a/packages/ui/src/components/templates/index.ts
+++ b/packages/ui/src/components/templates/index.ts
@@ -6,3 +6,5 @@ export type {
   HeaderProps,
   SiderProps,
 } from './layout';
+export { default as Result } from './result';
+export type { Props as ResultProps } from './result';

--- a/packages/ui/src/components/templates/result.tsx
+++ b/packages/ui/src/components/templates/result.tsx
@@ -1,0 +1,71 @@
+import {
+  Check,
+  FileQuestion,
+  Info,
+  OctagonAlert,
+  OctagonX,
+  ServerCrash,
+  ShieldAlert,
+} from 'lucide-react';
+
+import { cn } from '@repo/ui/utils';
+
+type Status = 'success' | 'error' | 'info' | 'warning' | '404' | '403' | '500';
+
+// Reuses Modal's exact STATIC_ICONS set (Check/OctagonX/Info/OctagonAlert,
+// same colors) for the 4 statuses they share, so a Result page matches the
+// tone of a Modal.success()/error()/etc a user may have just seen.
+const STATUS_ICONS: Record<Status, React.ReactNode> = {
+  success: <Check className="text-green-400" />,
+  error: <OctagonX className="text-red-400" />,
+  info: <Info className="text-blue-400" />,
+  warning: <OctagonAlert className="text-yellow-400" />,
+  '404': <FileQuestion className="text-muted-foreground" />,
+  '403': <ShieldAlert className="text-muted-foreground" />,
+  '500': <ServerCrash className="text-muted-foreground" />,
+};
+
+export interface Props extends Omit<React.ComponentProps<'div'>, 'title'> {
+  status?: Status;
+  icon?: React.ReactNode;
+  title?: React.ReactNode;
+  subTitle?: React.ReactNode;
+  extra?: React.ReactNode;
+}
+
+// Full-page success/failure/404/403 state screen — Empty's larger,
+// more prominent sibling (Empty says "nothing here yet" inline within a
+// list/table; Result says "here's what happened" for an entire page/view).
+const Result = ({
+  status = 'info',
+  icon,
+  title,
+  subTitle,
+  extra,
+  className,
+  children,
+  ...props
+}: Props) => {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-2 py-16 text-center',
+        className,
+        //
+      )}
+      {...props}
+    >
+      <div className="mb-2 [&_svg]:size-16">{icon ?? STATUS_ICONS[status]}</div>
+      {title && <p className="text-xl font-medium">{title}</p>}
+      {subTitle && <p className="text-muted-foreground text-sm">{subTitle}</p>}
+      {extra && (
+        <div className="mt-4 flex items-center justify-center gap-2">
+          {extra}
+        </div>
+      )}
+      {children && <div className="mt-4 w-full">{children}</div>}
+    </div>
+  );
+};
+
+export default Result;


### PR DESCRIPTION
## Summary
Third of 5 new-component proposals from #180 (item G) — `Result`.

> 성공/실패/404/403 전면 상태 화면. `Modal` 의 static 아이콘 세트(`STATIC_ICONS`)와 톤을 맞춰 재사용할 수 있다.

```tsx
<Result status="404" title="Page not found" subTitle="Sorry, the page you visited does not exist." extra={<Button>Back Home</Button>} />
```

- `status`: `'success' | 'error' | 'info' | 'warning' | '404' | '403' | '500'`
- Reuses Modal's exact `STATIC_ICONS` set (`Check`/`OctagonX`/`Info`/`OctagonAlert`, same colors) for the 4 statuses they share, so a `Result` page matches the tone of a `Modal.success()`/`error()`/etc a user may have just seen
- `404`/`403`/`500` get distinct neutral-toned icons (`FileQuestion`/`ShieldAlert`/`ServerCrash`) since those aren't alert-toned states the way success/error/warning are
- `icon`/`title`/`subTitle`/`extra`/`children` all optional and overridable

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output: `status="success"` and `status="404"` both render the expected icon/title/subtitle/extra

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for success/404 status variants
- [ ] CI green