### PR TITLE
✨ feat: Config supports per-component defaultProps (#181)

### DIFF
--- a/.changeset/feat-config-default-props.md
+++ b/.changeset/feat-config-default-props.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Added support for per-component default props, allowing components to customize their default behavior.

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -103,7 +103,7 @@ const Button = ({
   htmlType = 'button',
   size,
   color = 'default',
-  shape = 'default',
+  shape,
   block = false,
   disabled,
   loading,
@@ -112,8 +112,12 @@ const Button = ({
   onMouseDown,
   ...props
 }: Props) => {
-  const { componentSize } = useConfig();
+  const { componentSize, defaultProps } = useConfig();
+  const buttonDefaults = defaultProps?.button as
+    | Partial<Pick<Props, 'shape'>>
+    | undefined;
   const resolvedSize = size ?? componentSize ?? 'middle';
+  const resolvedShape = shape ?? buttonDefaults?.shape ?? 'default';
   const iconOnly = icon && !children;
   const computedColor = danger ? 'danger' : color;
   const colored = computedColor && computedColor !== 'default';
@@ -146,7 +150,7 @@ const Button = ({
         variantClasses[resolvedVariant],
         sizesClasses[resolvedSize],
         iconOnly && ['p-0', iconClasses[resolvedSize]],
-        shapesClasses[shape || 'default'],
+        shapesClasses[resolvedShape],
         block && 'w-full',
         colored &&
           (resolvedVariant === 'solid'

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -7,7 +7,13 @@ import { DirectionProvider } from '@radix-ui/react-direction';
 import { cn } from '@repo/ui/utils';
 
 import { Context, DEFAULT_LOCALE, useConfig } from './context';
-import type { ComponentSize, Locale, ThemeConfig, ThemeToken } from './types';
+import type {
+  ComponentSize,
+  DefaultProps,
+  Locale,
+  ThemeConfig,
+  ThemeToken,
+} from './types';
 
 const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 
@@ -110,6 +116,7 @@ interface Props {
   getContainer?: () => HTMLElement;
   componentSize?: ComponentSize;
   direction?: 'ltr' | 'rtl';
+  defaultProps?: DefaultProps;
   className?: string;
   style?: React.CSSProperties;
   children: React.ReactNode;
@@ -121,6 +128,7 @@ const Config = ({
   getContainer,
   componentSize,
   direction,
+  defaultProps,
   className,
   style,
   children,
@@ -212,6 +220,18 @@ const Config = ({
   const resolvedComponentSize = componentSize ?? parent.componentSize;
   const resolvedDirection = direction ?? parent.direction;
 
+  const defaultPropsKey = JSON.stringify(defaultProps);
+  const parentDefaultPropsKey = JSON.stringify(parent.defaultProps);
+
+  const mergedDefaultProps = useMemo<DefaultProps | undefined>(
+    () =>
+      parent.defaultProps || defaultProps
+        ? { ...parent.defaultProps, ...defaultProps }
+        : undefined,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [parentDefaultPropsKey, defaultPropsKey],
+  );
+
   const contextValue = useMemo(
     () => ({
       theme: mergedTheme,
@@ -219,6 +239,7 @@ const Config = ({
       getContainer: resolvedGetContainer,
       componentSize: resolvedComponentSize,
       direction: resolvedDirection,
+      defaultProps: mergedDefaultProps,
       isConfigured: true,
     }),
     [
@@ -227,6 +248,7 @@ const Config = ({
       resolvedGetContainer,
       resolvedComponentSize,
       resolvedDirection,
+      mergedDefaultProps,
     ],
   );
 
@@ -284,4 +306,11 @@ const Config = ({
 
 export default Config;
 export { useConfig, DEFAULT_LOCALE };
-export type { Props, ComponentSize, Locale, ThemeConfig, ThemeToken };
+export type {
+  Props,
+  ComponentSize,
+  DefaultProps,
+  Locale,
+  ThemeConfig,
+  ThemeToken,
+};

--- a/packages/ui/src/providers/config/index.ts
+++ b/packages/ui/src/providers/config/index.ts
@@ -2,6 +2,7 @@ export { default, useConfig, DEFAULT_LOCALE } from './config';
 export type {
   Props,
   ComponentSize,
+  DefaultProps,
   Locale,
   ThemeConfig,
   ThemeToken,

--- a/packages/ui/src/providers/config/types.ts
+++ b/packages/ui/src/providers/config/types.ts
@@ -95,6 +95,18 @@ export interface Locale {
 // explicitly, instead of each hardcoding its own default.
 export type ComponentSize = 'small' | 'middle' | 'large';
 
+// Per-component default props (e.g. { button: { shape: 'round' } }), keyed
+// by an informal lowercase component name each opting-in component reads
+// itself (e.g. Button reads defaultProps?.button). Deliberately untyped
+// beyond this shape rather than importing every component's real Props
+// type here: Config lives in providers/, several components already import
+// useConfig from providers/ (for componentSize/locale/etc), so importing
+// their Props back into this file would be circular. Each component casts
+// its own slice locally instead. Merges shallowly per outer key, same as
+// theme/locale/componentSize — a nested Config's own `button` entry (if
+// set at all) fully replaces the parent's, it doesn't deep-merge the two.
+export type DefaultProps = Record<string, Record<string, unknown>>;
+
 export interface ContextValue {
   theme: ThemeConfig;
   locale: Locale;
@@ -110,6 +122,7 @@ export interface ContextValue {
   // callers fall back to their own normal default (document.body).
   getContainer: () => HTMLElement | undefined;
   componentSize?: ComponentSize;
+  defaultProps?: DefaultProps;
   // False for the raw context default (no <Config> ancestor) — every
   // <Config>, even one rendering with no props at all, sets this true, so
   // `useConfig().isConfigured` tells a consumer whether the values it got

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -2,6 +2,7 @@ export { default as Config, useConfig, DEFAULT_LOCALE } from './config';
 export type {
   Props as ConfigProps,
   ComponentSize,
+  DefaultProps,
   Locale,
   ThemeConfig,
   ThemeToken,


### PR DESCRIPTION
## Summary
Last remaining item from #181 (F4) — antd's `ConfigProvider` component-level default props.

> `theme` 외에 `button: { shape: 'round' }` 처럼 컴포넌트 단위 기본값을 주입할 수 있으면 디자인 시스템 프리셋을 앱 레벨에서 한 번에 정의할 수 있다.

```tsx
<Config defaultProps={{ button: { shape: 'round' } }}>
  <App /> {/* every Button defaults to shape="round" unless it sets its own */}
</Config>
```

## Design note
`Config.defaultProps` is deliberately typed as `Record<string, Record<string, unknown>>` rather than importing each component's real `Props` type. `Config` lives in `providers/`, and several components (`Button` included) already import `useConfig` from `providers/` for `componentSize`/`locale`/etc — importing their `Props` back into this file would be circular. Each opting-in component casts its own slice locally instead (see `button.tsx`'s `defaultProps?.button as Partial<Pick<Props, 'shape'>>`).

Wired up `Button`'s `shape` prop as the proof of concept — matches the issue's own example exactly: `shape ?? buttonDefaults?.shape ?? 'default'`, the same prop-wins-over-Config-wins-over-hardcoded-default resolution order already established for `componentSize` (#219). Merges shallowly per outer key, same as `theme`/`locale`/`componentSize`.

**Scope note:** only `Button`/`shape` is wired up. Extending this to other components' other props is the same three-line pattern but left for whoever actually needs it, rather than speculatively wiring up props nothing has asked for yet.

## Verification
- `pnpm --filter @repo/ui check-types` / `lint` / `pnpm build` (root, all 3 packages) all pass
- SSR-rendered via `react-dom/server` against the built output: no `Config` → default shape, `Config defaultProps={{ button: { shape: 'round' } }}` → round applied, explicit `shape="circle"` inside that same `Config` → circle wins

## Test plan
- [x] `pnpm --filter @repo/ui check-types`
- [x] `pnpm --filter @repo/ui lint`
- [x] `pnpm build`
- [x] SSR render check: default / Config-provided / explicit-prop-override all behave correctly
- [ ] CI green