### PR TITLE
fix(imperative-stack): use useSyncExternalStore for stack updates

### DIFF
--- a/.changeset/fix-imperative-stack-sync-external-store.md
+++ b/.changeset/fix-imperative-stack-sync-external-store.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix `Modal`/`Toast`'s shared imperative stack renderer to use `useSyncExternalStore` instead of an effect-registered `forceUpdate`. Previously, updates pushed between a container's first render and its effect mount (a real gap, since the imperative API is called outside the React render cycle) could be silently dropped, and reading the external `stack` array directly in the render body risked tearing under concurrent rendering. Also fixed a related bug where `render()` mutated `state.stack` in place via `.push()`, which would have defeated `useSyncExternalStore`'s reference-equality change detection — pushes now produce a new array.

--- a/packages/ui/src/components/organisms/imperative-stack.tsx
+++ b/packages/ui/src/components/organisms/imperative-stack.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 
 import { v4 as uuid } from 'uuid';
@@ -96,17 +96,23 @@ export function createImperativeStack<
   };
 
   const StackRenderer = ({ container }: { container: HTMLElement }) => {
-    const [, forceUpdate] = useState({});
+    const subscribe = useCallback(
+      (onStoreChange: () => void) => {
+        const state = getContainerState(container);
+        state.update = onStoreChange;
+        return () => {
+          state.update = null;
+        };
+      },
+      [container],
+    );
 
-    useEffect(() => {
-      const state = getContainerState(container);
-      state.update = () => forceUpdate({});
-      return () => {
-        state.update = null;
-      };
-    }, [container]);
+    const getSnapshot = useCallback(
+      () => getContainerState(container).stack,
+      [container],
+    );
 
-    const { stack } = getContainerState(container);
+    const stack = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
     return (
       <ConfigSnapshotProvider>
@@ -139,7 +145,7 @@ export function createImperativeStack<
 
     const state = getContainerState(targetContainer);
     const id = props.id || uuid();
-    state.stack.push({ ...props, id });
+    state.stack = [...state.stack, { ...props, id }];
     state.update?.();
 
     return id;


### PR DESCRIPTION
## Summary
- `StackRenderer` subscribed to updates via an effect-registered `forceUpdate`, leaving a gap between first render and effect mount where `render()` (called imperatively, outside the React render cycle) could push without notifying. Reading the external `stack` array directly in the render body also risked tearing under concurrent rendering.
- Switched to `useSyncExternalStore` per the issue's suggestion.
- Also fixed a bug the issue didn't call out: `render()` mutated `state.stack` in place via `.push()`, which returns the same array reference — this would have defeated `useSyncExternalStore`'s `Object.is` change detection entirely. Changed to produce a new array per push (matching the pattern `destroy()` already used).

Fixes #240

## Test plan
- [x] `pnpm lint` / `pnpm check-types` pass in `packages/ui`
- [x] Verified in a real Chromium render via the `Feedback/Toast` → `StaticToast` story: rapid-fired 4 toast triggers → all 4 rendered (no drops), then 2 more → 6 total, then closed one → count dropped to 1 as expected