### PR TITLE
🐛 fix(ui): give list components and Typography their own reset

### DIFF
--- a/.changeset/fix-list-typography-reset.md
+++ b/.changeset/fix-list-typography-reset.md
@@ -1,5 +1,5 @@
 ---
-'@repo/ui': minor
+'@repo/ui': patch
 ---
 
-Added 'm-0' utility class to various components to remove default margin.
+Fixed a regression from #252 (dropping global preflight): Checkbox.Group, Radio.Group, Upload's file list, Menu (and its submenu), and Typography.Title/Paragraph had no `list-style`/`margin`/`padding` reset of their own — they'd only ever gotten it for free from preflight. In a non-Tailwind host, they now render correctly again instead of picking up UA-default indentation and block margins.

--- a/.changeset/fix-list-typography-reset.md
+++ b/.changeset/fix-list-typography-reset.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Added 'm-0' utility class to various components to remove default margin.

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -66,6 +66,7 @@ const Group = ({
     <ul
       {...props}
       className={cn(
+        'm-0 list-none p-0',
         orientation === 'vertical' ? 'space-y-2' : 'flex gap-2',
         className,
       )}

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -98,7 +98,7 @@ const RadioGroup = ({
     <ul
       {...props}
       className={cn(
-        'flex gap-4',
+        'm-0 flex list-none gap-4 p-0',
         className,
         orientation === 'vertical' && 'flex-col',
         isButton && 'gap-0',

--- a/packages/ui/src/components/atoms/typography/paragraph.tsx
+++ b/packages/ui/src/components/atoms/typography/paragraph.tsx
@@ -7,6 +7,7 @@ const Paragraph = ({ children, className, ...props }: Props) => {
     <p
       {...props}
       className={cn(
+        'm-0',
         className,
         //
       )}

--- a/packages/ui/src/components/atoms/typography/title.tsx
+++ b/packages/ui/src/components/atoms/typography/title.tsx
@@ -25,7 +25,7 @@ const Title = ({ children, level = 1, className, ...props }: Props) => {
 
   return (
     <Element
-      className={cn('leading-snug font-bold', styles[Element], className)}
+      className={cn('m-0 leading-snug font-bold', styles[Element], className)}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/molecules/menu/menu.tsx
+++ b/packages/ui/src/components/molecules/menu/menu.tsx
@@ -54,6 +54,8 @@ export type ClickEventHandler = (params: {
 }) => void;
 
 export const MENU_CLASSNAMES = [
+  'm-0',
+  'list-none',
   'p-0',
   'bg-popover',
   'text-popover-foreground',

--- a/packages/ui/src/components/molecules/upload.tsx
+++ b/packages/ui/src/components/molecules/upload.tsx
@@ -163,7 +163,7 @@ const Upload = ({
       {files.length > 0 && (
         <ul
           className={cn(
-            'flex flex-col gap-2',
+            'm-0 flex list-none flex-col gap-2 p-0',
             classNames?.list,
             //
           )}


### PR DESCRIPTION
## Summary
#252 dropped Tailwind preflight from the shipped stylesheet, but five `<ul>` elements (Checkbox.Group, Radio.Group, Upload's file list, Menu and its submenu) and Typography.Title/Paragraph had no reset of their own — they'd only ever gotten `list-style`/`margin`/`padding: 0` for free from preflight. In a non-Tailwind host (e.g. live-editor's Docusaurus docs), dropping preflight left them with UA-default indentation and block margins instead.

- Added `m-0 list-none p-0` (or the subset already missing) to each affected `<ul>`; `MENU_CLASSNAMES` is shared by `menu.tsx` and its submenu in `item.tsx`, so one edit covers both
- Added `m-0` to `Typography.Title`/`Paragraph`, matching their prior (preflight-borrowed) zero-margin behavior rather than introducing new deliberate rhythm — a design decision on real vertical rhythm is left for a separate discussion

## Verification
Verified with a real build, not a code read: loaded the built `dist/style.css` as a page's only stylesheet and measured computed styles on markup matching each component's actual class output — `padding-left`/`margin`/`list-style-type` all read `0`/`none` as expected, and #252's own guarantees (single, color-only `@layer base`, no bare-tag resets) still hold.

Fixes #253

## Test plan
- [x] `pnpm lint` / `pnpm check-types` (full monorepo: `@repo/ui`, `docs`, `web`) — all pass
- [x] `pnpm --filter @repo/ui run check-dynamic-classes` — pass
- [x] Real-DOM computed-style verification described above (CDP against the built `dist/style.css`)