### PR TITLE
🐛 fix(web): sync Docusaurus dark mode onto <html>, not a nested wrapper

### DIFF
--- a/.changeset/fix-web-dark-mode-body-scope-web.md
+++ b/.changeset/fix-web-dark-mode-body-scope-web.md
@@ -1,5 +1,5 @@
 ---
-'web': minor
+'web': patch
 ---
 
-Toggle dark mode on the page based on the navbar's light/dark toggle.
+Fix dark mode toggle not reaching `<body>` — the page background/text color stayed light while ui-kit components inside it went dark, because the `.dark` class was only applied to a wrapper nested inside the page content instead of `<html>`.

--- a/.changeset/fix-web-dark-mode-body-scope-web.md
+++ b/.changeset/fix-web-dark-mode-body-scope-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Toggle dark mode on the page based on the navbar's light/dark toggle.

--- a/apps/web/src/components/DemoTheme.tsx
+++ b/apps/web/src/components/DemoTheme.tsx
@@ -1,13 +1,18 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 
 import { useColorMode } from '@docusaurus/theme-common';
 
-import { Config } from '@repo/ui';
-
 // Bridges Docusaurus' color mode into ui-kit's own dark-mode mechanism (a
-// `.dark` class ancestor, toggled via Config's `theme.dark`) so components
-// on this page follow the navbar's light/dark toggle instead of defaulting
-// to light.
+// `.dark` class ancestor) so components on this page — and <body> itself —
+// follow the navbar's light/dark toggle instead of defaulting to light.
+//
+// Deliberately toggles `.dark` on <html> directly rather than wrapping
+// children in ui-kit's <Config theme={{ dark }}>: Config only applies
+// `.dark` to a div it renders *inside* this component's children, which is
+// a descendant of <body> — too low for custom.css's
+// `body { @apply bg-background text-foreground }` to see it, since that
+// rule needs `.dark` on an ANCESTOR of <body>. Toggling <html> covers both
+// <body> and every ui-kit component under it in one place.
 //
 // Must be used from inside page content, not from `@theme/Root`: Root
 // renders above Docusaurus' ColorModeProvider, so useColorMode() throws
@@ -15,5 +20,9 @@ import { Config } from '@repo/ui';
 export default function DemoTheme({ children }: { children: ReactNode }) {
   const { colorMode } = useColorMode();
 
-  return <Config theme={{ dark: colorMode }}>{children}</Config>;
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', colorMode === 'dark');
+  }, [colorMode]);
+
+  return children;
 }


### PR DESCRIPTION
## Summary
`DemoTheme` wrapped page content in ui-kit's `<Config theme={{ dark }}>`, which only applies the `.dark` class to a div rendered *inside* the page content — a descendant of `<body>`. `custom.css`'s `body { @apply bg-background text-foreground }` needs `.dark` on an **ancestor** of `<body>` to pick up the dark tokens, so toggling the navbar's dark mode switch left `<body>` stuck on light colors while the ui-kit components inside it (correctly reached by Config's wrapper) went dark — a visible mismatch reported after #257/#259.

Toggle `.dark` on `<html>` directly instead, so both `<body>` and every ui-kit component under it read the same theme from one place.

## Test plan
- [x] `pnpm --filter=web lint` / `check-types` / `build`
- [x] verified the compiled client bundle contains the new `classList.toggle` logic
- [ ] visual confirmation on the deployed preview (browser tooling wasn't available in this environment this session)