### PR TITLE
fix(ci): make changeset-draft dedup diff-based, exclude non-code files

### DIFF
--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // Drafts .changeset/<branch-slug>[-<suffix>].md file(s) by asking an LLM
-// to summarize this PR's diff to each tracked package as a semver
-// bump + one-paragraph description, in changesets' own file format. Runs
-// once per PR (the calling workflow skips this script entirely if any
-// changeset file for this branch already exists), so it never overwrites
+// to summarize this PR's diff to each tracked package (minus each
+// package's own `exclude` list — see PACKAGES) as a semver bump +
+// one-paragraph description, in changesets' own file format. Runs once
+// per PR (the calling workflow skips this script entirely if a
+// changeset was already added in this PR), so it never overwrites
 // something a human already wrote or edited. One file is written per
 // package that actually changed, since each needs its own bump + summary.
 //
@@ -24,18 +25,34 @@ const PACKAGES = [
   {
     name: '@repo/ui',
     dir: 'packages/ui',
+    // README/CHANGELOG/AGENTS.md edits at the package root have zero
+    // effect on what actually publishes (files: ["dist"]) — excluded so
+    // a docs-wording-only PR doesn't get a changeset. Everything else
+    // under packages/ui (src/, package.json, build config) stays in
+    // scope: a dependency bump or build-config change can legitimately
+    // warrant one (e.g. 5.3.0's "Update dependencies to latest
+    // versions"), so this only excludes specific known-irrelevant files
+    // rather than narrowing wholesale to src/.
+    exclude: [
+      'packages/ui/README.md',
+      'packages/ui/README.ko.md',
+      'packages/ui/CHANGELOG.md',
+      'packages/ui/AGENTS.md',
+    ],
     fileSuffix: '',
     kind: 'React component library, published to npm',
   },
   {
     name: 'web',
     dir: 'apps/web',
+    exclude: [],
     fileSuffix: '-web',
     kind: 'Next.js marketing site, deployed but not published to npm',
   },
   {
     name: 'docs',
     dir: 'apps/docs',
+    exclude: [],
     fileSuffix: '-docs',
     kind: 'Storybook/docs site, deployed but not published to npm',
   },
@@ -88,17 +105,24 @@ function extractJson(content) {
   return JSON.parse(raw.trim());
 }
 
-function diffBetween(base, head, dir) {
-  return execFileSync('git', ['diff', `${base}...${head}`, '--', dir], {
-    encoding: 'utf8',
-    maxBuffer: 1024 * 1024 * 20,
-  });
+function diffBetween(base, head, dir, exclude = []) {
+  return execFileSync(
+    'git',
+    [
+      'diff',
+      `${base}...${head}`,
+      '--',
+      dir,
+      ...exclude.map(path => `:!${path}`),
+    ],
+    { encoding: 'utf8', maxBuffer: 1024 * 1024 * 20 },
+  );
 }
 
 async function draftFor(pkg, { apiKey, baseSha, headSha, branchSlug }) {
   let diff;
   try {
-    diff = diffBetween(baseSha, headSha, pkg.dir);
+    diff = diffBetween(baseSha, headSha, pkg.dir, pkg.exclude);
   } catch (err) {
     console.log(
       `Could not diff ${baseSha}...${headSha} for ${pkg.dir}: ${err.message}`,

--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -32,34 +32,38 @@ jobs:
         with:
           node-version: 24.x
 
-      # Only draft once per PR — if a changeset already exists for *this
-      # branch* (hand-written, or from an earlier run of this workflow on
-      # this PR), leave it alone rather than overwriting a human's edits on
-      # every subsequent push. Keyed off the branch name (slugified: `/`
-      # and other unsafe characters become `-`) rather than PR number so
-      # the check itself doubles as a human-readable filename — but the
-      # important part is that it's scoped to *this* branch specifically.
-      # An earlier version of this check looked for *any* changeset file
-      # anywhere in .changeset/, which falsely treated an older, still-
-      # unconsumed PR's changeset (one that just hadn't been released yet)
-      # as "this PR already has one" and silently skipped drafting for
-      # every PR merged after it until the next release. Scoping to this
-      # branch's own slug avoids that false positive the same way the
-      # original pr-<PR#>.md-specific check did, without losing this
-      # check's recognition of hand-written changesets under any name for
-      # *this* branch.
+      # Only draft once per PR — if a changeset was already added in this
+      # PR (hand-written under any filename, or from an earlier run of
+      # this workflow on this PR), leave it alone rather than adding a
+      # second, possibly-conflicting one on every subsequent push.
+      #
+      # This checks the PR's actual diff (any new .changeset/*.md file
+      # between base and head) rather than matching a filename pattern.
+      # An earlier version matched only `.changeset/<branch-slug>*.md`,
+      # which missed any hand-written changeset not named after the
+      # branch — e.g. a descriptive name like `fix-foo-bug.md` on a
+      # branch called `fix/unrelated-slug` — so the bot drafted a second,
+      # duplicate changeset alongside it every time. (An even earlier
+      # version checked for *any* changeset file anywhere in .changeset/,
+      # which had the opposite problem: an older, still-unreleased PR's
+      # changeset made every PR merged after it silently skip drafting
+      # its own, until the next release. Scoping to *this PR's diff*
+      # avoids both failure modes — it only reacts to files this PR
+      # itself introduces, under any name.)
       - name: Check for existing changeset
         id: existing
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BRANCH_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           slug=$(printf '%s' "$BRANCH_REF" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
           echo "slug=$slug" >> "$GITHUB_OUTPUT"
-          shopt -s nullglob
-          files=(".changeset/${slug}"*.md)
-          shopt -u nullglob
-          if [ "${#files[@]}" -gt 0 ]; then
+          added=$(git diff --name-only --diff-filter=A "$BASE_SHA...$HEAD_SHA" -- '.changeset/*.md')
+          if [ -n "$added" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Changeset(s) already added in this PR — skipping draft:"
+            echo "$added"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Same two bugs fixed in use-hooks (pjb0811/use-hooks#173) and mirrored here, found while manually cleaning up duplicate/unwarranted changesets across this repo, use-hooks, and live-editor this session:

1. **Duplicate drafting.** The "already has a changeset" check only matched `.changeset/<branch-slug>*.md`. A hand-written changeset under any other filename didn't match, so the bot drafted a *second* changeset on every push — this happened repeatedly in live-editor (#145, #149) with conflicting semver bumps. Fixed: now checks whether this PR's diff added any `.changeset/*.md` file at all, regardless of name.
2. **Non-code files inflating the diff scope.** `@repo/ui`'s diff scope was the whole `packages/ui` directory, including `README.md`/`README.ko.md`/`CHANGELOG.md`/`AGENTS.md` at the package root — none of which affect what actually publishes (`files: ["dist"]`). Excluded those specific files.

Deliberately did **not** narrow the scope to `packages/ui/src` only (unlike the use-hooks/live-editor fix, which excludes the whole demo app): a dependency bump or build-config change under `packages/ui` has legitimately warranted a changeset here before (5.3.0's "Update dependencies to latest versions"), so this only excludes the specific known-irrelevant docs files rather than the wider net.

`apps/web`/`apps/docs` are untouched — those are already correctly tracked as their own "packages" with their own changesets by design (private, deployed-but-not-published), and I found no evidence of false positives there.

## Test plan
- [x] `node --check` on the modified script
- [x] Verified the diff-exclusion pathspec against real history: re-running it against the last 5 `@repo/ui` commits still shows the real source changes (switch/marquees/imperative-stack fixes), confirming the exclude list doesn't over-filter
- [x] Verified the new `--diff-filter=A` existence check logic matches the one already validated in use-hooks#173
- Not runnable locally end-to-end (needs a real PR event + `NVIDIA_API_KEY`) — will confirm behavior on the next real PR