### PR TITLE
✨ feat: Config accepts a style prop (#181)

### DIFF
--- a/.changeset/feat-config-style-prop.md
+++ b/.changeset/feat-config-style-prop.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+You can now pass a style object to the Config component.

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -55,6 +55,7 @@ interface Props {
   getContainer?: () => HTMLElement;
   componentSize?: ComponentSize;
   className?: string;
+  style?: React.CSSProperties;
   children: React.ReactNode;
 }
 
@@ -64,6 +65,7 @@ const Config = ({
   getContainer,
   componentSize,
   className,
+  style,
   children,
 }: Props) => {
   const parent = useConfig();
@@ -112,7 +114,7 @@ const Config = ({
 
   const hasCssVars = Object.keys(cssVars).length > 0;
   const hasDarkMode = mergedTheme.dark !== undefined;
-  const needsWrapper = hasCssVars || hasDarkMode || className;
+  const needsWrapper = hasCssVars || hasDarkMode || !!className || !!style;
 
   // Resolution order: an explicit `getContainer` prop on this Config wins;
   // otherwise, if this Config renders its own themed wrapper below, that's
@@ -152,16 +154,20 @@ const Config = ({
           className={cn(mergedTheme.dark && 'dark', className)}
           style={{
             ...(hasCssVars ? cssVars : undefined),
+            ...style,
             // Keeps this element out of the layout box tree — so it
             // doesn't intercept flex/grid child relationships or break
             // height chains like min-h-screen — while custom properties
             // and the `dark` class selector still cascade to children
             // normally (inheritance and box generation are separate
-            // mechanisms in CSS). Note this means className shouldn't be
-            // used here for anything that needs a real box (padding,
-            // background, borders); Config's className is meant for
-            // theming hooks (the `dark` class, arbitrary selector hooks),
-            // not layout.
+            // mechanisms in CSS). Note this means className/style
+            // shouldn't be used here for anything that needs a real box
+            // (padding, background, borders); Config's className/style are
+            // meant for theming hooks (the `dark` class, arbitrary
+            // selector hooks, custom properties), not layout — spread
+            // after the caller's `style` so it can't be overridden into
+            // something that reintroduces the layout-breaking wrapper this
+            // was added to fix in the first place.
             display: 'contents',
           }}
         >


### PR DESCRIPTION
## Summary
Simplest of the remaining 🟡 improvements from #181 (item 6).

> `className` 은 받지만 `style` 은 내부 CSS 변수 전용이라 사용자가 wrapper 에 스타일을 줄 수 없다. `hasCssVars` 가 false 면 `style` 자체가 `undefined` 로 고정된다.

- `Config` now accepts `style?: React.CSSProperties`, merged the same way `className` already is
- `needsWrapper` now also considers `style` — previously a `style`-only `Config` (no `theme`/`dark`/`className`) silently rendered no wrapper at all and dropped the style entirely
- The caller's `style` is spread **before** the internal `display: 'contents'`, not after — so it can't override that invariant back into a real box and reintroduce the layout-breaking wrapper bug this element was specifically built to avoid (#181 bug 2, fixed in PR #195)

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output:
  - `style`-only `Config` (no theme) now renders its wrapper with the style applied
  - `style={{ display: 'block', ... }}` combined with a `theme` still ends up `display: contents` in the final output — confirms the override protection works

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check: style-only Config, and style+theme combined with a conflicting `display` value
- [ ] CI green