### PR TITLE
✨ feat: Config supports componentSize global default (#181)

### DIFF
--- a/.changeset/feat-config-component-size.md
+++ b/.changeset/feat-config-component-size.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Buttons now respect the global component size configuration.

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -3,6 +3,7 @@
 import { LoaderCircle } from 'lucide-react';
 
 import { button } from '@repo/ui/core';
+import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 const Core = button.Button;
@@ -100,7 +101,7 @@ const Button = ({
   type = 'default',
   variant,
   htmlType = 'button',
-  size = 'middle',
+  size,
   color = 'default',
   shape = 'default',
   block = false,
@@ -111,6 +112,8 @@ const Button = ({
   onMouseDown,
   ...props
 }: Props) => {
+  const { componentSize } = useConfig();
+  const resolvedSize = size ?? componentSize ?? 'middle';
   const iconOnly = icon && !children;
   const computedColor = danger ? 'danger' : color;
   const colored = computedColor && computedColor !== 'default';
@@ -141,8 +144,8 @@ const Button = ({
         'h-auto py-0',
         'transition-all',
         variantClasses[resolvedVariant],
-        sizesClasses[size],
-        iconOnly && ['p-0', iconClasses[size]],
+        sizesClasses[resolvedSize],
+        iconOnly && ['p-0', iconClasses[resolvedSize]],
         shapesClasses[shape || 'default'],
         block && 'w-full',
         colored &&

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { cn } from '@repo/ui/utils';
 
 import { Context, DEFAULT_LOCALE, useConfig } from './context';
-import type { Locale, ThemeConfig, ThemeToken } from './types';
+import type { ComponentSize, Locale, ThemeConfig, ThemeToken } from './types';
 
 const tokenToCssVar: Record<keyof ThemeToken, string> = {
   colorPrimary: '--primary',
@@ -53,6 +53,7 @@ interface Props {
   theme?: ThemeConfig;
   locale?: Locale;
   getContainer?: () => HTMLElement;
+  componentSize?: ComponentSize;
   className?: string;
   children: React.ReactNode;
 }
@@ -61,6 +62,7 @@ const Config = ({
   theme = {},
   locale = {},
   getContainer,
+  componentSize,
   className,
   children,
 }: Props) => {
@@ -130,13 +132,16 @@ const Config = ({
     return parent.getContainer();
   }, [getContainer, needsWrapper, wrapperEl, parent]);
 
+  const resolvedComponentSize = componentSize ?? parent.componentSize;
+
   const contextValue = useMemo(
     () => ({
       theme: mergedTheme,
       locale: mergedLocale,
       getContainer: resolvedGetContainer,
+      componentSize: resolvedComponentSize,
     }),
-    [mergedTheme, mergedLocale, resolvedGetContainer],
+    [mergedTheme, mergedLocale, resolvedGetContainer, resolvedComponentSize],
   );
 
   return (
@@ -171,4 +176,4 @@ const Config = ({
 
 export default Config;
 export { useConfig, DEFAULT_LOCALE };
-export type { Props, Locale, ThemeConfig, ThemeToken };
+export type { Props, ComponentSize, Locale, ThemeConfig, ThemeToken };

--- a/packages/ui/src/providers/config/index.ts
+++ b/packages/ui/src/providers/config/index.ts
@@ -1,2 +1,8 @@
 export { default, useConfig, DEFAULT_LOCALE } from './config';
-export type { Props, Locale, ThemeConfig, ThemeToken } from './config';
+export type {
+  Props,
+  ComponentSize,
+  Locale,
+  ThemeConfig,
+  ThemeToken,
+} from './config';

--- a/packages/ui/src/providers/config/types.ts
+++ b/packages/ui/src/providers/config/types.ts
@@ -42,6 +42,11 @@ export interface Locale {
   collapse?: string;
 }
 
+// antd's componentSize equivalent — components with a `size` prop (e.g.
+// Button) read this as their fallback when the caller doesn't pass one
+// explicitly, instead of each hardcoding its own default.
+export type ComponentSize = 'small' | 'middle' | 'large';
+
 export interface ContextValue {
   theme: ThemeConfig;
   locale: Locale;
@@ -55,4 +60,5 @@ export interface ContextValue {
   // Returns undefined when nothing in the tree renders a wrapper, so
   // callers fall back to their own normal default (document.body).
   getContainer: () => HTMLElement | undefined;
+  componentSize?: ComponentSize;
 }

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,6 +1,7 @@
 export { default as Config, useConfig, DEFAULT_LOCALE } from './config';
 export type {
   Props as ConfigProps,
+  ComponentSize,
   Locale,
   ThemeConfig,
   ThemeToken,


### PR DESCRIPTION
## Summary
Next new-feature item from #181 (F3) — antd's `componentSize` equivalent.

> `Button` / `Input.Search` / `Radio.Group` 이 `size` 를 받는데 앱 전체 기본값을 지정할 방법이 없다.

```tsx
<Config componentSize="small">
  <App />  {/* every Button defaults to size="small" unless it sets its own */}
</Config>
```

- `Config` exposes `componentSize?: 'small' | 'middle' | 'large'` via context, cascading the same way `theme`/`locale` already do (own value wins, else inherit from the nearest ancestor `Config`)
- `Button` reads it as `size ?? componentSize ?? 'middle'` — an explicit `size` prop always wins over the `Config` default, which still falls back to `'middle'` when neither is set (unchanged default behavior)
- `Radio.Group`'s `optionType="button"` variant already passes its own (optional, no-default) `size` straight through to `Button`, so it picks up this default for free — no changes needed there

## Scope note
Checked `Input.Search` and plain `Radio` (not the button variant) — neither currently has a real `size` prop implemented despite #181's issue text mentioning them, so there's nothing to wire up there yet. Scoped this to `Button` (the one place a `size` default actually exists and matters today).

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output: no `Config` → `middle` (unchanged default), `Config componentSize="small"` → `small`, explicit `size="large"` inside that same `Config` → `large` (explicit prop correctly wins)

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check: default / Config-provided / explicit-prop-override all behave correctly
- [ ] CI green