### PR TITLE
🐛 fix: stop Tailwind preflight from leaking into apps/web's Docusaurus theme

### DIFF
--- a/.changeset/fix-web-docusaurus-preflight-leak-web.md
+++ b/.changeset/fix-web-docusaurus-preflight-leak-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Update production domain to ui-kit-web.vercel.app.

--- a/.changeset/fix-web-docusaurus-preflight-leak-web.md
+++ b/.changeset/fix-web-docusaurus-preflight-leak-web.md
@@ -1,5 +1,5 @@
 ---
-'web': minor
+'web': patch
 ---
 
-Update production domain to ui-kit-web.vercel.app.
+Fix Tailwind preflight leaking into the Docusaurus theme (was resetting Infima's navbar/footer/heading styles), and update the production domain to ui-kit-web.vercel.app.

--- a/apps/web/docusaurus.config.ts
+++ b/apps/web/docusaurus.config.ts
@@ -32,9 +32,7 @@ const config: Config = {
   // Vercel is the deploy target (see vercel.json). `url` + `baseUrl` must
   // match it, since canonical <link> tags, sitemap.xml, and Open Graph URLs
   // are all derived from them.
-  // TODO: confirm this matches the actual Vercel production domain for
-  // this app once deployed.
-  url: 'https://ui-kit-web-lab.vercel.app',
+  url: 'https://ui-kit-web.vercel.app',
   baseUrl: '/',
 
   organizationName: 'pjb0811',

--- a/apps/web/src/css/custom.css
+++ b/apps/web/src/css/custom.css
@@ -6,13 +6,15 @@
 
 /*
  * `@repo/ui/style.css` resolves to the library's source globals.css inside
- * this workspace (theme tokens + utilities layer, no preflight — see that
- * file for why), so importing `tailwindcss` here is what actually turns
- * this page's own utility classes (`flex`, `max-w-5xl`, `grid-cols-3`, ...)
- * into real CSS; the `configurePostCss` hook in docusaurus.config.ts is
- * what runs the Tailwind build itself.
+ * this workspace, which already does `@import 'tailwindcss/theme.css'` +
+ * `@import 'tailwindcss/utilities.css'` (the `configurePostCss` hook in
+ * docusaurus.config.ts is what actually runs the Tailwind build, generating
+ * utility classes for this page's own JSX too, e.g. `flex`, `max-w-5xl`,
+ * `grid-cols-3`). Deliberately NOT `@import 'tailwindcss'` here — that also
+ * pulls in preflight, a document-wide reset that stomps Infima's own base
+ * styles (navbar/footer/headings) on this Docusaurus site. See the comment
+ * at the top of that file for the full reasoning.
  */
-@import 'tailwindcss';
 @import '@repo/ui/style.css';
 
 body {


### PR DESCRIPTION
## Summary
- `apps/web/src/css/custom.css` imported `tailwindcss` directly (full import, includes preflight), which reset Infima's own base styles (heading sizes, button/list defaults) across the navbar/footer. Visible as broken styling on the deployed site (https://ui-kit-web.vercel.app) after #257 merged. `@repo/ui/style.css` already provides theme+utilities without preflight for exactly this reason (see its own comment) — drop the redundant import.
- Update `docusaurus.config.ts`'s `url` to the confirmed production domain (`https://ui-kit-web.vercel.app`), replacing the placeholder from #257.

## Test plan
- [x] `pnpm --filter=web build` + verified compiled CSS: preflight heading reset (`font-size:inherit;font-weight:inherit`) gone, utility classes (`grid-cols-3`, `max-w-5xl`, `bg-background`) still present
- [x] `pnpm --filter=web lint` / `check-types`
- [x] `docusaurus serve` + confirmed same result served locally