### PR TITLE
🔥 fix(ui): drop global preflight from shipped style.css

### DIFF
--- a/.changeset/scope-drop-preflight.md
+++ b/.changeset/scope-drop-preflight.md
@@ -1,0 +1,17 @@
+---
+'@repo/ui': minor
+---
+
+Stop shipping Tailwind's global preflight (and the global `body {}` rule) in `@repo/ui/style.css`.
+
+`@import 'tailwindcss'` pulled in preflight — a document-wide reset (`*, ::before, ::after { margin: 0; box-sizing: border-box; border: 0 }` plus bare-tag resets on headings, lists, buttons, etc.). Because the library ships this compiled into `style.css`, importing the package flattened the spacing/typography of any host page (e.g. a Docusaurus/Infima docs site) — a leak, not the library's job. The `body { background/color }` rule leaked similarly, painting the host's `<body>`.
+
+**What changed**
+
+- `style.css` now imports only Tailwind's `theme` and `utilities` layers (no `preflight`).
+- The `@layer base` now contains only the border/outline **color** defaults (`* { border-color; outline-color }`), which restore the design tokens for bare `border`/`outline` utilities. This is color-only, sits in the low-priority `base` layer, and never affects layout.
+
+**Consumer impact / migration**
+
+- Apps that run their own Tailwind (import `tailwindcss` themselves) are unaffected — they already provide preflight.
+- Consumers that relied on `@repo/ui/style.css` alone for a CSS reset should add their own preflight (`@import 'tailwindcss'`, or `tailwindcss/preflight.css`) and set their own `body` colors. This repo's Storybook (`apps/docs`) and `apps/web` were updated accordingly.

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -2,6 +2,13 @@ import type { Preview } from '@storybook/nextjs-vite';
 
 import '@repo/ui/style.css';
 
+// `@repo/ui/style.css` no longer ships Tailwind's preflight (it's a global
+// reset that shouldn't leak from a component library). Import the app's own
+// globals first — it runs Tailwind (`@import 'tailwindcss'`) and provides
+// preflight + base resets for the story canvas — then the ui-kit theme,
+// utilities and component styles. Mirrors how a real app consumes the package.
+import '../app/globals.css';
+
 const preview: Preview = {
   parameters: {
     controls: {

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -2,12 +2,11 @@ import type { Preview } from '@storybook/nextjs-vite';
 
 import '@repo/ui/style.css';
 
-// `@repo/ui/style.css` no longer ships Tailwind's preflight (it's a global
-// reset that shouldn't leak from a component library). Import the app's own
-// globals first — it runs Tailwind (`@import 'tailwindcss'`) and provides
-// preflight + base resets for the story canvas — then the ui-kit theme,
-// utilities and component styles. Mirrors how a real app consumes the package.
-import '../app/globals.css';
+// Tailwind (with preflight, in `@layer base`) first, then the ui-kit theme,
+// utilities and component styles. `@repo/ui/style.css` no longer ships
+// preflight, so `./tailwind.css` supplies it for the story canvas — see that
+// file for why the app's globals.css must NOT be used here.
+import './tailwind.css';
 
 const preview: Preview = {
   parameters: {

--- a/apps/docs/.storybook/tailwind.css
+++ b/apps/docs/.storybook/tailwind.css
@@ -1,0 +1,12 @@
+/*
+ * Storybook-only Tailwind entry.
+ *
+ * `@repo/ui/style.css` no longer ships Tailwind's preflight (it's a global
+ * reset that shouldn't leak from a component library), so the story canvas
+ * needs its own. `@import 'tailwindcss'` puts preflight in `@layer base`, where
+ * it correctly loses to the component/utility layers — importing the app's
+ * globals.css instead would drag in its top-level (UN-layered) `* { margin:0;
+ * padding:0 }` reset, which beats every `@layer utilities` spacing class and
+ * flattens all component spacing.
+ */
+@import 'tailwindcss';

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -11,6 +11,10 @@ html.dark {
 }
 
 body {
+  /* Theme body colors used to come from `@repo/ui/style.css`; that global
+     `body {}` rule was removed from the library (a component lib shouldn't
+     paint the host body), so the app sets them itself now. */
+  @apply bg-background text-foreground;
   max-width: 100vw;
   overflow-x: hidden;
 }

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -1,4 +1,20 @@
-@import 'tailwindcss';
+/*
+ * Import Tailwind WITHOUT its global preflight (base) layer.
+ *
+ * `@import 'tailwindcss'` also pulls in preflight — a document-wide reset
+ * (`*, ::before, ::after { margin: 0; box-sizing: border-box; border: 0 }`,
+ * bare-tag resets on headings/lists/buttons/etc). Shipping that in a component
+ * library's stylesheet flattens the spacing/typography of any host page that
+ * imports it (e.g. a Docusaurus/Infima site), which is a leak, not our job.
+ *
+ * Consumers that run their own Tailwind (the usual case — apps import
+ * `tailwindcss` themselves before this file) still get preflight from their own
+ * build, so components are unaffected. Non-Tailwind hosts simply don't get a
+ * global reset applied on their behalf.
+ */
+@layer theme, base, components, utilities;
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities);
 
 @config "../tailwind.config.mjs";
 
@@ -117,11 +133,21 @@
 }
 
 @layer base {
+  /*
+   * Border/outline color defaults. Tailwind v4 defaults `border`/`outline`
+   * color to `currentColor`; this restores the design-system tokens so a bare
+   * `border`/`outline` utility on a component renders in the theme color. Kept
+   * global (not scoped to a wrapper) so components work without consumers
+   * adding a root marker — it only sets *color* (cosmetic), lives in the
+   * low-priority `base` layer (a host's own unlayered rules win), and never
+   * affects layout the way preflight did.
+   *
+   * The former `body { @apply bg-background text-foreground }` was removed: a
+   * component library shouldn't paint the host's <body>. Apps set their own
+   * body colors in their own globals.
+   */
   * {
     @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
   }
 }
 


### PR DESCRIPTION
## Problem

`@repo/ui/style.css` is built from `src/globals.css`, which did `@import 'tailwindcss'` — pulling **Tailwind's preflight** (a document-wide reset: `*, ::before, ::after { margin: 0; box-sizing: border-box; border: 0 }` plus bare-tag resets on headings/lists/buttons/etc.) into the shipped stylesheet, along with a global `body { background/color }` rule.

Any host page that imports the package then gets its spacing/typography flattened (surfaced while embedding ui-kit components in a Docusaurus/Infima docs site). A component library resetting the host's `*`/`<body>` is a leak, not its job.

## Change

- **`packages/ui/src/globals.css`** — import only Tailwind's `theme` + `utilities` layers (drop `preflight`). `@layer base` now contains only the border/outline **color** tokens (`* { border-color; outline-color }`) — color-only, low-priority layer, no layout impact. Removed the `body {}` paint rule.
- **`apps/web`** — sets its own body theme colors in its globals (previously relied on the library's global `body {}`).
- **`apps/docs` (Storybook)** — the story canvas needs its own preflight now. Added a Storybook-only `.storybook/tailwind.css` (`@import 'tailwindcss'`) and import it in `preview.ts` before the ui-kit styles.
- **changeset** (`minor`) documenting the migration.

### ⚠️ Storybook: preflight must be *layered*

First attempt imported `apps/docs/app/globals.css` into the preview to restore preflight. That file also contains a top-level (**un-layered**) `* { margin: 0; padding: 0 }` reset — and un-layered rules beat every `@layer utilities` class, so it zeroed all component padding/margin in stories (broken spacing/alignment). The dedicated `.storybook/tailwind.css` puts preflight in `@layer base`, where it correctly loses to the utility/component layers.

Verified against a `main` Storybook build: the story CSS **selector set matches exactly** (nothing added/removed), preflight is present (layered), and no un-layered app resets leak in.

## Consumer impact

- Apps that run their own Tailwind (import `tailwindcss` themselves) are **unaffected** — they already provide preflight.
- Consumers relying on `@repo/ui/style.css` alone for a reset should add their own (`@import 'tailwindcss'` / `tailwindcss/preflight.css`) and set their own `body` colors.

This unblocks rendering ui-kit components inline in non-Tailwind hosts without a global reset leaking out. (Two-directional isolation and bundle weight are separate concerns — the live-editor docs demo keeps using an iframe.)

## Verify

- `apps/docs`: `pnpm storybook` → stories render with correct spacing/alignment (confirmed ✅).
- `apps/web`: `pnpm --filter web dev` → body colors + component spacing intact.
- Emitted `packages/ui/dist/style.css`: no universal `*` reset / bare-tag resets; theme vars, utilities, `[data-slot=…]` components, and `* { border-color }` all present.

> ✅ `pnpm check-types` passes repo-wide (3/3: @repo/ui, docs, web). An earlier local `useThrottledValue` resolution error was a stale/partial install of `@jbpark/use-hooks` (the export ships in 4.0.0+, installed 4.0.1) and no longer reproduces after a clean build.
