### PR TITLE
fix(switch): correct label text contrast against track background

### DIFF
--- a/.changeset/fix-switch-dark-theme-label-contrast.md
+++ b/.changeset/fix-switch-dark-theme-label-contrast.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix Switch label text contrast against its track background. The label color is now conditional on checked state (`text-primary-foreground` when checked, `text-foreground` when unchecked) instead of a hardcoded `text-white`, which was unreadable against the light track color used in dark theme.

--- a/packages/ui/src/components/atoms/switch.tsx
+++ b/packages/ui/src/components/atoms/switch.tsx
@@ -95,10 +95,12 @@ const Switch = ({
       {hasChildren && (
         <span
           className={cn(
-            `grid leading-none text-white transition-[margin] duration-200
+            `grid leading-none transition-[margin] duration-200
             will-change-[margin]`,
             config.fontSize,
-            checked ? config.marginChecked : config.marginUnchecked,
+            checked
+              ? [config.marginChecked, 'text-primary-foreground']
+              : [config.marginUnchecked, 'text-foreground'],
             //
           )}
         >


### PR DESCRIPTION
## Summary
- `Switch`'s checked/unchecked label text was hardcoded to `text-white`, which becomes unreadable in dark theme where the checked-state track (`--primary`) is light gray.
- Label text color is now conditional on `checked`: `text-primary-foreground` when checked, `text-foreground` when unchecked — matching each state's actual track background instead of a single static color.

Fixes #244

## Test plan
- [x] `pnpm lint` / `pnpm check-types` pass in `packages/ui`
- [x] Verified visually in a real Chromium render (dark theme): unchecked shows white text on the dark track, checked shows dark text on the light track — both readable