### PR TITLE
fix(marquees): extract usePauseOnHover, add keyboard focus pause

### DIFF
--- a/.changeset/fix-marquees-pause-on-hover-hook.md
+++ b/.changeset/fix-marquees-pause-on-hover-hook.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Extract `Marquees`' and `Item`'s duplicated pause-on-hover state/handlers into a shared `usePauseOnHover` hook, and add `onFocus`/`onBlur` alongside `onMouseEnter`/`onMouseLeave` so keyboard-focused users can also pause the marquee — previously only mouse hover could pause it, leaving keyboard users with no way to stop a marquee containing links or buttons.

--- a/packages/ui/src/components/molecules/marquees/item.tsx
+++ b/packages/ui/src/components/molecules/marquees/item.tsx
@@ -5,6 +5,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useGSAP } from '@gsap/react';
 import { gsap } from 'gsap';
 
+import usePauseOnHover from './use-pause-on-hover';
+
 export interface ItemProps {
   key?: React.Key;
   speed?: number;
@@ -41,7 +43,7 @@ const Item = ({
   const tweenRef = useRef<gsap.core.Tween | null>(null);
 
   const [width, setWidth] = useState<string | number>(_width);
-  const [pause, setPause] = useState(false);
+  const { pause, hoverEvents } = usePauseOnHover(pauseOnHover);
   const [repeatCount, setRepeatCount] = useState(
     autoFill
       ? typeof autoFill === 'boolean'
@@ -72,17 +74,6 @@ const Item = ({
   }
 
   const isPaused = _pause || pause;
-
-  const hoverEvents = pauseOnHover
-    ? {
-        onMouseEnter: () => {
-          setPause(true);
-        },
-        onMouseLeave: () => {
-          setPause(false);
-        },
-      }
-    : {};
 
   useEffect(() => {
     if (

--- a/packages/ui/src/components/molecules/marquees/marquees.tsx
+++ b/packages/ui/src/components/molecules/marquees/marquees.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from '@repo/ui/utils';
 
 import Item, { type ItemProps } from './item';
+import usePauseOnHover from './use-pause-on-hover';
 
 export interface Props extends React.ComponentPropsWithoutRef<'div'> {
   speed?: number;
@@ -32,23 +33,13 @@ const Marquees = ({
     //
   );
   const [padding, setPadding] = useState(0);
-  const [pause, setPause] = useState(false);
+  const { pause, hoverEvents } = usePauseOnHover(pauseOnHover);
 
   const throttledWidth = useThrottledValue(width, 200);
 
   const { size, ref: responsiveRef } = useResponsiveSize<HTMLDivElement>();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const setContainerRef = useMergedRef(containerRef, responsiveRef);
-  const hoverEvents = pauseOnHover
-    ? {
-        onMouseEnter: () => {
-          setPause(true);
-        },
-        onMouseLeave: () => {
-          setPause(false);
-        },
-      }
-    : {};
 
   useEffect(() => {
     if (!size.width || !containerRef.current) {

--- a/packages/ui/src/components/molecules/marquees/use-pause-on-hover.ts
+++ b/packages/ui/src/components/molecules/marquees/use-pause-on-hover.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+// Pausing on hover alone leaves keyboard users with no way to stop the
+// marquee, so focus/blur (which bubble from any interactive child) pause it
+// the same way hover does.
+const usePauseOnHover = (enabled: boolean) => {
+  const [pause, setPause] = useState(false);
+
+  const hoverEvents = enabled
+    ? {
+        onMouseEnter: () => {
+          setPause(true);
+        },
+        onMouseLeave: () => {
+          setPause(false);
+        },
+        onFocus: () => {
+          setPause(true);
+        },
+        onBlur: () => {
+          setPause(false);
+        },
+      }
+    : {};
+
+  return { pause, hoverEvents };
+};
+
+export default usePauseOnHover;


### PR DESCRIPTION
## Summary
- `marquees.tsx` and `item.tsx` had byte-for-byte identical pause state + hover-handler code. Extracted into a shared local hook, `usePauseOnHover`.
- Added `onFocus`/`onBlur` alongside `onMouseEnter`/`onMouseLeave` (React's synthetic focus events bubble from any focusable descendant) — previously a marquee containing links or buttons had no keyboard-accessible way to pause it.

Fixes #241

Left `prefers-reduced-motion` out of scope — worth a separate issue/discussion since it'd need a product decision (pause vs. remove entirely) rather than a mechanical extraction.

## Test plan
- [x] `pnpm lint` / `pnpm check-types` pass in `packages/ui`
- [x] Verified in a real Chromium render via `Data Display/Marquees` → `MultipleHoverEvent`: item continues animating by default, freezes when a focusable child is focused, resumes on blur