### PR TITLE
✨ feat(web): add docs section, starting with Tag

### DIFF
--- a/.changeset/feat-web-docs-tag-page-web.md
+++ b/.changeset/feat-web-docs-tag-page-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+A new UI component library, ui-kit, is now documented with a marketing landing page and component documentation, including interactive demos.

--- a/.changeset/feat-web-docs-tag-page-web.md
+++ b/.changeset/feat-web-docs-tag-page-web.md
@@ -2,4 +2,4 @@
 'web': minor
 ---
 
-A new UI component library, ui-kit, is now documented with a marketing landing page and component documentation, including interactive demos.
+Add a docs/ section (was disabled) with the first component page, Tag — description, live demo, and props table. More components will be added incrementally.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -4,19 +4,23 @@ apps/web 프로젝트에서 작업할 때 참고하는 가이드입니다.
 
 ## Scope
 
-- Docusaurus 기반 ui-kit 패키지 랜딩 페이지 (포트 3000)
-- 컴포넌트 문서/플레이그라운드는 `apps/docs`(Storybook)가 담당하므로, 여기는 마케팅 랜딩 콘텐츠 위주
+- Docusaurus 기반 ui-kit 패키지 랜딩 페이지 + 컴포넌트 문서 (포트 3000)
+- 컴포넌트별 인터랙티브 플레이그라운드(모든 variant/props 조합)는 계속 `apps/docs`(Storybook)가 담당함 — 여기 `docs/`는 컴포넌트를 하나씩 채워나가는 설명 + 라이브 데모 위주 문서이고, 전수 커버리지를 목표로 하지 않음
+- 새 컴포넌트 문서 페이지 추가 패턴: `packages/ui/src/components`와 동일한 계층(atoms/molecules/organisms/templates)으로 `docs/components/{tier}/{kebab-case-name}.mdx` 작성 + 필요하면 `src/demo/{kebab-case-name}-demo.tsx`에 라이브 데모 컴포넌트 작성 + `sidebars.ts`에 항목 추가. `docs/components/atoms/tag.mdx` + `src/demo/tag-demo.tsx`가 참고할 템플릿
 
 ## Key Paths
 
 - `src/pages/`: 커스텀 페이지 (현재는 홈페이지 하나)
+- `docs/`: 컴포넌트 문서 페이지 (계층별로 `components/{tier}/`)
+- `src/demo/`: 문서 페이지에 임베드하는 라이브 데모 컴포넌트
 - `src/components/`: `DemoTheme` 등 페이지에서 쓰는 컴포넌트
 - `src/css/custom.css`: Tailwind + `@repo/ui/style.css` 진입점
 - `static/`: 정적 리소스 (favicon 등)
 - `docusaurus.config.ts`: 사이트 설정 (navbar/footer, Tailwind postcss 플러그인 연결)
+- `sidebars.ts`: 문서 사이드바 (수동 관리 — 새 페이지 추가 시 여기도 같이 갱신)
 
 ## Rules
 
 - `@repo/ui/style.css`는 워크스페이스 안에서 소스 CSS(`packages/ui/src/globals.css`)로 resolve되므로, 이 앱이 자체 Tailwind 빌드(`configurePostCss`)를 돌려야 유틸리티 클래스가 생성된다 — 이 설정을 건드릴 때는 `docusaurus.config.ts`의 주석을 참고
 - 공용 UI는 가능하면 `@repo/ui`를 우선 재사용
-- 다크모드는 Docusaurus의 `useColorMode`를 `DemoTheme`을 통해 ui-kit의 `Config`에 연결해서 따라가게 되어 있음 — 페이지 콘텐츠는 `<DemoTheme>` 안에서 렌더링해야 함
+- 다크모드는 `DemoTheme`이 Docusaurus의 `useColorMode`를 읽어서 `<html>`에 직접 `.dark` 클래스를 토글하는 방식 (ui-kit의 `Config` wrapper는 안 씀 — 그 wrapper는 `<body>`의 조상이 되지 못해서 body 배경/텍스트 색이 안 바뀌는 버그가 있었음). 라이브 데모를 넣는 문서 페이지 콘텐츠는 `<DemoTheme>` 안에서 렌더링해야 함

--- a/apps/web/docs/components/atoms/tag.mdx
+++ b/apps/web/docs/components/atoms/tag.mdx
@@ -1,0 +1,34 @@
+---
+sidebar_position: 1
+title: Tag
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import TagDemo from '../../../src/demo/tag-demo';
+
+# Tag
+
+A small labeled badge, typically used to categorize or highlight content.
+
+```tsx
+import { Tag } from '@jbpark/ui-kit';
+
+<Tag color="primary">primary</Tag>;
+```
+
+<DemoTheme>
+
+<TagDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop        | Type                                                                | Default     |
+| ----------- | -------------------------------------------------------------------- | ----------- |
+| `variant`   | `'default' \| 'outlined'`                                          | `'default'` |
+| `color`     | `'default' \| 'primary' \| 'success' \| 'warning' \| 'danger'`     | `'default'` |
+| `className` | `string`                                                              | -           |
+| `children`  | `ReactNode`                                                           | -           |
+
+`Tag` also accepts the rest of `React.ComponentProps<'span'>` (e.g. `onClick`, `style`).

--- a/apps/web/docs/intro.md
+++ b/apps/web/docs/intro.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 1
+title: Overview
+---
+
+# ui-kit
+
+A React UI component library built with TypeScript, Tailwind CSS, and Radix UI.
+
+## Install
+
+```bash
+npm install @jbpark/ui-kit
+```
+
+## Components
+
+Pages here are being added one component at a time, grouped by the same
+atomic-design tiers as the source (atoms/molecules/organisms/templates). For
+the full interactive catalog of every component right now, see
+[Storybook](https://ui-kit-docs-lab.vercel.app).
+
+## Links
+
+- [GitHub](https://github.com/pjb0811/ui-kit)
+- [npm](https://www.npmjs.com/package/@jbpark/ui-kit)

--- a/apps/web/docusaurus.config.ts
+++ b/apps/web/docusaurus.config.ts
@@ -49,7 +49,10 @@ const config: Config = {
     [
       'classic',
       {
-        docs: false,
+        docs: {
+          sidebarPath: './sidebars.ts',
+          editUrl: 'https://github.com/pjb0811/ui-kit/tree/main/apps/web/',
+        },
         blog: false,
         theme: {
           customCss: './src/css/custom.css',
@@ -68,8 +71,14 @@ const config: Config = {
       title: 'ui-kit',
       items: [
         {
-          href: 'https://ui-kit-docs-lab.vercel.app',
+          type: 'docSidebar',
+          sidebarId: 'docsSidebar',
+          position: 'left',
           label: 'Docs',
+        },
+        {
+          href: 'https://ui-kit-docs-lab.vercel.app',
+          label: 'Storybook',
           position: 'left',
         },
         {
@@ -90,7 +99,8 @@ const config: Config = {
         {
           title: 'More',
           items: [
-            { label: 'Docs', href: 'https://ui-kit-docs-lab.vercel.app' },
+            { label: 'Docs', to: '/docs/intro' },
+            { label: 'Storybook', href: 'https://ui-kit-docs-lab.vercel.app' },
             { label: 'GitHub', href: 'https://github.com/pjb0811/ui-kit' },
             {
               label: 'npm',

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -1,0 +1,19 @@
+import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
+
+// Pages are added one component at a time — see AGENTS.md. Grouped by the
+// same atomic-design tiers as packages/ui/src/components (atoms/molecules/
+// organisms/templates), so a new page's place in the sidebar matches where
+// its source lives.
+const sidebars: SidebarsConfig = {
+  docsSidebar: [
+    'intro',
+    {
+      type: 'category',
+      label: 'Atoms',
+      collapsed: false,
+      items: ['components/atoms/tag'],
+    },
+  ],
+};
+
+export default sidebars;

--- a/apps/web/src/demo/tag-demo.tsx
+++ b/apps/web/src/demo/tag-demo.tsx
@@ -1,0 +1,24 @@
+import { Space, Tag } from '@repo/ui';
+
+const COLORS = ['default', 'primary', 'success', 'warning', 'danger'] as const;
+
+export default function TagDemo() {
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Space wrap>
+        {COLORS.map(color => (
+          <Tag key={color} color={color}>
+            {color}
+          </Tag>
+        ))}
+      </Space>
+      <Space wrap>
+        {COLORS.map(color => (
+          <Tag key={color} color={color} variant="outlined">
+            {color}
+          </Tag>
+        ))}
+      </Space>
+    </Space>
+  );
+}


### PR DESCRIPTION
## Summary
- Enable Docusaurus' docs preset (was `docs: false`) with a manually maintained sidebar grouped by the same atomic-design tiers as `packages/ui/src/components`
- Add `docs/components/atoms/tag.mdx` as the first component page (description, live demo via `src/demo/tag-demo.tsx`, props table) — a template for adding the rest one at a time
- Split navbar/footer's "Docs" (now the internal sidebar) from "Storybook" (the external interactive playground at ui-kit-docs-lab.vercel.app, unaffected — it still covers every component)
- Update `AGENTS.md` with the new `docs/` scope and pattern, and fix a stale line describing dark mode as going through ui-kit's `Config` (already changed to toggling `<html>` directly in #261)

## Test plan
- [x] `pnpm --filter=web build` / `lint` / `check-types`
- [x] `pnpm exec turbo run build --filter=web --filter=@repo/ui`
- [x] served locally, verified `/docs/intro` and `/docs/components/atoms/tag` render correctly (title, live Tag demo with all 5 colors × 2 variants, props table)
- [x] confirmed no Tailwind preflight regression in the compiled CSS