### PR TITLE
🐛 fix(ui): give core/field.tsx its own preflight reset

### DIFF
--- a/.changeset/fix-field-preflight-reset.md
+++ b/.changeset/fix-field-preflight-reset.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Adds padding and border removal to FieldSet and FieldLegend components for improved customization and accessibility.

--- a/.changeset/fix-field-preflight-reset.md
+++ b/.changeset/fix-field-preflight-reset.md
@@ -1,5 +1,5 @@
 ---
-'@repo/ui': minor
+'@repo/ui': patch
 ---
 
-Adds padding and border removal to FieldSet and FieldLegend components for improved customization and accessibility.
+Fix FieldSet/FieldLegend/FieldError's error list rendering with UA default border/margin/padding (a UA groove border around FieldSet, extra padding on the legend and error list) in non-Tailwind hosts — a spot #254 missed when it restored the preflight reset removed in #252.

--- a/packages/ui/src/core/field.tsx
+++ b/packages/ui/src/core/field.tsx
@@ -14,7 +14,7 @@ function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
     <fieldset
       data-slot="field-set"
       className={cn(
-        'flex flex-col gap-6',
+        'm-0 flex flex-col gap-6 border-0 p-0',
         `has-[>[data-slot=checkbox-group]]:gap-3
         has-[>[data-slot=radio-group]]:gap-3`,
         className,
@@ -34,6 +34,7 @@ function FieldLegend({
       data-slot="field-legend"
       data-variant={variant}
       className={cn(
+        'p-0',
         'mb-3 font-medium',
         'data-[variant=legend]:text-base',
         'data-[variant=label]:text-sm',
@@ -222,7 +223,7 @@ function FieldError({
     }
 
     return (
-      <ul className="ml-4 flex list-disc flex-col gap-1">
+      <ul className="m-0 ml-4 flex list-disc flex-col gap-1 p-0">
         {uniqueErrors.map(
           (error, index) =>
             error?.message && <li key={index}>{error.message}</li>,


### PR DESCRIPTION
## Summary
- `FieldSet`'s `<fieldset>`: add `m-0 border-0 p-0`
- `FieldLegend`'s `<legend>`: add `p-0`
- `FieldError`'s error `<ul>`: add `m-0 p-0` (keeps `list-disc`)

#254 covered every component #253 listed, but `core/field.tsx`'s fieldset/legend/error-list weren't in that list and were missed. In non-Tailwind hosts (no preflight in `dist/style.css` since #252), the bare `<fieldset>` renders a UA groove border and the legend/error list keep UA padding.

Closes #256

## Test plan
- [x] `pnpm --filter @repo/ui build` + verified compiled CSS: `.border-0{border-width:0px}`, `.m-0{margin:0px}`, `.p-0{padding:0px}` present
- [x] `pnpm --filter @repo/ui lint` / `check-types` / `check-dynamic-classes`
- [x] `pnpm exec turbo run build --filter=@repo/ui --filter=docs`