### PR TITLE
🐛 fix: reverify follow-ups from #229 (Skeleton, Space, Dropdown, locale)

### DIFF
--- a/.changeset/fix-audit-229-followups.md
+++ b/.changeset/fix-audit-229-followups.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Components now support internationalization with locale-aware text and aria-labels.

--- a/packages/ui/src/components/atoms/skeleton/skeleton.tsx
+++ b/packages/ui/src/components/atoms/skeleton/skeleton.tsx
@@ -66,6 +66,7 @@ const Skeleton = ({
       role="status"
       aria-label={locale.loading ?? DEFAULT_LOCALE.loading}
       className={cn('flex items-center gap-3', className)}
+      style={style}
       {...props}
     >
       {avatar && (
@@ -103,7 +104,6 @@ const Skeleton = ({
                 //
               )}
               style={{
-                ...style,
                 width: itemWidth,
                 height: itemHeight,
               }}

--- a/packages/ui/src/components/molecules/dropdown.tsx
+++ b/packages/ui/src/components/molecules/dropdown.tsx
@@ -110,7 +110,7 @@ const Dropdown = ({
         {open && (
           <motion.div
             className={cn(
-              'absolute top-full pt-2',
+              'absolute top-full z-50 pt-2',
               //
             )}
             initial={{ opacity: 0, y: -10 }}

--- a/packages/ui/src/components/molecules/space.tsx
+++ b/packages/ui/src/components/molecules/space.tsx
@@ -59,6 +59,7 @@ const Space = ({
       <div
         className={cn(hidden && 'hidden', className)}
         style={style}
+        hidden={hidden}
         {...props}
       >
         {loader || <Skeleton />}
@@ -88,6 +89,7 @@ const Space = ({
           : undefined,
         ...style,
       }}
+      hidden={hidden}
       {...props}
     >
       {Children.map(children, (child, i) => (

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 
 import { dialog } from '@repo/ui/core';
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../atoms/button';
@@ -79,12 +80,14 @@ const Modal = ({
   footer,
   container,
   children,
-  okText = 'OK',
-  cancelText = 'Cancel',
+  okText,
+  cancelText,
   onOk,
   onCancel,
   ...props
 }: Props) => {
+  const { locale } = useConfig();
+
   if (typeof window === 'undefined') {
     return null;
   }
@@ -142,9 +145,11 @@ const Modal = ({
           >
             {footer || (
               <>
-                <Button onClick={onOk}>{okText}</Button>
+                <Button onClick={onOk}>
+                  {okText ?? locale.ok ?? DEFAULT_LOCALE.ok}
+                </Button>
                 <Button variant="outlined" onClick={onCancel}>
-                  {cancelText}
+                  {cancelText ?? locale.cancel ?? DEFAULT_LOCALE.cancel}
                 </Button>
               </>
             )}
@@ -168,15 +173,19 @@ const StaticModal = ({
   type,
   title,
   content,
-  okText = 'OK',
-  cancelText = 'Cancel',
+  okText,
+  cancelText,
   container,
   icon,
   onOk,
   onCancel,
   ...props
 }: StaticProps & { id: string }): React.ReactPortal | null => {
+  const { locale } = useConfig();
   const [open, setOpen] = useState(true);
+  const resolvedOkText = okText ?? locale.ok ?? DEFAULT_LOCALE.ok;
+  const resolvedCancelText =
+    cancelText ?? locale.cancel ?? DEFAULT_LOCALE.cancel;
 
   const closeModal = (callback?: () => void) => {
     callback?.();
@@ -194,10 +203,10 @@ const StaticModal = ({
           className="col-span-2"
           onClick={() => closeModal(onCancel)}
         >
-          {cancelText}
+          {resolvedCancelText}
         </Button>
         <Button className="col-span-3" onClick={() => closeModal(onOk)}>
-          {okText}
+          {resolvedOkText}
         </Button>
       </div>
     ) : (
@@ -208,7 +217,7 @@ const StaticModal = ({
         )}
         onClick={() => closeModal(onOk)}
       >
-        {okText}
+        {resolvedOkText}
       </Button>
     );
 

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom';
 import { useTimeout } from '@jbpark/use-hooks';
 import { Check, Info, OctagonAlert, OctagonX, X } from 'lucide-react';
 
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../atoms/button';
@@ -51,6 +52,8 @@ const Toast = ({
   className,
   onClose,
 }: Props) => {
+  const { locale } = useConfig();
+
   return (
     <div
       role={type === 'error' ? 'alert' : 'status'}
@@ -78,7 +81,7 @@ const Toast = ({
           type="text"
           shape="circle"
           size="small"
-          aria-label="Close"
+          aria-label={locale.close ?? DEFAULT_LOCALE.close}
           icon={<X />}
           onClick={onClose}
         />
@@ -138,6 +141,9 @@ const toastStack: ImperativeStack<StaticProps> =
     createRootElement: () => {
       const el = document.createElement('div');
       el.setAttribute('role', 'region');
+      // Plain DOM, created outside any React tree — no Config to read a
+      // locale override from until #226 gives the imperative stack a way
+      // to inherit one.
       el.setAttribute('aria-label', 'Notifications');
       el.style.zIndex = '10000';
       el.style.position = 'fixed';

--- a/packages/ui/src/components/templates/page-header.tsx
+++ b/packages/ui/src/components/templates/page-header.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowLeft } from 'lucide-react';
 
+import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
 import { cn, renderConditional } from '@repo/ui/utils';
 
 import Button from '../atoms/button';
@@ -23,12 +24,6 @@ export interface Props extends Omit<React.ComponentProps<'div'>, 'title'> {
 // Title + back button + extra action area — same shape as Drawer's header
 // (title/extra/closable), which this borrows the layout from wholesale;
 // PageHeader just swaps Drawer's close button for a back button.
-//
-// TODO: the back button's aria-label ("뒤로가기") is hardcoded the same
-// way every other component's was before #210 (Config's `locale` slot)
-// existed. Wire it up to `useConfig().locale` once that PR merges, adding
-// a `back` key to Locale/DEFAULT_LOCALE — left out here to avoid this PR
-// depending on an unmerged one.
 const PageHeader = ({
   title,
   subTitle,
@@ -40,6 +35,8 @@ const PageHeader = ({
   children,
   ...props
 }: Props) => {
+  const { locale } = useConfig();
+
   return (
     <div className={cn('flex flex-col gap-2', className)} {...props}>
       <div className="flex items-start gap-2">
@@ -48,7 +45,7 @@ const PageHeader = ({
             type="text"
             shape="circle"
             size="small"
-            aria-label="뒤로가기"
+            aria-label={locale.back ?? DEFAULT_LOCALE.back}
             icon={backIcon || <ArrowLeft />}
             onClick={onBack}
             className={cn(classNames?.back)}

--- a/packages/ui/src/providers/config/context.ts
+++ b/packages/ui/src/providers/config/context.ts
@@ -11,6 +11,9 @@ export const DEFAULT_LOCALE: Required<Locale> = {
   loading: '로딩 중',
   expand: '펼치기',
   collapse: '접기',
+  back: '뒤로가기',
+  ok: 'OK',
+  cancel: 'Cancel',
 };
 
 export const Context = createContext<ContextValue>({

--- a/packages/ui/src/providers/config/types.ts
+++ b/packages/ui/src/providers/config/types.ts
@@ -88,6 +88,9 @@ export interface Locale {
   loading?: string;
   expand?: string;
   collapse?: string;
+  back?: string;
+  ok?: string;
+  cancel?: string;
 }
 
 // antd's componentSize equivalent — components with a `size` prop (e.g.


### PR DESCRIPTION
## 배경

#229는 #177/#178/#179/#185 수정에 대한 재검증 리포트. 지적된 5건 중 API 일관성/버그 성격의 4건을 처리.

## 변경

1. **Skeleton** — `className`은 wrapper, `style`은 item에 흩어져 적용 대상이 갈리던 문제. `style`을 wrapper로 이동, item은 기존 `width`/`height`만 사용
2. **Space** — `hidden` prop이 Tailwind `hidden` 클래스로만 변환되고 네이티브 `hidden` 속성 자체는 버려지던 문제. 속성도 함께 전달 (`element.hidden`/`[hidden]` 선택자 정상 동작)
3. **Dropdown** — 메뉴에 z-index가 없어 다른 positioned 형제 요소 아래로 깔리던 문제. 라이브러리의 다른 floating 요소들과 동일하게 `z-50` 추가
4. **locale 미연결 라벨** — `Locale`/`DEFAULT_LOCALE`에 `back`/`ok`/`cancel` 키 추가:
   - `PageHeader`의 뒤로가기 버튼 (`aria-label="뒤로가기"` 하드코딩 → `locale.back`) — 기존 TODO가 가리키던 PR(#210, Config locale)은 이미 머지되어 있었음
   - `Toast`의 닫기 버튼 (`aria-label="Close"` → `locale.close`, Drawer와 동일 소스로 통일)
   - `Modal`의 `okText`/`cancelText` 기본값 (선언형 `Modal`, 명령형 `StaticModal` 둘 다) — 기존 표시값(`'OK'`/`'Cancel'`)은 유지하되 `Config`로 전역 override 가능하게

## 스코프 제외

- **Toast 스택 루트의 `aria-label="Notifications"`** — `createRootElement`가 React 트리 밖에서 순수 DOM으로 생성되어 `useConfig()` 접근 불가. #226(명령형 스택의 Config 미상속, 별도 이슈)이 선행되어야 함. 코드에 주석으로 명시
- **`useKeyPress`/`useToggle` 미적용** (#229 5번) — 이슈 본문이 "동작은 정상이라 버그는 아님", `useToggle`은 "검토 항목"이라 명시. dropdown/menu-item/radio/checkbox 4개 파일의 키보드 로직 교체 + 여러 컴포넌트의 boolean 상태 통일까지 걸리는 별도 판단 필요 작업이라 이번 PR 범위에서 제외

## 검증

- `pnpm --filter @repo/ui lint`, `pnpm check-types` (5개 패키지), `pnpm check-dynamic-classes` 모두 통과
- `pnpm --filter @repo/ui build` 성공
- Skeleton/Space: 빌드 산출물 SSR 렌더로 실측 — `style`이 wrapper에만 적용(중복 제거 확인), `hidden` 속성이 `hidden=""`으로 출력됨
- Dropdown: 렌더된 메뉴 클래스에 `z-50` 포함 확인
- PageHeader: `locale.back` 폴백 체인이 `aria-label="뒤로가기"`로 정확히 해석됨을 실측 (Modal/Toast는 동일 패턴이라 tsc/lint 통과 + 코드 리뷰로 확인)

Refs #229 (부분 반영 — useKeyPress/useToggle 항목은 별도 후속 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)