### PR TITLE
🐛 fix: imperative Modal/Toast inherit the root Config (#226)

### DIFF
--- a/.changeset/fix-imperative-stack-config-inherit.md
+++ b/.changeset/fix-imperative-stack-config-inherit.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Imperative stack components now inherit theme and locale from the root Config, allowing for consistent styling and behavior across the app.

--- a/packages/ui/src/components/organisms/imperative-stack.tsx
+++ b/packages/ui/src/components/organisms/imperative-stack.tsx
@@ -5,6 +5,8 @@ import { Root, createRoot } from 'react-dom/client';
 
 import { v4 as uuid } from 'uuid';
 
+import { ConfigSnapshotProvider, getRootConfigValue } from '@repo/ui/providers';
+
 // Shared machinery behind Modal.info/success/error/warning/confirm and
 // Toast.info/success/error/warning — both used to independently
 // reimplement ~120 near-identical lines of this (container-scoped stack,
@@ -64,12 +66,24 @@ export function createImperativeStack<
     return state;
   };
 
+  // Shared by `render` and `getRootElement` so both agree on the same
+  // target container whenever the caller doesn't pass one explicitly — the
+  // stack's React root (created once, in `render`) and the DOM node a
+  // `StackItem` (e.g. StaticToast) later portals into (calling
+  // `getRootElement` again with the same, possibly-undefined `container`)
+  // would otherwise resolve two different containers here, splitting the
+  // React tree (correctly under the root Config, via ConfigSnapshotProvider
+  // above) from the actual visible DOM (silently back under `document.body`,
+  // outside the Config's themed wrapper — undoing this fix's whole point).
+  const resolveContainer = (container?: HTMLElement): HTMLElement =>
+    container || getRootConfigValue()?.getContainer() || document.body;
+
   const getRootElement = (container?: HTMLElement): HTMLElement | null => {
     if (!isBrowser) {
       return null;
     }
 
-    const targetContainer = container || document.body;
+    const targetContainer = resolveContainer(container);
     let rootEl = rootElements.get(targetContainer);
 
     if (!rootEl) {
@@ -95,11 +109,11 @@ export function createImperativeStack<
     const { stack } = getContainerState(container);
 
     return (
-      <>
+      <ConfigSnapshotProvider>
         {stack.map(({ id, ...props }) => (
           <StackItem key={id} id={id} {...(props as TProps)} />
         ))}
-      </>
+      </ConfigSnapshotProvider>
     );
   };
 
@@ -108,7 +122,13 @@ export function createImperativeStack<
       return;
     }
 
-    const targetContainer = props.container || document.body;
+    // An explicit `container` prop always wins (it may be chosen for
+    // layout reasons unrelated to theming); otherwise mount into the root
+    // Config's own themed wrapper element (if one renders — see
+    // `needsWrapper` in config.tsx) so CSS custom properties and the
+    // `.dark` class cascade to this stack via normal DOM inheritance, not
+    // just `document.body` sitting as an unthemed sibling of it.
+    const targetContainer = resolveContainer(props.container);
     const rootElement = getRootElement(targetContainer)!;
 
     if (!reactRoots.has(targetContainer)) {

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 
 import { DirectionProvider } from '@radix-ui/react-direction';
 
 import { cn } from '@repo/ui/utils';
 
 import { Context, DEFAULT_LOCALE, useConfig } from './context';
+import { registerRootConfig } from './registry';
 import type {
   ComponentSize,
   DefaultProps,
@@ -136,6 +143,10 @@ const Config = ({
   const parent = useConfig();
   const [wrapperEl, setWrapperEl] = useState<HTMLDivElement | null>(null);
 
+  // Only a Config with no Config ancestor of its own registers for the
+  // imperative stack (Modal.*/Toast.*) to inherit — see registry.tsx.
+  const isRoot = !parent.isConfigured;
+
   // `theme` is typically a fresh inline object literal at the call site
   // (and `parent.theme` inherits the same problem from its own Config
   // ancestor), so depending on them directly meant mergedTheme/contextValue
@@ -251,6 +262,13 @@ const Config = ({
       mergedDefaultProps,
     ],
   );
+
+  useEffect(() => {
+    if (!isRoot) {
+      return;
+    }
+    return registerRootConfig(contextValue);
+  }, [isRoot, contextValue]);
 
   const content = (
     <Context.Provider value={contextValue}>

--- a/packages/ui/src/providers/config/index.ts
+++ b/packages/ui/src/providers/config/index.ts
@@ -1,4 +1,5 @@
 export { default, useConfig, DEFAULT_LOCALE } from './config';
+export { ConfigSnapshotProvider, getRootConfigValue } from './registry';
 export type {
   Props,
   ComponentSize,

--- a/packages/ui/src/providers/config/registry.tsx
+++ b/packages/ui/src/providers/config/registry.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Context } from './context';
+import type { ContextValue } from './types';
+
+// The imperative stack (Modal.*/Toast.*, see organisms/imperative-stack.tsx)
+// renders into its own React root, outside any <Config> ancestor — there's
+// no call-site component to read useConfig() from, since these are plain
+// function calls, not JSX. This module-level registry is how that root
+// finds a Config to inherit anyway: the app's root Config registers its
+// current context value here, and the stack re-wraps itself with it as a
+// snapshot at render time (not a live subscription — a Modal/Toast that's
+// already open won't pick up a Config change made after it was created,
+// same "reflects state at creation" behavior as everything else about the
+// imperative API being a one-shot call).
+//
+// Only the root Config (no Config ancestor of its own — see
+// `isRoot` in config.tsx) registers. A section-local nested Config (used
+// for one-off theming of part of a page) intentionally does not — an app-
+// wide `Modal.confirm()` call has no natural association with whichever
+// nested Config happened to render most recently, so it should inherit
+// the app's actual root configuration instead.
+let currentValue: ContextValue | null = null;
+
+export const registerRootConfig = (value: ContextValue): (() => void) => {
+  currentValue = value;
+
+  return () => {
+    if (currentValue === value) {
+      currentValue = null;
+    }
+  };
+};
+
+export const getRootConfigValue = (): ContextValue | null => currentValue;
+
+// Wraps the imperative stack's rendered items with whatever the root
+// Config's snapshot currently is, so useConfig() inside Modal/Toast (and
+// anything they render) resolves theme/locale/componentSize/etc instead of
+// the raw context default. A no-op passthrough when no root Config has
+// registered (e.g. no <Config> anywhere in the app).
+export const ConfigSnapshotProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const value = getRootConfigValue();
+
+  if (!value) {
+    return children;
+  }
+
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+};

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,4 +1,5 @@
 export { default as Config, useConfig, DEFAULT_LOCALE } from './config';
+export { ConfigSnapshotProvider, getRootConfigValue } from './config';
 export type {
   Props as ConfigProps,
   ComponentSize,


### PR DESCRIPTION
## 배경

#181 (Portal 렌더 컴포넌트 테마 미적용) 수정이 선언형 사용(`<Modal>`, `<Drawer>`, `Popover`, `Select`)은 고쳤지만, 명령형 API(`Modal.info/success/error/warning/confirm`, `Toast.info/...`)는 그대로 남아 있었다. `organisms/imperative-stack.tsx`가 스택 루트를 React 트리 완전히 바깥에 새 root로 렌더해서, 그 안의 `useConfig()`는 항상 raw 기본 컨텍스트를 돌려줌 → 테마/다크모드/locale/componentSize 전부 미적용.

## 변경

이슈가 제안한 "1(호출 시점 스냅샷) + 2(스택 루트를 테마 컨테이너에 mount) 병행"으로 구현:

1. **`providers/config/registry.tsx`** (신규) — 모듈 레벨 레지스트리. **루트 Config**(자신의 Config 조상이 없는 Config)만 자신의 context value를 등록. 여러 Config가 있을 때의 "어느 걸 쓸지" 문제는, 앱 전역으로 호출되는 `Modal.confirm()`이 우연히 최근 렌더된 로컬/섹션 Config가 아니라 **앱의 실제 루트 설정**을 물려받는 게 자연스럽다는 판단으로 "루트만 등록" 규칙 채택
2. **`ConfigSnapshotProvider`** — `StackRenderer`가 렌더하는 스택 아이템들을 이 레지스트리 스냅샷으로 감싸, 그 안의 `useConfig()`가 실제 앱 설정을 받도록
3. **컨테이너 기본값** — 호출자가 `container`를 명시하지 않으면 `document.body` 대신 루트 Config의 테마 wrapper 엘리먼트로 기본 마운트 (CSS 변수/`.dark` 클래스가 DOM 상속으로 전달). `render()`와 `getRootElement()`가 각자 따로 기본값을 계산하면 (Context가 씌워진 React 트리와 실제 portal DOM 타겟이) 서로 다른 컨테이너로 갈라질 수 있어서, `resolveContainer` 하나로 통합해 둘이 항상 같은 결과를 보도록 함
4. `Modal`의 Radix Dialog 자체 포탈은 이미 `container ?? getContainer()`(`core/dialog.tsx`, #181/#218에서 고쳐짐)로 동작하므로, 이번에 Context만 올바르게 주입되면 별도 수정 없이 자동으로 같이 고쳐짐

## 검증

jsdom + `react-dom/client` + `act()`로 Radix Dialog까지 실제로 마운트해서 확인 (임시 설치, 커밋 전 제거):

- `<Config theme={{ dark: 'dark', token: {...} }}>` 아래서 `Modal.confirm()` → 렌더된 dialog가 `.dark` wrapper **안에** 위치 (기존엔 `document.body`, wrapper 밖 — 이슈가 지적한 정확한 증상)
- 같은 조건에서 `Toast.info()` → toast도 `.dark` wrapper 안에 위치
- Toast 닫기 버튼 `aria-label`이 locale 기본값(`'닫기'`)으로 표시 — #229에서 배선해둔 `useConfig()` 호출이 이번에 처음으로 실제 Config를 전달받음

`pnpm --filter @repo/ui lint`, `pnpm check-types`(5개 패키지), `pnpm check-dynamic-classes`, `pnpm --filter @repo/ui build` 모두 통과

## 스코프 외

- Toast 스택 루트의 `aria-label="Notifications"` — `createRootElement`가 순수 DOM 생성 함수(React 트리 밖)라 여전히 하드코딩 (#229에서 이미 문서화된 제약, 이번 PR로도 해소 안 됨: React 트리 안이 아니라 DOM 노드 생성 시점의 문제라 Context 주입과 무관)
- 여러 개의 독립적인 "루트" Config가 동시에 존재하는 극단적 케이스(공유 조상 없는 두 위젯 아일랜드)의 동점 처리 — "마지막 등록이 이김" 자연 동작, 문서화하지 않음

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)