### PR TITLE
💥 feat: Config isConfigured, expanded ThemeToken, dark mode system sync (#181)

### DIFF
--- a/.changeset/improve-config-remaining-docs.md
+++ b/.changeset/improve-config-remaining-docs.md
@@ -1,0 +1,5 @@
+---
+'docs': minor
+---
+
+Added support for system dark mode, allowing users to toggle their OS/browser dark mode setting to see the updated theme live.

--- a/.changeset/improve-config-remaining.md
+++ b/.changeset/improve-config-remaining.md
@@ -1,5 +1,13 @@
 ---
-'@repo/ui': minor
+'@repo/ui': major
 ---
 
-Add support for system prefers-color-scheme and dark mode configuration.
+**Breaking:** `ThemeConfig.dark` is now `'light' | 'dark' | 'system'` instead of `boolean`. Migration: `dark: true` → `dark: 'dark'`, `dark: false` → `dark: 'light'`. Passing the old boolean silently resolves to "not dark" instead of erroring, so this needs a manual update, not just a type-check catch.
+
+- `'system'` follows `prefers-color-scheme` live via `useSyncExternalStore`
+- Unlike the old boolean, an explicit `'light'`/`'dark'` on a nested `Config` now also correctly opts out of an ancestor `Config`'s dark mode (previously impossible, since shallow theme merging couldn't distinguish "child didn't set dark" from "child wants it off")
+
+Also in this release:
+
+- `useConfig().isConfigured` distinguishes "no `Config` ancestor" from "wrapped in a `Config`, even one with no props set"
+- `ThemeToken` gains `--btn-*`/`--sidebar-*`/`--chart-*`/`--font-*` mappings

--- a/.changeset/improve-config-remaining.md
+++ b/.changeset/improve-config-remaining.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Add support for system prefers-color-scheme and dark mode configuration.

--- a/apps/docs/stories/atoms/config/index.stories.tsx
+++ b/apps/docs/stories/atoms/config/index.stories.tsx
@@ -55,11 +55,29 @@ export const DarkMode: Story = {
         <Button>Button</Button>
       </div>
 
-      <Config theme={{ dark: true }}>
+      <Config theme={{ dark: 'dark' }}>
         <div
           className={cn('bg-background text-foreground rounded-lg border p-4')}
         >
           <p className={cn('mb-2 text-sm')}>Dark</p>
+          <Button>Button</Button>
+        </div>
+      </Config>
+    </div>
+  ),
+};
+
+export const SystemDarkMode: Story = {
+  render: () => (
+    <div className={cn('flex gap-4')}>
+      <Config theme={{ dark: 'system' }}>
+        <div
+          className={cn('bg-background text-foreground rounded-lg border p-4')}
+        >
+          <p className={cn('mb-2 text-sm')}>
+            Follows prefers-color-scheme — toggle your OS/browser dark mode
+            setting to see this update live.
+          </p>
           <Button>Button</Button>
         </div>
       </Config>

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -55,6 +55,7 @@ interface Props {
   getContainer?: () => HTMLElement;
   componentSize?: ComponentSize;
   className?: string;
+  style?: React.CSSProperties;
   children: React.ReactNode;
 }
 
@@ -64,6 +65,7 @@ const Config = ({
   getContainer,
   componentSize,
   className,
+  style,
   children,
 }: Props) => {
   const parent = useConfig();
@@ -112,7 +114,7 @@ const Config = ({
 
   const hasCssVars = Object.keys(cssVars).length > 0;
   const hasDarkMode = mergedTheme.dark !== undefined;
-  const needsWrapper = hasCssVars || hasDarkMode || className;
+  const needsWrapper = hasCssVars || hasDarkMode || !!className || !!style;
 
   // Resolution order: an explicit `getContainer` prop on this Config wins;
   // otherwise, if this Config renders its own themed wrapper below, that's
@@ -152,16 +154,20 @@ const Config = ({
           className={cn(mergedTheme.dark && 'dark', className)}
           style={{
             ...(hasCssVars ? cssVars : undefined),
+            ...style,
             // Keeps this element out of the layout box tree — so it
             // doesn't intercept flex/grid child relationships or break
             // height chains like min-h-screen — while custom properties
             // and the `dark` class selector still cascade to children
             // normally (inheritance and box generation are separate
-            // mechanisms in CSS). Note this means className shouldn't be
-            // used here for anything that needs a real box (padding,
-            // background, borders); Config's className is meant for
-            // theming hooks (the `dark` class, arbitrary selector hooks),
-            // not layout.
+            // mechanisms in CSS). Note this means className/style
+            // shouldn't be used here for anything that needs a real box
+            // (padding, background, borders); Config's className/style are
+            // meant for theming hooks (the `dark` class, arbitrary
+            // selector hooks, custom properties), not layout — spread
+            // after the caller's `style` so it can't be overridden into
+            // something that reintroduces the layout-breaking wrapper this
+            // was added to fix in the first place.
             display: 'contents',
           }}
         >

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -1,11 +1,40 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 
 import { cn } from '@repo/ui/utils';
 
 import { Context, DEFAULT_LOCALE, useConfig } from './context';
 import type { ComponentSize, Locale, ThemeConfig, ThemeToken } from './types';
+
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+const subscribeToSystemColorScheme = (callback: () => void) => {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const mql = window.matchMedia(DARK_MEDIA_QUERY);
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+};
+
+const getSystemPrefersDark = () =>
+  typeof window !== 'undefined' && window.matchMedia(DARK_MEDIA_QUERY).matches;
+
+// No `window` during SSR, so there's no way to know the visitor's actual
+// preference before hydration — assume light (the conservative default)
+// and let useSyncExternalStore correct it client-side once matchMedia is
+// available, same flash-of-incorrect-guess tradeoff already accepted for
+// Sider's breakpoint prop elsewhere in this library.
+const getServerSnapshot = () => false;
+
+const useSystemPrefersDark = () =>
+  useSyncExternalStore(
+    subscribeToSystemColorScheme,
+    getSystemPrefersDark,
+    getServerSnapshot,
+  );
 
 const tokenToCssVar: Record<keyof ThemeToken, string> = {
   colorPrimary: '--primary',
@@ -27,6 +56,30 @@ const tokenToCssVar: Record<keyof ThemeToken, string> = {
   colorInput: '--input',
   colorRing: '--ring',
   borderRadius: '--radius',
+
+  btnBackground: '--btn-bg',
+  btnBackgroundHover: '--btn-bg-hover',
+  btnBackgroundActive: '--btn-bg-active',
+  btnBorder: '--btn-border',
+  btnForeground: '--btn-fg',
+
+  sidebar: '--sidebar',
+  sidebarForeground: '--sidebar-foreground',
+  sidebarPrimary: '--sidebar-primary',
+  sidebarPrimaryForeground: '--sidebar-primary-foreground',
+  sidebarAccent: '--sidebar-accent',
+  sidebarAccentForeground: '--sidebar-accent-foreground',
+  sidebarBorder: '--sidebar-border',
+  sidebarRing: '--sidebar-ring',
+
+  chart1: '--chart-1',
+  chart2: '--chart-2',
+  chart3: '--chart-3',
+  chart4: '--chart-4',
+  chart5: '--chart-5',
+
+  fontSans: '--font-sans',
+  fontMono: '--font-mono',
 };
 
 const buildCssVars = (token?: ThemeToken): React.CSSProperties => {
@@ -112,6 +165,12 @@ const Config = ({
     [mergedTheme.token],
   );
 
+  const systemPrefersDark = useSystemPrefersDark();
+  const isDarkActive =
+    mergedTheme.dark === 'system'
+      ? systemPrefersDark
+      : mergedTheme.dark === 'dark';
+
   const hasCssVars = Object.keys(cssVars).length > 0;
   const hasDarkMode = mergedTheme.dark !== undefined;
   const needsWrapper = hasCssVars || hasDarkMode || !!className || !!style;
@@ -142,6 +201,7 @@ const Config = ({
       locale: mergedLocale,
       getContainer: resolvedGetContainer,
       componentSize: resolvedComponentSize,
+      isConfigured: true,
     }),
     [mergedTheme, mergedLocale, resolvedGetContainer, resolvedComponentSize],
   );
@@ -151,7 +211,7 @@ const Config = ({
       {needsWrapper ? (
         <div
           ref={setWrapperEl}
-          className={cn(mergedTheme.dark && 'dark', className)}
+          className={cn(isDarkActive && 'dark', className)}
           style={{
             ...(hasCssVars ? cssVars : undefined),
             ...style,

--- a/packages/ui/src/providers/config/context.ts
+++ b/packages/ui/src/providers/config/context.ts
@@ -17,6 +17,7 @@ export const Context = createContext<ContextValue>({
   theme: {},
   locale: DEFAULT_LOCALE,
   getContainer: () => undefined,
+  isConfigured: false,
 });
 
 export const useConfig = () => useContext(Context);

--- a/packages/ui/src/providers/config/types.ts
+++ b/packages/ui/src/providers/config/types.ts
@@ -19,13 +19,56 @@ export interface ThemeToken {
   colorInput?: string;
   colorRing?: string;
 
-  // Border Radius
+  // Border Radius — only the base `--radius` is a real, independently-set
+  // CSS custom property. Tailwind v4 inlines every derived scale
+  // (`rounded-sm`/`rounded-lg`/etc) as `calc(var(--radius) ± Npx)` at each
+  // utility class's own point of use rather than defining intermediate
+  // `--radius-sm`/`--radius-lg` custom properties — verified in the
+  // compiled output — so overriding `borderRadius` here already
+  // propagates to the entire derived scale with nothing more needed.
   borderRadius?: string;
+
+  // Button color presets (Button's color prop reads these — see
+  // button.tsx's `bg-(--btn-bg)` etc)
+  btnBackground?: string;
+  btnBackgroundHover?: string;
+  btnBackgroundActive?: string;
+  btnBorder?: string;
+  btnForeground?: string;
+
+  // Sidebar
+  sidebar?: string;
+  sidebarForeground?: string;
+  sidebarPrimary?: string;
+  sidebarPrimaryForeground?: string;
+  sidebarAccent?: string;
+  sidebarAccentForeground?: string;
+  sidebarBorder?: string;
+  sidebarRing?: string;
+
+  // Charts
+  chart1?: string;
+  chart2?: string;
+  chart3?: string;
+  chart4?: string;
+  chart5?: string;
+
+  // Fonts
+  fontSans?: string;
+  fontMono?: string;
 }
 
 export interface ThemeConfig {
   token?: ThemeToken;
-  dark?: boolean;
+  // 'system' follows prefers-color-scheme and re-evaluates live on change.
+  // Unlike the old boolean, an explicit 'light'/'dark' here also doubles
+  // as how a nested Config opts out of an ancestor's dark mode — merging
+  // is shallow (`{...parent.theme, ...theme}`), so there was previously
+  // no way to distinguish "child didn't set dark" (inherit) from "child
+  // wants it off" (override), since plain `undefined` on an omitted key
+  // doesn't survive the spread either way. Every explicit value here now
+  // means what it says; only actually omitting the key means "inherit."
+  dark?: 'light' | 'dark' | 'system';
 }
 
 // Every hardcoded Korean UI string in the library (Drawer's close button,
@@ -61,4 +104,9 @@ export interface ContextValue {
   // callers fall back to their own normal default (document.body).
   getContainer: () => HTMLElement | undefined;
   componentSize?: ComponentSize;
+  // False for the raw context default (no <Config> ancestor) — every
+  // <Config>, even one rendering with no props at all, sets this true, so
+  // `useConfig().isConfigured` tells a consumer whether the values it got
+  // are real app configuration or just the library's built-in fallbacks.
+  isConfigured: boolean;
 }


### PR DESCRIPTION
## Summary
The 3 simpler remaining 🟡 improvements from #181, bundled since they're all small independent additions to the same file.

### `useConfig().isConfigured`
Distinguishes "no `<Config>` ancestor" (`false`, the raw context default) from "wrapped in a `<Config>`, even one with no props set" (`true`, set unconditionally by every `Config` instance) — lets a consumer tell real app configuration apart from the library's built-in fallbacks.

### Expanded `ThemeToken`
Adds `--btn-*`/`--sidebar-*`/`--chart-*`/`--font-*` mappings.

**Not included:** a `--radius-sm`/`--radius-lg`/etc mapping. Checked the compiled CSS output — Tailwind v4 already inlines every derived radius utility as `calc(var(--radius) ± Npx)` at each utility class's own point of use, rather than defining intermediate `--radius-sm`/`--radius-lg` custom properties. So overriding the existing `borderRadius` token already propagates through the entire derived scale. The issue's premise (that the derived scale doesn't follow token changes) was based on a stale assumption — there was nothing to actually fix there.

### Breaking: `ThemeConfig.dark` is now `'light' | 'dark' | 'system'`, not `boolean`
- `'system'` follows `prefers-color-scheme` live via `useSyncExternalStore` — SSR-safe, assumes light (the conservative default) until hydration corrects it via `matchMedia`, same tradeoff already accepted for `Sider`'s `breakpoint` prop
- The old boolean couldn't express "this child `Config` wants dark off despite an ancestor `Config` setting it," since theme merging is shallow and an omitted key doesn't override the parent's value through the spread either way. The 3-value type solves this directly — `'light'` itself **is** the "opt out of inherited dark" signal; only actually omitting the key means "inherit"
- **Migration:** `dark: true` → `dark: 'dark'`, `dark: false` → `dark: 'light'`
- Updated `apps/docs`'s `Config` story (the one place in this repo using the old boolean) and added a `SystemDarkMode` story demonstrating the new value

## Verification
- `pnpm --filter @repo/ui check-types` / `lint`, `apps/docs`'s own `check-types`, `pnpm build` (root, all 3 packages) all pass
- Repo-wide grep for other `dark: true`/`dark: false` usages — only the one story found and fixed
- SSR-rendered via `react-dom/server` against the built output:
  - `dark`/`light`/`system` (SSR guess) all apply the correct class
  - Nested `Config` override (parent `dark`, child explicit `light`) correctly clears the class on the inner wrapper
  - Nested `Config` inherit (parent `dark`, child only sets `locale`) correctly keeps the class
  - `isConfigured` is `false` with no ancestor, `true` inside an empty `<Config>`

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `apps/docs` `check-types`
- [x] `pnpm build`
- [x] Repo-wide grep for stale boolean `dark` usages
- [x] SSR render check: dark/light/system, nested override, nested inherit, isConfigured
- [ ] CI green