### PR TITLE
✨ feat: add PageHeader component (#180)

### DIFF
--- a/.changeset/feat-page-header-component.md
+++ b/.changeset/feat-page-header-component.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add a reusable PageHeader component for displaying title, subtitle, and extra content with a back button.

--- a/packages/ui/src/components/templates/index.ts
+++ b/packages/ui/src/components/templates/index.ts
@@ -6,3 +6,5 @@ export type {
   HeaderProps,
   SiderProps,
 } from './layout';
+export { default as PageHeader } from './page-header';
+export type { Props as PageHeaderProps } from './page-header';

--- a/packages/ui/src/components/templates/page-header.tsx
+++ b/packages/ui/src/components/templates/page-header.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+
+import { cn, renderConditional } from '@repo/ui/utils';
+
+import Button from '../atoms/button';
+
+export interface Props extends Omit<React.ComponentProps<'div'>, 'title'> {
+  title?: React.ReactNode;
+  subTitle?: React.ReactNode;
+  extra?: React.ReactNode;
+  backIcon?: React.ReactNode;
+  onBack?: () => void;
+  classNames?: {
+    back?: string;
+    title?: string;
+    subTitle?: string;
+    extra?: string;
+  };
+}
+
+// Title + back button + extra action area — same shape as Drawer's header
+// (title/extra/closable), which this borrows the layout from wholesale;
+// PageHeader just swaps Drawer's close button for a back button.
+//
+// TODO: the back button's aria-label ("뒤로가기") is hardcoded the same
+// way every other component's was before #210 (Config's `locale` slot)
+// existed. Wire it up to `useConfig().locale` once that PR merges, adding
+// a `back` key to Locale/DEFAULT_LOCALE — left out here to avoid this PR
+// depending on an unmerged one.
+const PageHeader = ({
+  title,
+  subTitle,
+  extra,
+  backIcon,
+  onBack,
+  className,
+  classNames,
+  children,
+  ...props
+}: Props) => {
+  return (
+    <div className={cn('flex flex-col gap-2', className)} {...props}>
+      <div className="flex items-start gap-2">
+        {onBack && (
+          <Button
+            type="text"
+            shape="circle"
+            size="small"
+            aria-label="뒤로가기"
+            icon={backIcon || <ArrowLeft />}
+            onClick={onBack}
+            className={cn(classNames?.back)}
+          />
+        )}
+        <div className="flex flex-1 items-start justify-between gap-2">
+          <div className="flex flex-col gap-0.5">
+            {title && (
+              <p className={cn('text-lg font-medium', classNames?.title)}>
+                {title}
+              </p>
+            )}
+            {subTitle && (
+              <p
+                className={cn(
+                  'text-muted-foreground text-sm',
+                  classNames?.subTitle,
+                )}
+              >
+                {subTitle}
+              </p>
+            )}
+          </div>
+          {renderConditional(extra, v => (
+            <div className={cn('shrink-0', classNames?.extra)}>{v}</div>
+          ))}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default PageHeader;


### PR DESCRIPTION
## Summary
Fourth of 5 new-component proposals from #180 (item H) — `PageHeader`.

> 제목 + 뒤로가기 + `extra` 액션 영역. `Drawer` 헤더(`title` / `extra` / `closable`)와 구조가 거의 같아 패턴을 그대로 옮길 수 있다.

```tsx
<PageHeader title="Order #1234" subTitle="Placed 2 days ago" onBack={() => router.back()} extra={<Button>Edit</Button>} />
```

- `title`/`subTitle`/`extra`/`onBack`/`backIcon` — same layout Drawer's header already uses (title/extra/back-instead-of-close), reused wholesale
- `children` renders below the header row (e.g. tabs, filters)

## Known follow-up
The back button's aria-label (`"뒤로가기"`) is hardcoded the same way every other component's was before #210 (Config's `locale` slot). Left as a `TODO` in the source rather than making this PR depend on an unmerged one — once #210 merges, this should get a `back` key added to `Locale`/`DEFAULT_LOCALE` the same way `Sider`/`Drawer`/etc. did.

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output: title-only (no back button) and full (back/subtitle/extra) both render correctly

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check for title-only and full-prop variants
- [ ] CI green