### PR TITLE
fix(marquees): use useThrottledValue instead of deprecated useThrottle

### DIFF
--- a/.changeset/fix-marquees-throttled-value-rename.md
+++ b/.changeset/fix-marquees-throttled-value-rename.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Replace the deprecated `useThrottle` alias with `useThrottledValue` in `Marquees`. No behavior change — internal cleanup ahead of `@jbpark/use-hooks` removing the alias in a future major version.

--- a/packages/ui/src/components/molecules/marquees/marquees.tsx
+++ b/packages/ui/src/components/molecules/marquees/marquees.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { useResponsiveSize, useThrottle } from '@jbpark/use-hooks';
+import { useResponsiveSize, useThrottledValue } from '@jbpark/use-hooks';
 
 import { cn } from '@repo/ui/utils';
 
@@ -30,7 +30,7 @@ const Marquees = ({
   const [padding, setPadding] = useState(0);
   const [pause, setPause] = useState(false);
 
-  const throttledWidth = useThrottle(width, 200);
+  const throttledWidth = useThrottledValue(width, 200);
 
   const { size, ref: responsiveRef } = useResponsiveSize<HTMLDivElement>();
   const containerRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
## Summary
- `use-hooks@4.0.0` renamed the debounce/throttle family to a symmetric `{action}{Value|Callback}` scheme; `useThrottle` is now a deprecated alias for `useThrottledValue`.
- `Marquees` was the only remaining `useThrottle` usage in ui-kit. Swapped to the canonical name — no behavior change.

Fixes #238

## Test plan
- [x] `pnpm lint` / `pnpm check-types` pass in `packages/ui`