### PR TITLE
📝 docs: add Storybook stories for Container, Empty, Result, PageHeader, Grid

### DIFF
--- a/.changeset/docs-templates-stories-docs.md
+++ b/.changeset/docs-templates-stories-docs.md
@@ -1,0 +1,5 @@
+---
+'docs': minor
+---
+
+New UI components and templates for layout, data display, navigation, and feedback have been added to the Storybook documentation site.

--- a/apps/docs/stories/templates/container/index.stories.tsx
+++ b/apps/docs/stories/templates/container/index.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Container } from '@repo/ui';
+
+const meta: Meta<typeof Container> = {
+  title: 'Layout/Container',
+  component: Container,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    maxWidth: {
+      control: { type: 'select' },
+      options: [
+        '3xs',
+        '2xs',
+        'xs',
+        'sm',
+        'md',
+        'lg',
+        'xl',
+        '2xl',
+        '3xl',
+        '4xl',
+        '5xl',
+        '6xl',
+        '7xl',
+        'full',
+        'none',
+      ],
+    },
+    padded: {
+      control: { type: 'boolean' },
+    },
+    asChild: {
+      table: { disable: true },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DemoContent = () => (
+  <div
+    className="rounded border border-dashed border-gray-300 bg-gray-50 py-6
+      text-center text-sm text-gray-500"
+  >
+    이 영역이 Container의 maxWidth/padded 설정에 따라 폭이 제한되고 좌우 여백이
+    붙습니다.
+  </div>
+);
+
+export const Default: Story = {
+  args: {
+    maxWidth: '7xl',
+    padded: true,
+  },
+  render: args => (
+    <Container {...args}>
+      <DemoContent />
+    </Container>
+  ),
+};
+
+export const NarrowMaxWidth: Story = {
+  args: {
+    maxWidth: 'md',
+    padded: true,
+  },
+  render: args => (
+    <Container {...args}>
+      <DemoContent />
+    </Container>
+  ),
+};
+
+export const NoPadding: Story = {
+  args: {
+    maxWidth: 'lg',
+    padded: false,
+  },
+  render: args => (
+    <Container {...args}>
+      <DemoContent />
+    </Container>
+  ),
+};

--- a/apps/docs/stories/templates/empty/index.stories.tsx
+++ b/apps/docs/stories/templates/empty/index.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button, Empty } from '@repo/ui';
+
+const meta: Meta<typeof Empty> = {
+  title: 'Data Display/Empty',
+  component: Empty,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    icon: { table: { disable: true } },
+    action: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    description: 'No data',
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    title: '검색 결과가 없습니다',
+    description: '다른 검색어로 다시 시도해 보세요',
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    title: '항목이 없습니다',
+    description: '첫 항목을 추가해 보세요',
+  },
+  render: args => (
+    <Empty {...args} action={<Button color="primary">항목 추가</Button>} />
+  ),
+};

--- a/apps/docs/stories/templates/grid/index.stories.tsx
+++ b/apps/docs/stories/templates/grid/index.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Col, Row } from '@repo/ui';
+import { cn } from '@repo/ui/utils';
+
+const meta: Meta<typeof Row> = {
+  title: 'Layout/Grid',
+  component: Row,
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    align: {
+      control: { type: 'select' },
+      options: ['top', 'middle', 'bottom', 'stretch'],
+    },
+    justify: {
+      control: { type: 'select' },
+      options: [
+        'start',
+        'end',
+        'center',
+        'space-around',
+        'space-between',
+        'space-evenly',
+      ],
+    },
+    wrap: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Block = ({ children }: { children: React.ReactNode }) => (
+  <div
+    className={cn(
+      'rounded bg-blue-50 py-4 text-center text-sm text-blue-700',
+      'border border-blue-200',
+    )}
+  >
+    {children}
+  </div>
+);
+
+// Resize the preview (or open on a phone) to see the columns reflow —
+// entirely via CSS media queries, no JavaScript measurement involved
+// (see #228: this used to only be correct after client-side hydration).
+export const Responsive: Story = {
+  args: {
+    gutter: 16,
+  },
+  render: args => (
+    <Row {...args}>
+      {[1, 2, 3, 4].map(n => (
+        <Col key={n} span={24} sm={12} md={8} lg={6}>
+          <Block>span=24 sm=12 md=8 lg=6</Block>
+        </Col>
+      ))}
+    </Row>
+  ),
+};
+
+export const Gutter: Story = {
+  args: {
+    gutter: [16, 24],
+  },
+  render: args => (
+    <Row {...args}>
+      {Array.from({ length: 6 }, (_, i) => i + 1).map(n => (
+        <Col key={n} span={8}>
+          <Block>span=8</Block>
+        </Col>
+      ))}
+    </Row>
+  ),
+};
+
+export const Offset: Story = {
+  args: {
+    gutter: 16,
+  },
+  render: args => (
+    <Row {...args}>
+      <Col span={8}>
+        <Block>span=8</Block>
+      </Col>
+      <Col span={8} offset={8}>
+        <Block>span=8 offset=8</Block>
+      </Col>
+    </Row>
+  ),
+};
+
+export const AlignAndJustify: Story = {
+  args: {
+    gutter: 16,
+    align: 'middle',
+    justify: 'space-between',
+  },
+  render: args => (
+    <Row {...args} className="h-32 bg-gray-50">
+      <Col span={4}>
+        <Block>span=4</Block>
+      </Col>
+      <Col span={4}>
+        <Block>span=4</Block>
+      </Col>
+      <Col span={4}>
+        <Block>span=4</Block>
+      </Col>
+    </Row>
+  ),
+};

--- a/apps/docs/stories/templates/page-header/index.stories.tsx
+++ b/apps/docs/stories/templates/page-header/index.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button, PageHeader } from '@repo/ui';
+
+const meta: Meta<typeof PageHeader> = {
+  title: 'Navigation/PageHeader',
+  component: PageHeader,
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    onBack: {
+      table: { disable: true },
+    },
+    backIcon: {
+      table: { disable: true },
+    },
+    extra: {
+      table: { disable: true },
+    },
+    classNames: {
+      table: { disable: true },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: '상품 상세',
+    onBack: () => {},
+  },
+};
+
+export const WithSubTitle: Story = {
+  args: {
+    title: '주문 #2026081300001',
+    subTitle: '2026년 8월 13일 결제 완료',
+    onBack: () => {},
+  },
+};
+
+export const WithExtra: Story = {
+  args: {
+    title: '상품 상세',
+    onBack: () => {},
+  },
+  render: args => (
+    <PageHeader
+      {...args}
+      extra={
+        <div className="flex gap-2">
+          <Button variant="outlined">공유</Button>
+          <Button color="primary">수정</Button>
+        </div>
+      }
+    />
+  ),
+};
+
+export const NoBackButton: Story = {
+  args: {
+    title: '설정',
+  },
+};

--- a/apps/docs/stories/templates/result/index.stories.tsx
+++ b/apps/docs/stories/templates/result/index.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button, Result } from '@repo/ui';
+
+const meta: Meta<typeof Result> = {
+  title: 'Feedback/Result',
+  component: Result,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    status: {
+      control: { type: 'select' },
+      options: ['success', 'error', 'info', 'warning', '404', '403', '500'],
+    },
+    icon: { table: { disable: true } },
+    extra: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  args: {
+    status: 'success',
+    title: '주문이 완료되었습니다',
+    subTitle: '주문번호 2026081300001을 확인해 주세요',
+  },
+  render: args => (
+    <Result {...args} extra={<Button color="primary">주문 내역 보기</Button>} />
+  ),
+};
+
+export const Error: Story = {
+  args: {
+    status: 'error',
+    title: '처리 중 문제가 발생했습니다',
+    subTitle: '입력하신 정보를 확인하고 다시 시도해 주세요',
+  },
+  render: args => (
+    <Result {...args} extra={<Button color="primary">다시 시도</Button>} />
+  ),
+};
+
+export const NotFound: Story = {
+  name: '404',
+  args: {
+    status: '404',
+    title: '404',
+    subTitle: '요청하신 페이지를 찾을 수 없습니다',
+  },
+  render: args => (
+    <Result {...args} extra={<Button color="primary">홈으로 이동</Button>} />
+  ),
+};
+
+export const Forbidden: Story = {
+  name: '403',
+  args: {
+    status: '403',
+    title: '403',
+    subTitle: '이 페이지에 접근할 권한이 없습니다',
+  },
+};
+
+export const ServerError: Story = {
+  name: '500',
+  args: {
+    status: '500',
+    title: '500',
+    subTitle: '서버에 일시적인 오류가 발생했습니다',
+  },
+};


### PR DESCRIPTION
## 배경

#228의 🟡(부수) 항목 — #180으로 추가된 templates 티어 컴포넌트 5개(`Container`, `Empty`, `Result`, `PageHeader`, `Row`/`Col`)에 Storybook 스토리가 하나도 없었음. atoms/molecules/organisms는 전부 커버돼 있어서 templates만 비어 있던 상태.

## 변경

- `Container` (`Layout/Container`) — maxWidth/padded 조합 3종
- `Empty` (`Data Display/Empty`) — 기본/제목 포함/액션 버튼 포함
- `Result` (`Feedback/Result`) — success/error/404/403/500
- `PageHeader` (`Navigation/PageHeader`) — 기본/부제목/extra 액션/뒤로가기 버튼 없음
- `Row`/`Col` (`Layout/Grid`) — 반응형 컬럼, gutter, offset, align/justify. `Responsive` 스토리는 #234에서 CSS 미디어쿼리로 전환한 SSR 수정을 시각적으로 확인하는 용도도 겸함 (뷰포트를 조절하면 클라이언트 JS 없이 CSS만으로 리플로우)

카테고리 taxonomy(`Layout`/`Data Display`/`Feedback`/`Navigation`)는 기존 스토리들의 기존 분류 관례를 그대로 따름.

## 검증

- `pnpm --filter docs lint`, `pnpm check-types`(5개 패키지) 통과
- `pnpm --filter docs build-storybook` 프로덕션 빌드 성공 — 신규 스토리 5개가 정상적으로 인덱싱·번들링됨
- 이 환경에서 브라우저 도구가 응답하지 않아 실제 렌더링 스크린샷 확인은 못 했음 — 위 정적 검증(빌드 성공, 타입 통과)으로 갈음

Refs #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)