### PR TITLE
♻️ refactor: adopt useKeyPress in Dropdown, Radio, Checkbox

### DIFF
--- a/.changeset/refactor-use-key-press-adoption.md
+++ b/.changeset/refactor-use-key-press-adoption.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Radio and checkbox components now support keyboard navigation with Enter and space keys.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
-    "@jbpark/use-hooks": "^3.0.0",
+    "@jbpark/use-hooks": "^4.0.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/ui/src/components/atoms/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/atoms/checkbox/checkbox.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 
-import { useControllableState } from '@jbpark/use-hooks';
+import { useControllableState, useKeyPress } from '@jbpark/use-hooks';
 import { Square, SquareCheck } from 'lucide-react';
 
 import { checkbox, label } from '@repo/ui/core';
@@ -61,6 +61,17 @@ const Checkbox = ({
     setChecked(next);
   };
 
+  const iconTriggerRef = useRef<HTMLSpanElement>(null);
+
+  useKeyPress(
+    ['Enter', 'space'],
+    event => {
+      event.preventDefault();
+      onChange(!checked);
+    },
+    { target: iconTriggerRef, enabled: !!icons && !disabled },
+  );
+
   const renderContent = icons ? (
     <>
       <input
@@ -76,6 +87,7 @@ const Checkbox = ({
         }}
       />
       <span
+        ref={iconTriggerRef}
         role="checkbox"
         aria-checked={checked}
         aria-disabled={disabled}
@@ -83,12 +95,6 @@ const Checkbox = ({
         className={cn(cursorClassName, disabled && 'opacity-50')}
         onClick={() => {
           onChange(!checked);
-        }}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onChange(!checked);
-          }
         }}
       >
         {checked

--- a/packages/ui/src/components/atoms/radio/radio.tsx
+++ b/packages/ui/src/components/atoms/radio/radio.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useContext, useId } from 'react';
+import { useContext, useId, useRef } from 'react';
 
-import { useControllableState } from '@jbpark/use-hooks';
+import { useControllableState, useKeyPress } from '@jbpark/use-hooks';
 import { Circle, CircleCheck } from 'lucide-react';
 
 import { field, radio } from '@repo/ui/core';
@@ -73,6 +73,17 @@ const Radio = ({
     setChecked(next);
   };
 
+  const iconTriggerRef = useRef<HTMLSpanElement>(null);
+
+  useKeyPress(
+    ['Enter', 'space'],
+    event => {
+      event.preventDefault();
+      onChange(true);
+    },
+    { target: iconTriggerRef, enabled: !!icons && !disabled },
+  );
+
   // When rendered inside a `RadioGroup`, the group owns the single shared
   // `Core` (Radix radiogroup root) so that arrow keys move focus across every
   // option. A standalone `Radio` still has to provide its own root.
@@ -104,6 +115,7 @@ const Radio = ({
         }}
       />
       <span
+        ref={iconTriggerRef}
         role="radio"
         aria-checked={checked}
         aria-disabled={disabled}
@@ -111,12 +123,6 @@ const Radio = ({
         className={cn(cursorClassName, disabled && 'opacity-50')}
         onClick={() => {
           onChange(true);
-        }}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onChange(true);
-          }
         }}
       >
         {checked

--- a/packages/ui/src/components/molecules/dropdown.tsx
+++ b/packages/ui/src/components/molecules/dropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useId, useRef } from 'react';
 
-import { useControllableState } from '@jbpark/use-hooks';
+import { useControllableState, useKeyPress } from '@jbpark/use-hooks';
 import { AnimatePresence, motion } from 'motion/react';
 
 import { cn } from '@repo/ui/utils';
@@ -38,6 +38,24 @@ const Dropdown = ({
   const isClickTrigger = trigger === 'click';
   const menuId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  useKeyPress(
+    'esc',
+    () => {
+      onOpenChange(false);
+    },
+    { target: triggerRef },
+  );
+
+  useKeyPress(
+    ['Enter', 'space'],
+    event => {
+      event.preventDefault();
+      onOpenChange(!open);
+    },
+    { target: triggerRef, enabled: isClickTrigger },
+  );
 
   return (
     <div
@@ -65,6 +83,7 @@ const Dropdown = ({
       }}
     >
       <div
+        ref={triggerRef}
         role={isClickTrigger ? 'button' : undefined}
         tabIndex={isClickTrigger ? 0 : undefined}
         aria-haspopup="menu"
@@ -91,16 +110,6 @@ const Dropdown = ({
           // check menu/item/item.tsx already uses for the same reason.
           if (!containerRef.current?.contains(e.relatedTarget as Node)) {
             onOpenChange(false);
-          }
-        }}
-        onKeyDown={e => {
-          if (e.key === 'Escape') {
-            onOpenChange(false);
-            return;
-          }
-          if (isClickTrigger && (e.key === 'Enter' || e.key === ' ')) {
-            e.preventDefault();
-            onOpenChange(!open);
           }
         }}
       >

--- a/packages/ui/src/components/molecules/menu/item/item.tsx
+++ b/packages/ui/src/components/molecules/menu/item/item.tsx
@@ -123,6 +123,17 @@ const Item = ({
   // fully state-tracked implementation — focus resets to the first item
   // if the user Tabs out and back in rather than resuming where they left
   // off.
+  //
+  // Deliberately not `useKeyPress` (unlike dropdown.tsx's trigger and
+  // radio.tsx/checkbox.tsx's icon mode, #229's action item 5): that hook
+  // is a static combo -> handler binding, one listener per combo. This
+  // handler is a single stateful branch — Enter/Space select, Escape
+  // conditionally closes a submenu and stops the event from also closing
+  // an ancestor Dropdown, and the arrow-key branch reads `itemRef` at
+  // fire time to focus a *sibling* `<li>`. Splitting that into 3-4
+  // separate useKeyPress calls (each its own listener) per menu item
+  // wouldn't fix a bug — the existing logic is already correct — it would
+  // just multiply listeners across every item in a menu for no benefit.
   const handleKeyDown = (domEvent: React.KeyboardEvent) => {
     if (domEvent.key === 'Enter' || domEvent.key === ' ') {
       domEvent.preventDefault();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.3)
       '@jbpark/use-hooks':
-        specifier: ^3.0.0
-        version: 3.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^4.0.0
+        version: 4.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -880,8 +880,8 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@jbpark/use-hooks@3.0.0':
-    resolution: {integrity: sha512-anqXEbjtzPgmUss2o6+AueEU7aMs0/5qGFUJScEuyLZ7auEP/PpkrFmwh287qa2/HLB+wHDjqJeQAAUKbiS49Q==}
+  '@jbpark/use-hooks@4.0.0':
+    resolution: {integrity: sha512-aEjYUEfajslgzeiSzH7s6jgx91sxjAh0v5XXcsED8weH50/J7zjDEjfPry/2WUqjQfzuV8J16EMX/gyWstWmBw==}
     peerDependencies:
       react: ^19.1.1
       react-dom: ^19.1.1
@@ -5431,7 +5431,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@jbpark/use-hooks@3.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@jbpark/use-hooks@4.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## 배경

#229 5번 — #185에서 체크리스트에 있었지만 미반영으로 이슈가 닫힌 항목. `dropdown.tsx`, `menu/item/item.tsx`, `radio.tsx`, `checkbox.tsx`가 모두 `onKeyDown` 수동 분기를 유지하고 있었음. 동작 자체는 정상이라 버그는 아니었음.

## 변경

- `@jbpark/use-hooks`를 `^3.0.0` → `^4.0.0`으로 업그레이드 — Enter/Space를 다루는 세 컴포넌트에 필요한 space 별칭 수정(space-hooks#139)이 4.0.0에만 있음
- **Dropdown**: 트리거의 Escape(항상)와 Enter/Space(click trigger일 때만)를 `useKeyPress`로 전환 (트리거 ref 타겟)
- **Radio/Checkbox**: `icons` 모드에서 직접 굴리는 `role="radio"`/`role="checkbox"` span의 Enter/Space 선택·토글도 동일하게 전환

## 스코프 제외 — `menu/item/item.tsx`

의도적으로 그대로 둠. 이 핸들러는 Enter/Space 선택, Escape의 조건부 서브메뉴 닫기+`stopPropagation`, 화살표 키의 형제 `<li>` 포커스 이동이 하나의 상태 기반 분기로 얽혀 있어 — `useKeyPress`는 "정적 combo → handler, combo당 리스너 1개" 모델이라 이 로직을 3~4개의 개별 `useKeyPress` 호출로 쪼개면 메뉴 항목마다 리스너만 늘어날 뿐 고쳐지는 버그는 없음(기존 로직은 이미 정확함). 코드에 이유를 문서화.

## 검증

jsdom + `react-dom/client` + `act()`로 실제 키 이벤트 발생시켜 확인 (임시 설치, 커밋 전 제거):

- Dropdown(`trigger="click"`): Space로 열림, Escape로 닫힘, Enter로 재오픈
- Dropdown(`trigger="hover"`, 기본값): Space/Enter 무반응(의도대로 `enabled: isClickTrigger`), Escape는 여전히 닫음
- Radio(icons 모드): Space로 선택
- Radio(icons 모드, disabled): Space 무반응
- Checkbox(icons 모드): Space로 토글 on, Enter로 토글 off

12개 케이스 전부 PASS. `pnpm --filter @repo/ui lint`, `pnpm check-types`(5개 패키지), `pnpm check-dynamic-classes`, `pnpm --filter @repo/ui build` 모두 통과

Refs #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## useToggle 검토 (#229 5번, 나머지 절반)

`dropdown`/`collapse`/`drawer`/`modal`의 boolean 상태를 `useToggle`로 통일하는 안을 검토했음. 결론은 **적용 대상 없음**:

- **Dropdown/Radio/Checkbox**: `useControllableState`로 제어형(`value`/`onChange`) API를 지원해야 하는데, `useToggle`의 시그니처(`[value, toggle, setValue]`)엔 그게 없음. 바꾸면 controlled 모드가 깨짐
- **Collapse**: 로컬 boolean 상태 자체가 없음 — Radix `Accordion`에 `activeKey`(문자열 키 배열)로 완전히 위임
- **Drawer**: 로컬 상태 전혀 없음, 완전히 prop 기반
- **Modal**: `StaticModal`에 `useState(true)` → `setOpen(false)` 한 번 전환만 있고 `toggle()`은 안 씀 — 진짜 "토글"이 아니라 바꿔도 이득 없는 치환

4곳 모두 `useToggle`을 억지로 적용할 이유가 없어 코드 변경 없이 검토만으로 마무리.
