### PR TITLE
🐛 fix: reverify Layout.Sider follow-ups from #227

### DIFF
--- a/.changeset/fix-layout-sider-reverify.md
+++ b/.changeset/fix-layout-sider-reverify.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+A sider component now correctly handles nested layouts and sider components without intervening layouts.

--- a/packages/ui/src/components/templates/layout/content.tsx
+++ b/packages/ui/src/components/templates/layout/content.tsx
@@ -2,6 +2,8 @@ import { Slot } from '@radix-ui/react-slot';
 
 import { cn } from '@repo/ui/utils';
 
+import { SiderRegistryContext } from './sider-context';
+
 export interface Props extends React.ComponentProps<'main'> {
   asChild?: boolean;
 }
@@ -32,7 +34,14 @@ const Content = ({ children, className, asChild = false, ...props }: Props) => {
       )}
       {...props}
     >
-      {children}
+      {/* Reset the registry to null so a `Sider` used inside `Content`
+          (e.g. a detail page's own sub-navigation) doesn't register
+          against the ancestor `Layout` and flip its axis to flex-row —
+          a genuinely nested `Layout` already gets its own fresh registry,
+          this only guards the "Sider with no intervening Layout" case. */}
+      <SiderRegistryContext.Provider value={null}>
+        {children}
+      </SiderRegistryContext.Provider>
     </Comp>
   );
 };

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId, useLayoutEffect } from 'react';
+import { useEffect, useId, useRef } from 'react';
 
 import { useControllableState, useResponsiveSize } from '@jbpark/use-hooks';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
@@ -77,14 +77,62 @@ const Sider = ({
       BREAKPOINT_ORDER.indexOf(breakpoint)
     : false;
 
-  useLayoutEffect(() => {
+  const latestBrokenRef = useRef(broken);
+  const previousBrokenRef = useRef<boolean | null>(null);
+  const microtaskScheduledRef = useRef(false);
+  const onBreakpointRef = useRef(onBreakpoint);
+
+  useEffect(() => {
+    onBreakpointRef.current = onBreakpoint;
+  });
+
+  // `useResponsiveSize`'s own initial measurement resolves through its own
+  // layout effect, which (since it's called earlier in this component)
+  // commits and — if the real viewport differs from its SSR-safe 'xs'
+  // placeholder default — triggers a synchronous corrective re-render, all
+  // before the browser paints. Both the placeholder-derived render and the
+  // corrected one get their own effect pass (React doesn't coalesce
+  // same-tick synchronous re-commits into a single effect flush), so
+  // reacting to `broken` directly — in a layout or passive effect either
+  // way — fires once with the wrong placeholder value, then again with the
+  // corrected one.
+  //
+  // Coalescing through a microtask sidesteps that: every effect pass just
+  // records its `broken` into a ref and schedules (at most once) a
+  // microtask that reads whatever ended up latest once the synchronous
+  // cascade has fully settled, and acts on that single, correct value.
+  //
+  // The `previousBrokenRef` guard is the separate fix for #227 point 3:
+  // without it, an inline `onCollapse`/`onBreakpoint` (a fresh identity
+  // every render) would change `setCollapsed`'s own identity and re-run
+  // this effect on every unrelated parent re-render, reapplying `broken`
+  // and undoing a user's manual toggle. Only a genuine change should act.
+  useEffect(() => {
     if (!breakpoint) {
       return;
     }
 
-    setCollapsed(broken);
-    onBreakpoint?.(broken);
-  }, [broken, breakpoint, setCollapsed, onBreakpoint]);
+    latestBrokenRef.current = broken;
+
+    if (microtaskScheduledRef.current) {
+      return;
+    }
+    microtaskScheduledRef.current = true;
+
+    queueMicrotask(() => {
+      microtaskScheduledRef.current = false;
+
+      const settledBroken = latestBrokenRef.current;
+
+      if (previousBrokenRef.current === settledBroken) {
+        return;
+      }
+
+      previousBrokenRef.current = settledBroken;
+      setCollapsed(settledBroken);
+      onBreakpointRef.current?.(settledBroken);
+    });
+  }, [broken, breakpoint, setCollapsed]);
 
   const onTriggerClick = () => {
     setCollapsed(!collapsed);
@@ -126,7 +174,7 @@ const Sider = ({
       <div id={contentId} className="min-h-0 flex-1 overflow-auto">
         {children}
       </div>
-      {collapsible && (
+      {collapsible && trigger !== null && (
         <button
           type="button"
           aria-label={


### PR DESCRIPTION
## 배경

#227은 #180 수정에 대한 재검증 리포트. 지적된 4건 모두 처리.

## 변경

1. **`trigger={null}` 여전히 빈 버튼 렌더** — 조건에 `trigger !== null` 추가, 버튼 자체를 렌더하지 않음 (포커스/클릭 가능한 빈 영역이 사라짐)

2. **`breakpoint` 마운트 직후 오탐 (`onCollapse(true)`→`(false)`)** — `useResponsiveSize`가 SSR-safe 'xs' 플레이스홀더로 시작해 실제 뷰포트 측정 후 보정 재렌더를 한 번 더 거치는데, 이 두 렌더가 **React에서 각자 별도의 effect pass로 발화**돼(동일 tick 내 동기 재커밋이어도 병합되지 않음) 잘못된 값→맞는 값 순으로 두 번 콜백이 불림. 마이크로태스크로 같은 tick 안의 여러 effect 발화를 하나로 합쳐서, 최종 정착값으로 **한 번만** 콜백

3. **`breakpoint` 이펙트가 매 렌더 재실행되어 수동 토글을 되돌림** — 이전에 적용한 `broken` 값을 ref로 추적해, 실제로 바뀐 경우에만 `setCollapsed`/`onBreakpoint` 호출 (인라인 콜백의 매 렌더 identity 변경으로 인한 재실행은 early-return으로 무해화)

4. **`Content` 안의 `Sider`가 바깥 `Layout`의 방향을 뒤집음** — `Content`가 `SiderRegistryContext`를 `null`로 재설정해, 중간에 `Layout`이 끼지 않은 `Sider`는 어떤 레지스트리에도 등록되지 않도록 차단 (`useRegisterSider`가 이미 `null` 레지스트리를 안전하게 no-op 처리)

## 검증

jsdom + `react-dom/client` + `act()`로 실측 (임시 설치, 커밋 전 제거):

- 1024px(lg) 마운트, `breakpoint="md"` → `onCollapse`/`onBreakpoint` 정확히 `[false]` 1회 (기존 `[true,false]`)
- 375px(xs) 마운트, `breakpoint="md"` → `[true]` 1회 (실제 collapse 필요한 케이스도 정상 — "항상 false"로 퇴화하지 않음 확인)
- 수동 토글(80px) 후 무관한 리렌더 2회 → 폭 유지, 원복 안 됨
- `trigger={null}` → `<button>` 자체 미렌더
- `Layout > Content > Layout.Sider` → 바깥 `Layout`이 `flex-col` 유지 (`flex-row`로 안 뒤집힘)

`pnpm --filter @repo/ui lint`, `pnpm check-types`(5개 패키지), `pnpm check-dynamic-classes`, `pnpm --filter @repo/ui build` 모두 통과

Refs #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)