### PR TITLE
fix(marquees): use useMergedRef instead of manual ref merge

### DIFF
--- a/.changeset/fix-marquees-merged-ref.md
+++ b/.changeset/fix-marquees-merged-ref.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Replace `Marquees`' manual ref-merge (`containerRef.current = node; responsiveRef(node);`) with `useMergedRef`, matching the pattern used elsewhere (#185). Fixes the per-render new-function-identity churn that caused `useResponsiveSize`'s callback ref to detach/reattach on every render.

--- a/packages/ui/src/components/molecules/marquees/marquees.tsx
+++ b/packages/ui/src/components/molecules/marquees/marquees.tsx
@@ -2,7 +2,11 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { useResponsiveSize, useThrottledValue } from '@jbpark/use-hooks';
+import {
+  useMergedRef,
+  useResponsiveSize,
+  useThrottledValue,
+} from '@jbpark/use-hooks';
 
 import { cn } from '@repo/ui/utils';
 
@@ -34,10 +38,7 @@ const Marquees = ({
 
   const { size, ref: responsiveRef } = useResponsiveSize<HTMLDivElement>();
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const setContainerRef = (node: HTMLDivElement | null) => {
-    containerRef.current = node;
-    responsiveRef(node);
-  };
+  const setContainerRef = useMergedRef(containerRef, responsiveRef);
   const hoverEvents = pauseOnHover
     ? {
         onMouseEnter: () => {


### PR DESCRIPTION
## Summary
- `setContainerRef` was recreated every render, so React treated `useResponsiveSize`'s callback ref identity as changed and detached/reattached it on every render.
- Replaced with `useMergedRef(containerRef, responsiveRef)`, which wraps in `useCallback` internally — matches the merge pattern already used in `input/search.tsx` and `float-button/back-top.tsx` (#185). This was the last manual-merge site in the repo.

Fixes #239

## Test plan
- [x] `pnpm lint` / `pnpm check-types` pass in `packages/ui`
- [x] Verified in a real Chromium render via `Data Display/Marquees` → `RepeatCount` story: `autoFill` width measurement (which depends on `containerRef.current`) still resolves correctly, 16 items rendered as expected