### PR TITLE
🐛 fix: portal-rendered components now inherit Config's theme (#181)

### DIFF
--- a/.changeset/fix-portal-theme-container.md
+++ b/.changeset/fix-portal-theme-container.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+All portal-based primitives (Dialog, Drawer, Popover, Select) now inherit their container from the nearest Config, allowing them to be themed and dark-mode aware.

--- a/packages/ui/src/core/dialog.tsx
+++ b/packages/ui/src/core/dialog.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { XIcon } from 'lucide-react';
 
+import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../components/atoms/button';
@@ -67,6 +68,9 @@ function DialogContent({
   container,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & CustomContentProps) {
+  const { getContainer } = useConfig();
+  const resolvedContainer = container ?? getContainer();
+
   const closeIcon = (
     <DialogPrimitive.Close
       data-slot="dialog-close"
@@ -84,7 +88,7 @@ function DialogContent({
   );
 
   return (
-    <DialogPortal data-slot="dialog-portal" container={container}>
+    <DialogPortal data-slot="dialog-portal" container={resolvedContainer}>
       <DialogOverlay className={cn(classNames?.mask)} />
       <DialogPrimitive.Content
         data-slot="dialog-content"

--- a/packages/ui/src/core/drawer.tsx
+++ b/packages/ui/src/core/drawer.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { Drawer as DrawerPrimitive } from 'vaul';
 
+import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 interface CustomProps {
@@ -12,12 +13,16 @@ interface CustomProps {
 
 function Drawer({
   draggable,
+  container,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root> & CustomProps) {
+  const { getContainer } = useConfig();
+
   return (
     <DrawerPrimitive.Root
       data-slot="drawer"
       handleOnly={!draggable}
+      container={container ?? getContainer()}
       {...props}
     />
   );

--- a/packages/ui/src/core/popover.tsx
+++ b/packages/ui/src/core/popover.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 
+import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 function Popover({
@@ -22,10 +23,15 @@ function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
+  container,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
+  container?: HTMLElement;
+}) {
+  const { getContainer } = useConfig();
+
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container ?? getContainer()}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}

--- a/packages/ui/src/core/select.tsx
+++ b/packages/ui/src/core/select.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import { Select as SelectPrimitive } from 'radix-ui';
 
+import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 function Select({
@@ -68,10 +69,15 @@ function SelectContent({
   children,
   position = 'item-aligned',
   align = 'center',
+  container,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Content> & {
+  container?: HTMLElement;
+}) {
+  const { getContainer } = useConfig();
+
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal container={container ?? getContainer()}>
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { cn } from '@repo/ui/utils';
 
@@ -52,12 +52,20 @@ const buildCssVars = (token?: ThemeToken): React.CSSProperties => {
 interface Props {
   theme?: ThemeConfig;
   locale?: Locale;
+  getContainer?: () => HTMLElement;
   className?: string;
   children: React.ReactNode;
 }
 
-const Config = ({ theme = {}, locale = {}, className, children }: Props) => {
+const Config = ({
+  theme = {},
+  locale = {},
+  getContainer,
+  className,
+  children,
+}: Props) => {
   const parent = useConfig();
+  const [wrapperEl, setWrapperEl] = useState<HTMLDivElement | null>(null);
 
   // `theme` is typically a fresh inline object literal at the call site
   // (and `parent.theme` inherits the same problem from its own Config
@@ -95,11 +103,6 @@ const Config = ({ theme = {}, locale = {}, className, children }: Props) => {
     [parentLocaleKey, localeKey],
   );
 
-  const contextValue = useMemo(
-    () => ({ theme: mergedTheme, locale: mergedLocale }),
-    [mergedTheme, mergedLocale],
-  );
-
   const cssVars = useMemo(
     () => buildCssVars(mergedTheme.token),
     [mergedTheme.token],
@@ -109,10 +112,38 @@ const Config = ({ theme = {}, locale = {}, className, children }: Props) => {
   const hasDarkMode = mergedTheme.dark !== undefined;
   const needsWrapper = hasCssVars || hasDarkMode || className;
 
+  // Resolution order: an explicit `getContainer` prop on this Config wins;
+  // otherwise, if this Config renders its own themed wrapper below, that's
+  // the default (portaled content appended into it still inherits its CSS
+  // custom properties and matches the `.dark` selector — `display:
+  // contents` only removes the element from the layout box tree, not from
+  // the DOM/cascade); otherwise defer to the parent Config's resolution,
+  // so an inner Config that only sets e.g. `locale` doesn't shadow an
+  // outer one's theme container.
+  const resolvedGetContainer = useCallback((): HTMLElement | undefined => {
+    if (getContainer) {
+      return getContainer();
+    }
+    if (needsWrapper && wrapperEl) {
+      return wrapperEl;
+    }
+    return parent.getContainer();
+  }, [getContainer, needsWrapper, wrapperEl, parent]);
+
+  const contextValue = useMemo(
+    () => ({
+      theme: mergedTheme,
+      locale: mergedLocale,
+      getContainer: resolvedGetContainer,
+    }),
+    [mergedTheme, mergedLocale, resolvedGetContainer],
+  );
+
   return (
     <Context.Provider value={contextValue}>
       {needsWrapper ? (
         <div
+          ref={setWrapperEl}
           className={cn(mergedTheme.dark && 'dark', className)}
           style={{
             ...(hasCssVars ? cssVars : undefined),

--- a/packages/ui/src/providers/config/context.ts
+++ b/packages/ui/src/providers/config/context.ts
@@ -16,6 +16,7 @@ export const DEFAULT_LOCALE: Required<Locale> = {
 export const Context = createContext<ContextValue>({
   theme: {},
   locale: DEFAULT_LOCALE,
+  getContainer: () => undefined,
 });
 
 export const useConfig = () => useContext(Context);

--- a/packages/ui/src/providers/config/types.ts
+++ b/packages/ui/src/providers/config/types.ts
@@ -45,4 +45,14 @@ export interface Locale {
 export interface ContextValue {
   theme: ThemeConfig;
   locale: Locale;
+  // Resolves, in order: an explicit `getContainer` prop on the nearest
+  // Config, that Config's own themed wrapper element (if it renders one —
+  // see needsWrapper in config.tsx), or the parent Config's resolution.
+  // Portal-based primitives (Dialog/Popover/Select/Drawer) call this as
+  // their default `container` so themed/dark-mode content they render
+  // (via Radix/vaul portals to document.body by default) stays a DOM
+  // descendant of the themed wrapper instead of an unthemed sibling.
+  // Returns undefined when nothing in the tree renders a wrapper, so
+  // callers fall back to their own normal default (document.body).
+  getContainer: () => HTMLElement | undefined;
 }


### PR DESCRIPTION
## Summary
Fixes the 🔴 bug deferred from #181 (item 1, deferred in PR #195) — also implements F2 (`getContainer`), since they're the same fix.

`Config` injects theme tokens/dark mode via inline style + a `.dark` class on its own wrapper div. Radix/vaul portal to `document.body` by default, so `Dialog`/`Drawer`/`Popover`/`Select` content became **siblings** of that wrapper instead of descendants — a themed app's modals/dropdowns silently kept the default theme (dark mode showed light popovers, custom token colors never applied). Affects `Popover` (and `ColorPicker`/`DatePicker`, which use it), `Select`'s dropdown, `Modal`(dialog)/`Drawer`.

## Why now, and why this approach
PR #195 identified two options and shipped neither, since both had real costs:
- Apply tokens to `document.documentElement` — flashes unthemed content until a client effect runs (no `document` during SSR)
- Thread a portal-container context through every primitive — the *correct* fix, but a real feature addition (`getContainer`, #181's F2), not bug-fix-sized

Went with the second, since #181 explicitly frames F2 as "위 버그 1번의 구조적 해법" (the structural fix for bug 1) — implementing them separately would mean redoing the same plumbing twice.

## What changed
- `Config` exposes `getContainer(): HTMLElement | undefined` via context, resolving to (in order): an explicit `getContainer` prop on the nearest `Config` → that `Config`'s own themed wrapper (if it renders one) → the parent `Config`'s resolution — so a nested `Config` that only overrides e.g. `locale` doesn't shadow an outer one's theme container
- Content portaled into the wrapper still inherits its CSS custom properties and matches `.dark` even though the wrapper has `display: contents` — that only removes it from the *layout box tree*, not the DOM tree or CSS cascade
- `core/dialog.tsx`'s `DialogContent` (already had a `container` prop) and `core/drawer.tsx`'s `Drawer` (vaul's `Root`, already forwarded `container` via `...props`) now default it from context instead of leaving it unset
- `core/popover.tsx`'s `PopoverContent` and `core/select.tsx`'s `SelectContent` gain a **new** `container` prop (neither had one before), same default
- `<Modal>`/`<Drawer>` (organisms, declarative) needed **no changes** — they already pass their own `container` prop straight through, so `undefined` flows to the new default automatically

## Known limitation
`Modal.info()`/`Toast.success()`/etc.'s *imperative* static API runs from plain module-level functions outside any component's render, so it can't call `useConfig()` reactively — still defaults to `document.body`, with its existing explicit `container` prop as the escape hatch. Only declarative `<Modal>`/`<Toast>` usage and the four core primitives above pick up the new automatic default.

## Verification
Could not exercise this interactively in a live browser in this environment (browser automation unavailable here, same limitation noted for `Modal`/`Toast` and `Sider`'s `breakpoint` prop earlier this project) — Radix/vaul portals render nothing under `renderToStaticMarkup` regardless of open state, since portaling needs a real `document` at mount time. Verified instead via:
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR render (both open and closed) of `Dialog`/`Popover`/`Select`/`Drawer` nested in a themed `Config` confirms no runtime crash from the new context/ref wiring
- Code-level review of the CSS mechanism (`display: contents` preserving custom-property inheritance and descendant-selector matching is standard, spec'd CSS behavior)

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR crash check for Dialog/Popover/Select/Drawer inside themed Config (open + closed)
- [ ] CI green
- [ ] Manual visual check recommended before relying on this in production (dark-mode Popover/Select/Modal actually picking up the theme) — flagged since it couldn't be verified live here