### PR TITLE
✨ feat: add Row/Col grid system (#180)

### DIFF
--- a/.changeset/feat-grid-component.md
+++ b/.changeset/feat-grid-component.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add grid layout components, including Row and Col, for building responsive UI templates.

--- a/packages/ui/src/components/templates/grid/col.tsx
+++ b/packages/ui/src/components/templates/grid/col.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { cn } from '@repo/ui/utils';
+
+import { type Breakpoint, useRowContext } from './row-context';
+
+const TOTAL_COLUMNS = 24;
+
+const BREAKPOINT_ORDER: Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'];
+
+interface ResponsiveColSpan {
+  span?: number;
+  offset?: number;
+}
+
+type ColSpanProp = number | ResponsiveColSpan;
+
+export interface Props extends React.ComponentProps<'div'> {
+  span?: number;
+  offset?: number;
+  xs?: ColSpanProp;
+  sm?: ColSpanProp;
+  md?: ColSpanProp;
+  lg?: ColSpanProp;
+  xl?: ColSpanProp;
+  '2xl'?: ColSpanProp;
+}
+
+const resolveColSpan = (value: ColSpanProp | undefined) =>
+  typeof value === 'number' ? { span: value } : value;
+
+// 24-column system (matches Ant Design's Row/Col, a familiar mental model
+// for anyone coming from it) implemented with plain percentage widths
+// rather than Tailwind's col-span-* utilities — those utilities need a
+// literal, statically-scannable class per (breakpoint, span) combination,
+// and 6 breakpoints x 24 spans is 144 combinations, most of which would
+// never be used. Percentage math scales to any span/breakpoint
+// combination with one code path instead.
+const Col = ({
+  span = TOTAL_COLUMNS,
+  offset = 0,
+  xs,
+  sm,
+  md,
+  lg,
+  xl,
+  '2xl': xxl,
+  className,
+  style,
+  children,
+  ...props
+}: Props) => {
+  const { gutterX, breakpoint } = useRowContext();
+
+  const responsiveProps: Partial<Record<Breakpoint, ColSpanProp | undefined>> =
+    { xs, sm, md, lg, xl, '2xl': xxl };
+
+  let effectiveSpan = span;
+  let effectiveOffset = offset;
+
+  // Mobile-first cascade: walk breakpoints up to (and including) the
+  // current one, letting each defined prop override the last — so
+  // `<Col span={24} md={12} />` is 24 below md and 12 from md upward, with
+  // no need to also specify lg/xl/2xl for the value to keep applying.
+  for (const bp of BREAKPOINT_ORDER) {
+    if (BREAKPOINT_ORDER.indexOf(bp) > BREAKPOINT_ORDER.indexOf(breakpoint)) {
+      break;
+    }
+
+    const resolved = resolveColSpan(responsiveProps[bp]);
+
+    if (resolved?.span !== undefined) {
+      effectiveSpan = resolved.span;
+    }
+    if (resolved?.offset !== undefined) {
+      effectiveOffset = resolved.offset;
+    }
+  }
+
+  const widthPercent = (effectiveSpan / TOTAL_COLUMNS) * 100;
+  const offsetPercent = (effectiveOffset / TOTAL_COLUMNS) * 100;
+
+  return (
+    <div
+      className={cn('box-border shrink-0 grow-0', className)}
+      style={{
+        flexBasis: `${widthPercent}%`,
+        maxWidth: `${widthPercent}%`,
+        marginLeft: offsetPercent ? `${offsetPercent}%` : undefined,
+        paddingLeft: gutterX ? gutterX / 2 : undefined,
+        paddingRight: gutterX ? gutterX / 2 : undefined,
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Col;

--- a/packages/ui/src/components/templates/grid/index.ts
+++ b/packages/ui/src/components/templates/grid/index.ts
@@ -1,0 +1,4 @@
+export { default as Row } from './row';
+export type { Props as RowProps } from './row';
+export { default as Col } from './col';
+export type { Props as ColProps } from './col';

--- a/packages/ui/src/components/templates/grid/row-context.ts
+++ b/packages/ui/src/components/templates/grid/row-context.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+export interface RowContextValue {
+  gutterX: number;
+  gutterY: number;
+  breakpoint: Breakpoint;
+}
+
+// Defaults assume Col is used without a Row (not the intended usage, but
+// shouldn't crash) — 'xs' matches useResponsiveSize's own SSR-safe initial
+// guess (measures 0 width before mount), same mobile-first default Sider's
+// breakpoint feature already relies on.
+export const RowContext = createContext<RowContextValue>({
+  gutterX: 0,
+  gutterY: 0,
+  breakpoint: 'xs',
+});
+
+export const useRowContext = () => useContext(RowContext);

--- a/packages/ui/src/components/templates/grid/row.tsx
+++ b/packages/ui/src/components/templates/grid/row.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useResponsiveSize } from '@jbpark/use-hooks';
+
+import { cn } from '@repo/ui/utils';
+
+import { RowContext } from './row-context';
+
+const ALIGN_CLASSES = {
+  top: 'items-start',
+  middle: 'items-center',
+  bottom: 'items-end',
+  stretch: 'items-stretch',
+};
+
+const JUSTIFY_CLASSES = {
+  start: 'justify-start',
+  end: 'justify-end',
+  center: 'justify-center',
+  'space-around': 'justify-around',
+  'space-between': 'justify-between',
+  'space-evenly': 'justify-evenly',
+};
+
+export interface Props extends React.ComponentProps<'div'> {
+  gutter?: number | [number, number];
+  align?: keyof typeof ALIGN_CLASSES;
+  justify?: keyof typeof JUSTIFY_CLASSES;
+  wrap?: boolean;
+}
+
+// The breakpoint tier is resolved once here (not per-Col) so N columns
+// share a single resize listener instead of each mounting its own via
+// useResponsiveSize — matters once a grid has more than a couple Cols.
+const Row = ({
+  gutter = 0,
+  align,
+  justify,
+  wrap = true,
+  className,
+  style,
+  children,
+  ...props
+}: Props) => {
+  const [gutterX, gutterY] = Array.isArray(gutter) ? gutter : [gutter, 0];
+  const { breakpoint } = useResponsiveSize({ viewport: true });
+
+  const contextValue = useMemo(
+    () => ({ gutterX, gutterY, breakpoint: breakpoint.current }),
+    [gutterX, gutterY, breakpoint],
+  );
+
+  return (
+    <RowContext.Provider value={contextValue}>
+      <div
+        className={cn(
+          'flex',
+          wrap && 'flex-wrap',
+          align && ALIGN_CLASSES[align],
+          justify && JUSTIFY_CLASSES[justify],
+          className,
+          //
+        )}
+        style={{
+          // Negative margin + Col's matching padding is the classic
+          // gutter technique — unlike a plain `gap`, it doesn't break the
+          // percentage-width math when several Cols are meant to sum to
+          // exactly 100% of the row. Vertical gutter has no such
+          // constraint (it only affects spacing *between* wrapped rows),
+          // so it uses native `row-gap` directly.
+          marginLeft: gutterX ? -gutterX / 2 : undefined,
+          marginRight: gutterX ? -gutterX / 2 : undefined,
+          rowGap: gutterY || undefined,
+          ...style,
+        }}
+        {...props}
+      >
+        {children}
+      </div>
+    </RowContext.Provider>
+  );
+};
+
+export default Row;

--- a/packages/ui/src/components/templates/index.ts
+++ b/packages/ui/src/components/templates/index.ts
@@ -6,3 +6,5 @@ export type {
   HeaderProps,
   SiderProps,
 } from './layout';
+export { Row, Col } from './grid';
+export type { RowProps, ColProps } from './grid';


### PR DESCRIPTION
## Summary
Last of 5 new-component proposals from #180 (item D) — `Row`/`Col`.

> 현재 `Space` 는 1차원 간격만 다루고 `Space.grid` 는 `repeat(n, minmax(0,1fr))` 고정이라 반응형 컬럼 구성을 못 한다. 반응형 breakpoint 별 span 을 받는 `Grid` 는 templates 티어에서 가장 자주 필요한 조각이다.

```tsx
<Row gutter={16}>
  <Col span={24} md={12} lg={8}>...</Col>
  <Col span={24} md={12} lg={8}>...</Col>
  <Col span={24} md={24} lg={8}>...</Col>
</Row>
```

- 24-column system (matches Ant Design's `Row`/`Col`, a familiar mental model for anyone coming from it)
- `Col` accepts `span`/`offset` and per-breakpoint overrides (`xs`/`sm`/`md`/`lg`/`xl`/`2xl`, each a number or `{ span, offset }`), resolved mobile-first — `<Col span={24} md={12} />` is full-width below `md` and half from `md` upward, no need to also repeat the value at `lg`/`xl`/`2xl`
- `Row` accepts `gutter` (`number | [horizontal, vertical]`), `align`, `justify`, `wrap`

## Implementation notes
- Uses plain percentage widths (inline `style`) rather than Tailwind's `col-span-*` utilities — those need a literal, statically-scannable class per `(breakpoint, span)` combination, and 6 breakpoints × 24 spans is 144 combinations, most of which would never be used. `check-dynamic-classes` guard still passes since no class strings are constructed dynamically anywhere — the responsive part isn't Tailwind classes at all.
- Breakpoint resolution reuses `@jbpark/use-hooks`'s `useResponsiveSize` — the exact same hook already backing `Sider`'s `breakpoint` prop (#207) — called **once** in `Row` and threaded to every `Col` via context, instead of each `Col` mounting its own resize listener.
- Horizontal gutter uses the classic negative-margin-on-`Row` + padding-on-`Col` technique (not `gap`), since `gap` breaks the percentage math once several `Col`s are meant to sum to exactly 100% of the row. Vertical gutter has no such constraint and uses native `row-gap` directly.

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- `check-dynamic-classes` guard passes
- SSR-rendered via `react-dom/server` against the built output:
  - mobile-first cascade (`span=24 md=12` renders at 100% width under SSR's xs-tier guess, matching the hook's own SSR-safe fallback — same tradeoff already accepted for `Sider`'s `breakpoint`)
  - `offset` renders the correct `margin-left` percentage
  - `align`/`justify` apply the correct flex classes
- Could not exercise an actual window resize (crossing into `md`/`lg`/etc.) interactively in this environment — reasoned through the cascade logic and hook behavior instead, same limitation as `Sider`'s `breakpoint` verification

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm --filter @repo/ui check-dynamic-classes`
- [x] `pnpm build`
- [x] SSR render check for span cascade, offset, align/justify
- [ ] CI green