### PR TITLE
✨ feat: Config supports darkToken (#181)

### DIFF
--- a/.changeset/feat-config-dark-token.md
+++ b/.changeset/feat-config-dark-token.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Dark mode theme tokens can now be overridden on a per-key basis, allowing for more fine-grained control over dark mode styling.

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -146,6 +146,10 @@ const Config = ({
         ...parent.theme.token,
         ...theme.token,
       },
+      darkToken: {
+        ...parent.theme.darkToken,
+        ...theme.darkToken,
+      },
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [parentThemeKey, themeKey],
@@ -160,16 +164,23 @@ const Config = ({
     [parentLocaleKey, localeKey],
   );
 
-  const cssVars = useMemo(
-    () => buildCssVars(mergedTheme.token),
-    [mergedTheme.token],
-  );
-
   const systemPrefersDark = useSystemPrefersDark();
   const isDarkActive =
     mergedTheme.dark === 'system'
       ? systemPrefersDark
       : mergedTheme.dark === 'dark';
+
+  // `darkToken` overrides individual keys of `token` (not a full swap)
+  // only while dark mode is actually active.
+  const cssVars = useMemo(
+    () =>
+      buildCssVars(
+        isDarkActive
+          ? { ...mergedTheme.token, ...mergedTheme.darkToken }
+          : mergedTheme.token,
+      ),
+    [mergedTheme.token, mergedTheme.darkToken, isDarkActive],
+  );
 
   const hasCssVars = Object.keys(cssVars).length > 0;
   const hasDarkMode = mergedTheme.dark !== undefined;

--- a/packages/ui/src/providers/config/types.ts
+++ b/packages/ui/src/providers/config/types.ts
@@ -60,6 +60,11 @@ export interface ThemeToken {
 
 export interface ThemeConfig {
   token?: ThemeToken;
+  // Applied on top of `token` (per-key override, not a full replacement)
+  // only while dark mode is actually active — lets an app specify "this
+  // one color should differ in dark mode" without needing a second nested
+  // Config just to swap a single token.
+  darkToken?: ThemeToken;
   // 'system' follows prefers-color-scheme and re-evaluates live on change.
   // Unlike the old boolean, an explicit 'light'/'dark' here also doubles
   // as how a nested Config opts out of an ancestor's dark mode — merging


### PR DESCRIPTION
## Summary
Last of the "improvements" batch from #181 (item F6, dark-only token separation).

> 지금은 token 이 라이트/다크 공용이라 다크에서만 다른 색을 쓰려면 Config 를 중첩해야 한다. token / darkToken 을 분리하거나 antd 의 algorithm 같은 개념이 필요하다.

```tsx
<Config theme={{ dark: 'dark', token: { colorPrimary: '#111' }, darkToken: { colorPrimary: '#eee' } }}>
```

- `ThemeConfig.darkToken?: ThemeToken` overrides individual `token` keys — not a full replacement — only while dark mode is actually active (`dark: 'dark'`, or `'system'` currently resolving dark)
- Any `token` key `darkToken` doesn't mention keeps its light-mode value (per-key override, matching how `token` itself already merges parent → own)
- Merges the same way `token` already does (parent + own, own wins), so a nested `Config`'s `darkToken` cascades correctly too

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output:
  - `dark: 'light'` with both `token`/`darkToken` set: only the base `token` value applies
  - `dark: 'dark'` with both set: `darkToken`'s `colorPrimary` overrides, while `token`'s `colorBackground` (not present in `darkToken`) keeps its light-mode value

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check: light mode ignores darkToken, dark mode applies per-key override
- [ ] CI green