### PR TITLE
🐛 fix: drive Row/Col's responsive layout with CSS, not JS measurement

### DIFF
--- a/.changeset/fix-row-col-ssr-breakpoint.md
+++ b/.changeset/fix-row-col-ssr-breakpoint.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Added support for responsive grid layout with mobile-first cascade, allowing for dynamic column and offset values based on breakpoint tiers.

--- a/packages/ui/src/components/templates/grid/col.tsx
+++ b/packages/ui/src/components/templates/grid/col.tsx
@@ -29,13 +29,54 @@ export interface Props extends React.ComponentProps<'div'> {
 const resolveColSpan = (value: ColSpanProp | undefined) =>
   typeof value === 'number' ? { span: value } : value;
 
+// Mobile-first cascade, run once per breakpoint tier (not just the
+// "current" one) — each tier's entry is what a `<Col span={24} md={12} />`
+// effectively resolves to *at and above* that tier, letting each defined
+// prop override the last. `globals.css`'s `[data-slot='col']` rules read
+// one of these six values per tier, switched by a real `@media` query —
+// see the comment on the returned CSS custom properties below for why.
+const resolveEffectiveValuesByTier = (
+  span: number,
+  offset: number,
+  responsiveProps: Partial<Record<Breakpoint, ColSpanProp | undefined>>,
+) => {
+  let effectiveSpan = span;
+  let effectiveOffset = offset;
+  const spans = {} as Record<Breakpoint, number>;
+  const offsets = {} as Record<Breakpoint, number>;
+
+  for (const bp of BREAKPOINT_ORDER) {
+    const resolved = resolveColSpan(responsiveProps[bp]);
+
+    if (resolved?.span !== undefined) {
+      effectiveSpan = resolved.span;
+    }
+    if (resolved?.offset !== undefined) {
+      effectiveOffset = resolved.offset;
+    }
+
+    spans[bp] = effectiveSpan;
+    offsets[bp] = effectiveOffset;
+  }
+
+  return { spans, offsets };
+};
+
 // 24-column system (matches Ant Design's Row/Col, a familiar mental model
-// for anyone coming from it) implemented with plain percentage widths
-// rather than Tailwind's col-span-* utilities — those utilities need a
-// literal, statically-scannable class per (breakpoint, span) combination,
-// and 6 breakpoints x 24 spans is 144 combinations, most of which would
-// never be used. Percentage math scales to any span/breakpoint
-// combination with one code path instead.
+// for anyone coming from it). The actual `flex-basis`/`max-width`/
+// `margin-left` math lives in `globals.css` (`[data-slot='col']`), driven
+// by real `@media` queries — this component's only job is resolving each
+// breakpoint tier's effective span/offset (pure prop math, no `window`
+// access) and handing them over as CSS custom properties. That's what
+// makes the responsive behavior work from the very first (server-rendered)
+// paint: previously this picked one "current" tier via `useResponsiveSize`
+// (which measures the viewport client-side, so it can't know the real
+// value until after mount) and baked only *that* into an inline style,
+// so SSR output — and the first client paint, before that measurement
+// effect ran — was always the same-as-`useResponsiveSize`'s SSR-safe 'xs'
+// guess, regardless of the real viewport. Handing over all six tiers and
+// letting CSS pick lets the browser resolve the right one immediately,
+// with no JS and no resize listener needed at all.
 const Col = ({
   span = TOTAL_COLUMNS,
   offset = 0,
@@ -50,43 +91,38 @@ const Col = ({
   children,
   ...props
 }: Props) => {
-  const { gutterX, breakpoint } = useRowContext();
+  const { gutterX } = useRowContext();
 
   const responsiveProps: Partial<Record<Breakpoint, ColSpanProp | undefined>> =
     { xs, sm, md, lg, xl, '2xl': xxl };
 
-  let effectiveSpan = span;
-  let effectiveOffset = offset;
+  const { spans, offsets } = resolveEffectiveValuesByTier(
+    span,
+    offset,
+    responsiveProps,
+  );
 
-  // Mobile-first cascade: walk breakpoints up to (and including) the
-  // current one, letting each defined prop override the last — so
-  // `<Col span={24} md={12} />` is 24 below md and 12 from md upward, with
-  // no need to also specify lg/xl/2xl for the value to keep applying.
-  for (const bp of BREAKPOINT_ORDER) {
-    if (BREAKPOINT_ORDER.indexOf(bp) > BREAKPOINT_ORDER.indexOf(breakpoint)) {
-      break;
-    }
-
-    const resolved = resolveColSpan(responsiveProps[bp]);
-
-    if (resolved?.span !== undefined) {
-      effectiveSpan = resolved.span;
-    }
-    if (resolved?.offset !== undefined) {
-      effectiveOffset = resolved.offset;
-    }
-  }
-
-  const widthPercent = (effectiveSpan / TOTAL_COLUMNS) * 100;
-  const offsetPercent = (effectiveOffset / TOTAL_COLUMNS) * 100;
+  const cssVars = {
+    '--col-span-xs': spans.xs,
+    '--col-span-sm': spans.sm,
+    '--col-span-md': spans.md,
+    '--col-span-lg': spans.lg,
+    '--col-span-xl': spans.xl,
+    '--col-span-2xl': spans['2xl'],
+    '--col-offset-xs': offsets.xs,
+    '--col-offset-sm': offsets.sm,
+    '--col-offset-md': offsets.md,
+    '--col-offset-lg': offsets.lg,
+    '--col-offset-xl': offsets.xl,
+    '--col-offset-2xl': offsets['2xl'],
+  } as React.CSSProperties;
 
   return (
     <div
+      data-slot="col"
       className={cn('box-border shrink-0 grow-0', className)}
       style={{
-        flexBasis: `${widthPercent}%`,
-        maxWidth: `${widthPercent}%`,
-        marginLeft: offsetPercent ? `${offsetPercent}%` : undefined,
+        ...cssVars,
         paddingLeft: gutterX ? gutterX / 2 : undefined,
         paddingRight: gutterX ? gutterX / 2 : undefined,
         ...style,

--- a/packages/ui/src/components/templates/grid/row-context.ts
+++ b/packages/ui/src/components/templates/grid/row-context.ts
@@ -5,17 +5,13 @@ export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 export interface RowContextValue {
   gutterX: number;
   gutterY: number;
-  breakpoint: Breakpoint;
 }
 
 // Defaults assume Col is used without a Row (not the intended usage, but
-// shouldn't crash) — 'xs' matches useResponsiveSize's own SSR-safe initial
-// guess (measures 0 width before mount), same mobile-first default Sider's
-// breakpoint feature already relies on.
+// shouldn't crash).
 export const RowContext = createContext<RowContextValue>({
   gutterX: 0,
   gutterY: 0,
-  breakpoint: 'xs',
 });
 
 export const useRowContext = () => useContext(RowContext);

--- a/packages/ui/src/components/templates/grid/row.tsx
+++ b/packages/ui/src/components/templates/grid/row.tsx
@@ -2,8 +2,6 @@
 
 import { useMemo } from 'react';
 
-import { useResponsiveSize } from '@jbpark/use-hooks';
-
 import { cn } from '@repo/ui/utils';
 
 import { RowContext } from './row-context';
@@ -31,9 +29,6 @@ export interface Props extends React.ComponentProps<'div'> {
   wrap?: boolean;
 }
 
-// The breakpoint tier is resolved once here (not per-Col) so N columns
-// share a single resize listener instead of each mounting its own via
-// useResponsiveSize — matters once a grid has more than a couple Cols.
 const Row = ({
   gutter = 0,
   align,
@@ -45,11 +40,10 @@ const Row = ({
   ...props
 }: Props) => {
   const [gutterX, gutterY] = Array.isArray(gutter) ? gutter : [gutter, 0];
-  const { breakpoint } = useResponsiveSize({ viewport: true });
 
   const contextValue = useMemo(
-    () => ({ gutterX, gutterY, breakpoint: breakpoint.current }),
-    [gutterX, gutterY, breakpoint],
+    () => ({ gutterX, gutterY }),
+    [gutterX, gutterY],
   );
 
   return (

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -192,4 +192,53 @@
   [data-slot='button'][data-color='gold'] {
     --btn-bg: #f59e0b;
   }
+
+  /* Row/Col's 24-column responsive grid (templates/grid/col.tsx) — Col
+   * hands over one CSS custom property per breakpoint tier, already
+   * resolved via its own mobile-first cascade (pure prop math, no
+   * `window` access), and these rules pick the active tier via a real
+   * @media query. That's what makes the layout correct from the very
+   * first (server-rendered) paint, with no client JS needed for the
+   * responsive behavior itself. Breakpoints match Tailwind v4's own
+   * defaults (40/48/64/80/96rem). */
+  [data-slot='col'] {
+    flex-basis: calc(var(--col-span-xs) / 24 * 100%);
+    max-width: calc(var(--col-span-xs) / 24 * 100%);
+    margin-left: calc(var(--col-offset-xs, 0) / 24 * 100%);
+  }
+  @media (width >= 40rem) {
+    [data-slot='col'] {
+      flex-basis: calc(var(--col-span-sm) / 24 * 100%);
+      max-width: calc(var(--col-span-sm) / 24 * 100%);
+      margin-left: calc(var(--col-offset-sm, 0) / 24 * 100%);
+    }
+  }
+  @media (width >= 48rem) {
+    [data-slot='col'] {
+      flex-basis: calc(var(--col-span-md) / 24 * 100%);
+      max-width: calc(var(--col-span-md) / 24 * 100%);
+      margin-left: calc(var(--col-offset-md, 0) / 24 * 100%);
+    }
+  }
+  @media (width >= 64rem) {
+    [data-slot='col'] {
+      flex-basis: calc(var(--col-span-lg) / 24 * 100%);
+      max-width: calc(var(--col-span-lg) / 24 * 100%);
+      margin-left: calc(var(--col-offset-lg, 0) / 24 * 100%);
+    }
+  }
+  @media (width >= 80rem) {
+    [data-slot='col'] {
+      flex-basis: calc(var(--col-span-xl) / 24 * 100%);
+      max-width: calc(var(--col-span-xl) / 24 * 100%);
+      margin-left: calc(var(--col-offset-xl, 0) / 24 * 100%);
+    }
+  }
+  @media (width >= 96rem) {
+    [data-slot='col'] {
+      flex-basis: calc(var(--col-span-2xl) / 24 * 100%);
+      max-width: calc(var(--col-span-2xl) / 24 * 100%);
+      margin-left: calc(var(--col-offset-2xl, 0) / 24 * 100%);
+    }
+  }
 }


### PR DESCRIPTION
## 배경

#180 D 제안으로 추가된 `Row`/`Col`(#215)의 24컬럼 퍼센트 계산 자체는 의도대로 동작하지만, 반응형 판정이 전적으로 JS 런타임 측정(`useResponsiveSize`)에 의존해서 **SSR 결과가 항상 모바일(`xs`) 레이아웃**으로 고정되는 문제.

```tsx
<Row gutter={16}>
  <Col span={24} md={12} lg={6}>a</Col>
  <Col span={24} md={12} lg={6}>b</Col>
</Row>
```

기존엔 `lg={6}`(25%)을 지정해도 서버 출력이 두 컬럼 모두 `flex-basis:100%`였고, 하이드레이션 후에야 4열로 재배치되며 눈에 띄는 레이아웃 시프트(CLS)가 발생. JS 없이는 반응형이 전혀 동작하지 않았음.

## 변경

이슈가 제안한 "CSS 변수 + 미디어쿼리" 방향으로 구현:

- `Col`이 이미 갖고 있던 mobile-first cascade 로직을 "현재 tier 하나"가 아니라 **6개 tier 전부**에 대해 계산(순수 prop 연산, `window` 접근 없음)해서 `--col-span-*`/`--col-offset-*` CSS 커스텀 속성으로 전부 내려줌
- `globals.css`에 `[data-slot='col']` 규칙 블록 신설 — 실제 `@media` 쿼리(Tailwind v4 기본 breakpoint 40/48/64/80/96rem과 동일)로 활성 tier를 골라 `flex-basis`/`max-width`/`margin-left`를 `calc()`로 계산. 손으로 쓴 정적 CSS라 `check-dynamic-classes` 스크립트의 "literal class" 제약과 무관하고, 144개(6 breakpoint × 24 span) 조합을 나열할 필요 없이 `calc()` 하나로 전부 커버
- `Row`는 이제 `useResponsiveSize`/resize 리스너가 아예 필요 없음 (Col의 크기 결정이 완전히 CSS로 이관됨) — `RowContext`의 `breakpoint` 필드도 다른 소비처가 없어 함께 제거

## 검증

`pnpm --filter @repo/ui build` 산출물을 `renderToStaticMarkup`으로 실측:

```
<div data-slot="col" ... style="--col-span-xs:24;--col-span-sm:24;--col-span-md:12;--col-span-lg:6;--col-span-xl:6;--col-span-2xl:6;...">
```

- SSR 출력에 6개 tier 값이 전부 담기고, 인라인 `flex-basis`는 완전히 사라짐 (CSS가 담당)
- 컴파일된 `dist/style.css`에 6개 `@media (width >= ...)` 블록이 Tailwind v4 기본 breakpoint와 정확히 일치

`pnpm --filter @repo/ui lint`, `pnpm check-types`(5개 패키지), `pnpm check-dynamic-classes`, `pnpm --filter @repo/ui build` 모두 통과

## 스코프 외

이슈의 🟡(부수) 섹션 — `Container`/`Empty`/`Result`/`PageHeader`/`Row`·`Col`의 Storybook 스토리 5개 누락은 SSR 버그와 무관한 별개 작업이라 이번 PR에 포함하지 않음. 필요하면 별도로 처리 가능.

Refs #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)