### PR TITLE
✨ feat(web): add 8 more atoms docs pages (Progress → Switch)

### DIFF
--- a/.changeset/feat-web-docs-progress-page-web.md
+++ b/.changeset/feat-web-docs-progress-page-web.md
@@ -2,4 +2,4 @@
 'web': minor
 ---
 
-Added new UI components, including Color Picker, Date Picker, Float Button, Progress, Select, Spin, and Switch, as well as Typography primitives.
+Add docs pages for 8 more atoms: Progress, Spin, Select, Date Picker, Float Button, Color Picker, Typography, and Switch.

--- a/.changeset/feat-web-docs-progress-page-web.md
+++ b/.changeset/feat-web-docs-progress-page-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Added new UI components, including Color Picker, Date Picker, Float Button, Progress, Select, Spin, and Switch, as well as Typography primitives.

--- a/apps/web/docs/components/atoms/color-picker.mdx
+++ b/apps/web/docs/components/atoms/color-picker.mdx
@@ -1,0 +1,41 @@
+---
+sidebar_position: 7
+title: Color Picker
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import ColorPickerDemo from '../../../src/demo/color-picker-demo';
+
+# Color Picker
+
+A swatch that opens a popover for picking a hex color.
+
+```tsx
+import { ColorPicker } from '@jbpark/ui-kit';
+
+<ColorPicker value={color} onChange={setColor} showText />;
+```
+
+<DemoTheme>
+
+<ColorPickerDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop           | Type                      | Default   |
+| -------------- | --------------------------- | --------- |
+| `value`        | `string`                    | -         |
+| `defaultValue` | `string`                    | `'#fff'`  |
+| `showText`     | `boolean`                   | -         |
+| `disabled`     | `boolean`                   | -         |
+| `onChange`     | `(color: string) => void`   | -         |
+| `open`         | `boolean`                   | -         |
+| `defaultOpen`  | `boolean`                   | -         |
+| `onOpenChange` | `(open: boolean) => void`   | -         |
+| `className`    | `string`                    | -         |
+
+`showText` renders the current hex value next to the swatch. Works both
+controlled (pass `value` + `onChange`) and uncontrolled (pass
+`defaultValue`, or neither).

--- a/apps/web/docs/components/atoms/date-picker.mdx
+++ b/apps/web/docs/components/atoms/date-picker.mdx
@@ -1,0 +1,37 @@
+---
+sidebar_position: 5
+title: Date Picker
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import DatePickerDemo from '../../../src/demo/date-picker-demo';
+
+# Date Picker
+
+A button that opens a calendar popover for picking a single date.
+
+```tsx
+import { DatePicker } from '@jbpark/ui-kit';
+
+<DatePicker onChange={date => console.log(date)} />;
+```
+
+<DemoTheme>
+
+<DatePickerDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop           | Type                              | Default        |
+| -------------- | ----------------------------------- | -------------- |
+| `value`        | `Date`                              | -               |
+| `defaultValue` | `Date`                              | -               |
+| `placeholder`  | `string`                            | `'Pick a date'` |
+| `disabled`     | `boolean`                           | -               |
+| `onChange`     | `(date: Date \| undefined) => void` | -               |
+| `className`    | `string`                            | -               |
+
+Works both controlled (pass `value` + `onChange`) and uncontrolled (pass
+`defaultValue`, or neither).

--- a/apps/web/docs/components/atoms/float-button.mdx
+++ b/apps/web/docs/components/atoms/float-button.mdx
@@ -1,0 +1,56 @@
+---
+sidebar_position: 6
+title: Float Button
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import FloatButtonDemo from '../../../src/demo/float-button-demo';
+import { FloatButton } from '@repo/ui';
+
+# Float Button
+
+A circular button fixed to a corner of the viewport, for a persistent
+floating action. `FloatButton.BackTop` is a ready-made variant that scrolls
+the page back to the top.
+
+```tsx
+import { FloatButton } from '@jbpark/ui-kit';
+
+<FloatButton icon={<Settings />} aria-label="Settings" />
+<FloatButton.BackTop />;
+```
+
+<DemoTheme>
+
+<FloatButtonDemo />
+
+</DemoTheme>
+
+`FloatButton` is `fixed`-positioned by design, so the box above overrides it
+to `absolute` just to keep this preview contained. `FloatButton.BackTop` is
+rendered for real below (`visibilityHeight={200}`, lower than its default
+`450`) — scroll this page down a bit and it appears in the actual bottom-right
+corner of your viewport; clicking it scrolls back to the top.
+
+<DemoTheme>
+
+<FloatButton.BackTop visibilityHeight={200} aria-label="Back to top" />
+
+</DemoTheme>
+
+## Props
+
+`FloatButton` accepts the same props as `Button` (icon, loading, shape,
+color, etc. — see its own docs page once added), plus fixed
+positioning/size/shape styling applied by default (all overridable via
+`className`).
+
+`FloatButton.BackTop` additionally accepts:
+
+| Prop                | Type                              | Default |
+| ------------------- | ------------------------------------ | ------- |
+| `visibilityHeight`  | `number`                             | `450`   |
+| `onClick`           | `(e: MouseEvent<HTMLElement>) => void` | -     |
+
+`BackTop` hides itself (`display: none`) until the page has scrolled past
+`visibilityHeight`.

--- a/apps/web/docs/components/atoms/progress.mdx
+++ b/apps/web/docs/components/atoms/progress.mdx
@@ -1,0 +1,34 @@
+---
+sidebar_position: 2
+title: Progress
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import ProgressDemo from '../../../src/demo/progress-demo';
+
+# Progress
+
+A bar that fills to a given percentage, horizontally or vertically.
+
+```tsx
+import { Progress } from '@jbpark/ui-kit';
+
+<Progress value={50} />;
+```
+
+<DemoTheme>
+
+<ProgressDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop         | Type                                       | Default        |
+| ------------ | ------------------------------------------- | -------------- |
+| `value`      | `number`                                    | -               |
+| `direction`  | `'horizontal' \| 'vertical'`               | `'horizontal'` |
+| `classNames` | `{ background?: string; bar?: string }`    | -               |
+| `className`  | `string`                                    | -               |
+
+`value` is clamped to `0`–`100`. `Progress` also accepts the rest of `React.ComponentPropsWithoutRef<'div'>`.

--- a/apps/web/docs/components/atoms/select.mdx
+++ b/apps/web/docs/components/atoms/select.mdx
@@ -1,0 +1,57 @@
+---
+sidebar_position: 4
+title: Select
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SelectDemo from '../../../src/demo/select-demo';
+
+# Select
+
+A dropdown for choosing one value from a list, built on Radix UI's Select
+primitive. Options can be flat or grouped.
+
+```tsx
+import { Select } from '@jbpark/ui-kit';
+
+<Select
+  placeholder="Choose a framework"
+  options={[
+    { label: 'React', value: 'react' },
+    { label: 'Vue', value: 'vue' },
+  ]}
+  onChange={value => console.log(value)}
+/>;
+```
+
+<DemoTheme>
+
+<SelectDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop          | Type                        | Default |
+| ------------- | ----------------------------- | ------- |
+| `options`     | `(Option \| OptionGroup)[]`  | -       |
+| `placeholder` | `string`                      | -       |
+| `onChange`    | `(value: string) => void`     | -       |
+| `className`   | `string`                      | -       |
+
+```ts
+interface Option {
+  label: React.ReactNode;
+  value: string;
+}
+
+interface OptionGroup {
+  label: React.ReactNode;
+  options: Option[];
+}
+```
+
+An `OptionGroup` entry (an `options` array instead of `value`) renders as a
+labeled group. `Select` also accepts the rest of Radix UI's `Select` root
+props (e.g. `value`, `defaultValue`, `disabled`, `name`, `required`) except
+`onValueChange`, which is renamed to `onChange` above.

--- a/apps/web/docs/components/atoms/spin.mdx
+++ b/apps/web/docs/components/atoms/spin.mdx
@@ -1,0 +1,43 @@
+---
+sidebar_position: 3
+title: Spin
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SpinDemo from '../../../src/demo/spin-demo';
+
+# Spin
+
+A loading indicator, either standalone or as an overlay on top of existing
+content.
+
+```tsx
+import { Spin } from '@jbpark/ui-kit';
+
+// standalone
+<Spin spinning />
+
+// overlay on content
+<Spin spinning={isLoading}>
+  <MyContent />
+</Spin>;
+```
+
+<DemoTheme>
+
+<SpinDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop        | Type      | Default |
+| ----------- | ---------- | ------- |
+| `spinning`  | `boolean` | -       |
+| `children`  | `ReactNode` | -     |
+| `className` | `string`  | -       |
+
+With `children`, `Spin` renders them dimmed underneath the spinner while
+`spinning` is true, and renders them as-is (no wrapper) while false. Without
+`children`, it renders nothing while `spinning` is false. `Spin` also
+accepts the rest of `React.ComponentPropsWithoutRef<'div'>`.

--- a/apps/web/docs/components/atoms/switch.mdx
+++ b/apps/web/docs/components/atoms/switch.mdx
@@ -1,0 +1,42 @@
+---
+sidebar_position: 9
+title: Switch
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SwitchDemo from '../../../src/demo/switch-demo';
+
+# Switch
+
+A boolean on/off toggle.
+
+```tsx
+import { Switch } from '@jbpark/ui-kit';
+
+<Switch checked={checked} onChange={setChecked} />;
+```
+
+<DemoTheme>
+
+<SwitchDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop                | Type                        | Default    |
+| ------------------- | ------------------------------ | ---------- |
+| `checked`           | `boolean`                      | -          |
+| `defaultChecked`    | `boolean`                      | `false`    |
+| `size`               | `'small' \| 'medium'`         | `'medium'` |
+| `disabled`           | `boolean`                      | -          |
+| `onChange`           | `(checked: boolean) => void`   | -          |
+| `checkedChildren`    | `ReactNode`                    | -          |
+| `unCheckedChildren`  | `ReactNode`                    | -          |
+| `classNames`         | `{ track?: string; handle?: string }` | -   |
+| `className`          | `string`                       | -          |
+
+Works both controlled (pass `checked` + `onChange`) and uncontrolled (pass
+`defaultChecked`, or neither). `Switch` also accepts the rest of
+`React.ComponentPropsWithoutRef<'button'>` except `onChange` (renamed to the
+boolean-callback form above).

--- a/apps/web/docs/components/atoms/typography.mdx
+++ b/apps/web/docs/components/atoms/typography.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 8
+title: Typography
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import TypographyDemo from '../../../src/demo/typography-demo';
+
+# Typography
+
+`Typography.Title`, `Typography.Text`, `Typography.Paragraph`, and
+`Typography.Link` — text primitives for headings, inline emphasis,
+paragraphs, and links. `Typography` itself is a plain `<article>` wrapper.
+
+```tsx
+import { Typography } from '@jbpark/ui-kit';
+
+<Typography.Title level={2}>Heading</Typography.Title>
+<Typography.Paragraph>
+  Some <Typography.Text strong>strong</Typography.Text> text.
+</Typography.Paragraph>;
+```
+
+<DemoTheme>
+
+<TypographyDemo />
+
+</DemoTheme>
+
+## Title {/* #title */}
+
+Renders `h1`–`h6` depending on `level`.
+
+| Prop    | Type                       | Default |
+| ------- | ---------------------------- | ------- |
+| `level` | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | `1`     |
+
+Also accepts the rest of `React.ComponentPropsWithoutRef<'h1'|...|'h6'>`.
+
+## Text {/* #text */}
+
+Renders a `span`.
+
+| Prop        | Type      | Default |
+| ----------- | ---------- | ------- |
+| `underline` | `boolean` | -       |
+| `strong`    | `boolean` | -       |
+
+Also accepts the rest of `React.ComponentPropsWithoutRef<'span'>`.
+
+## Paragraph {/* #paragraph */}
+
+Renders a `p`. No props beyond `React.ComponentPropsWithoutRef<'p'>`.
+
+## Link {/* #link */}
+
+Renders an `a`. No props beyond `React.ComponentPropsWithoutRef<'a'>` —
+`rel="noopener noreferrer"` is added automatically when `target="_blank"`
+and no `rel` is passed.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@docusaurus/theme-common": "3.10.2",
     "@repo/ui": "workspace:*",
     "clsx": "^2.0.0",
+    "date-fns": "^4.4.0",
     "lucide-react": "^1.31.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -16,6 +16,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/progress',
         'components/atoms/spin',
         'components/atoms/select',
+        'components/atoms/date-picker',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/float-button',
         'components/atoms/color-picker',
         'components/atoms/typography',
+        'components/atoms/switch',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -15,6 +15,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/tag',
         'components/atoms/progress',
         'components/atoms/spin',
+        'components/atoms/select',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -11,7 +11,11 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Atoms',
       collapsed: false,
-      items: ['components/atoms/tag', 'components/atoms/progress'],
+      items: [
+        'components/atoms/tag',
+        'components/atoms/progress',
+        'components/atoms/spin',
+      ],
     },
   ],
 };

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -18,6 +18,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/select',
         'components/atoms/date-picker',
         'components/atoms/float-button',
+        'components/atoms/color-picker',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -19,6 +19,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/date-picker',
         'components/atoms/float-button',
         'components/atoms/color-picker',
+        'components/atoms/typography',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/spin',
         'components/atoms/select',
         'components/atoms/date-picker',
+        'components/atoms/float-button',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -11,7 +11,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Atoms',
       collapsed: false,
-      items: ['components/atoms/tag'],
+      items: ['components/atoms/tag', 'components/atoms/progress'],
     },
   ],
 };

--- a/apps/web/src/demo/color-picker-demo.tsx
+++ b/apps/web/src/demo/color-picker-demo.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+import { ColorPicker, Space } from '@repo/ui';
+
+export default function ColorPickerDemo() {
+  const [color, setColor] = useState('#1677ff');
+
+  return (
+    <Space align="center" size="middle">
+      <ColorPicker value={color} onChange={setColor} showText />
+    </Space>
+  );
+}

--- a/apps/web/src/demo/date-picker-demo.tsx
+++ b/apps/web/src/demo/date-picker-demo.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+import { format } from 'date-fns';
+
+import { DatePicker, Space, Typography } from '@repo/ui';
+
+export default function DatePickerDemo() {
+  const [date, setDate] = useState<Date>();
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <DatePicker value={date} onChange={setDate} />
+      <Typography.Text className="text-muted-foreground text-sm">
+        Selected: {date ? format(date, 'PPP') : 'none'}
+      </Typography.Text>
+    </Space>
+  );
+}

--- a/apps/web/src/demo/float-button-demo.tsx
+++ b/apps/web/src/demo/float-button-demo.tsx
@@ -1,0 +1,27 @@
+import { Settings } from 'lucide-react';
+
+import { FloatButton, Typography } from '@repo/ui';
+
+// FloatButton is `fixed`-positioned by design (it floats over the whole
+// viewport in real use). For this scoped demo, `className="absolute"`
+// overrides that so it stays contained inside this box instead of
+// escaping over the rest of the docs page.
+export default function FloatButtonDemo() {
+  return (
+    <div
+      className="border-border bg-muted/30 relative h-56 w-full overflow-hidden
+        rounded-md border"
+    >
+      <Typography.Text
+        className="text-muted-foreground absolute top-3 left-3 text-sm"
+      >
+        Scoped preview — normally fixed to the viewport corner
+      </Typography.Text>
+      <FloatButton
+        icon={<Settings />}
+        aria-label="Settings"
+        className="absolute right-5 bottom-5"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/demo/progress-demo.tsx
+++ b/apps/web/src/demo/progress-demo.tsx
@@ -1,0 +1,32 @@
+import { Progress, Space, Typography } from '@repo/ui';
+
+const VALUES = [25, 50, 75, 100] as const;
+
+export default function ProgressDemo() {
+  return (
+    <Space
+      orientation="vertical"
+      align="start"
+      size="middle"
+      className="w-full"
+    >
+      {VALUES.map(value => (
+        <Space key={value} align="center" size="small" className="w-full">
+          <Progress value={value} />
+          <Typography.Text
+            className="text-muted-foreground w-10 text-right text-sm"
+          >
+            {value}%
+          </Typography.Text>
+        </Space>
+      ))}
+      <Space align="end" size="middle">
+        {VALUES.map(value => (
+          <div key={value} className="h-32">
+            <Progress value={value} direction="vertical" />
+          </div>
+        ))}
+      </Space>
+    </Space>
+  );
+}

--- a/apps/web/src/demo/select-demo.tsx
+++ b/apps/web/src/demo/select-demo.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+import { Select, Space, Typography } from '@repo/ui';
+
+const FRAMEWORKS = [
+  { label: 'React', value: 'react' },
+  { label: 'Vue', value: 'vue' },
+  { label: 'Svelte', value: 'svelte' },
+];
+
+const GROUPED_FOODS = [
+  {
+    label: 'Fruits',
+    options: [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Banana', value: 'banana' },
+    ],
+  },
+  {
+    label: 'Vegetables',
+    options: [
+      { label: 'Carrot', value: 'carrot' },
+      { label: 'Potato', value: 'potato' },
+    ],
+  },
+];
+
+export default function SelectDemo() {
+  const [value, setValue] = useState<string>();
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Space orientation="vertical" align="start" size="small">
+        <Select
+          placeholder="Choose a framework"
+          options={FRAMEWORKS}
+          onChange={setValue}
+        />
+        <Typography.Text className="text-muted-foreground text-sm">
+          Selected: {value ?? 'none'}
+        </Typography.Text>
+      </Space>
+      <Select placeholder="Choose a food" options={GROUPED_FOODS} />
+    </Space>
+  );
+}

--- a/apps/web/src/demo/spin-demo.tsx
+++ b/apps/web/src/demo/spin-demo.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+import { Button, Card, Space, Spin, Typography } from '@repo/ui';
+
+export default function SpinDemo() {
+  const [spinning, setSpinning] = useState(true);
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Button onClick={() => setSpinning(s => !s)}>
+        {spinning ? 'Stop' : 'Start'} spinning
+      </Button>
+      <Space size="large" align="start" wrap>
+        <div
+          className="border-border flex h-32 w-32 items-center justify-center
+            rounded-md border border-dashed"
+        >
+          <Spin spinning={spinning} />
+        </div>
+        <Card className="h-32 w-48">
+          <Spin spinning={spinning}>
+            <Typography.Paragraph className="m-0">
+              Content stays visible but dimmed behind the spin overlay while
+              loading.
+            </Typography.Paragraph>
+          </Spin>
+        </Card>
+      </Space>
+    </Space>
+  );
+}

--- a/apps/web/src/demo/switch-demo.tsx
+++ b/apps/web/src/demo/switch-demo.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+import { Space, Switch, Typography } from '@repo/ui';
+
+export default function SwitchDemo() {
+  const [checked, setChecked] = useState(true);
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Space align="center" size="middle">
+        <Switch checked={checked} onChange={setChecked} />
+        <Typography.Text className="text-muted-foreground text-sm">
+          {checked ? 'checked' : 'unchecked'}
+        </Typography.Text>
+      </Space>
+      <Space align="center" size="middle">
+        <Switch size="small" defaultChecked />
+        <Switch checkedChildren="ON" unCheckedChildren="OFF" />
+        <Switch disabled defaultChecked />
+        <Switch disabled />
+      </Space>
+    </Space>
+  );
+}

--- a/apps/web/src/demo/typography-demo.tsx
+++ b/apps/web/src/demo/typography-demo.tsx
@@ -1,0 +1,20 @@
+import { Space, Typography } from '@repo/ui';
+
+export default function TypographyDemo() {
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Typography.Title level={3}>Title level=3</Typography.Title>
+      <Typography.Paragraph>
+        A <Typography.Text strong>strong</Typography.Text>,{' '}
+        <Typography.Text underline>underlined</Typography.Text>, and a{' '}
+        <Typography.Link
+          href="https://github.com/pjb0811/ui-kit"
+          target="_blank"
+        >
+          link
+        </Typography.Link>{' '}
+        inside a paragraph.
+      </Typography.Paragraph>
+    </Space>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)


### PR DESCRIPTION
## Summary
Sweep continuing the pattern from #263 (Tag) — one page per component, grouped under Atoms in `sidebars.ts`, each with a description, live demo, and props table:

- Progress
- Spin
- Select
- Date Picker
- Float Button (+ BackTop)
- Color Picker
- Typography (Title/Text/Paragraph/Link, one page)
- Switch

## Notable fixes found along the way
- `date-fns` was only reachable via hoisting through `@repo/ui`, not declared as an apps/web dependency — added explicitly
- `FloatButton`/`FloatButton.BackTop` are `fixed`-positioned by design, which would otherwise escape over the whole docs page when embedded — scoped demos with a `className="absolute"` override; `BackTop` is also demoed unscoped/for-real (`visibilityHeight={200}`) so scrolling the page shows it actually fixed to the viewport
- `FloatButton.BackTop`'s default `aria-label` is Korean ("맨 위로") — overridden to "Back to top" for this English-only docs site
- `## Heading {#id}` fails MDX compilation (acorn tries to parse `{#id}` as a JS expression) — fixed to the working form already used in use-hooks: `## Heading {/* #id */}`
- A multi-line markdown table cell (Select's props table) rendered garbled — collapsed to one line + a fenced code block for the longer type

## Test plan
- [x] `pnpm --filter=web lint` / `check-types` / `build` after every page
- [x] `pnpm exec turbo run build --filter=web --filter=@repo/ui`
- [x] served locally after every page, verified title/demo content/props table for each