### PR TITLE
✨ feat(web): finish atoms docs pages (Skeleton → Radio) + functional sidebar grouping

### DIFF
--- a/.changeset/feat-web-docs-skeleton-page-web.md
+++ b/.changeset/feat-web-docs-skeleton-page-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+New UI components and documentation pages have been added, including Button, Checkbox, Float Button, Input, Popover, and Radio, with live demos and detailed prop documentation.

--- a/.changeset/feat-web-docs-skeleton-page-web.md
+++ b/.changeset/feat-web-docs-skeleton-page-web.md
@@ -2,4 +2,4 @@
 'web': minor
 ---
 
-New UI components and documentation pages have been added, including Button, Checkbox, Float Button, Input, Popover, and Radio, with live demos and detailed prop documentation.
+Add docs pages for the last 6 atoms: Skeleton, Input, Button, Popover, Checkbox, and Radio — finishing every atom. Also regroup the docs sidebar by function (General/Data Entry/Data Display/Feedback/Navigation) instead of atomic-design tier.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -6,12 +6,12 @@ apps/web 프로젝트에서 작업할 때 참고하는 가이드입니다.
 
 - Docusaurus 기반 ui-kit 패키지 랜딩 페이지 + 컴포넌트 문서 (포트 3000)
 - 컴포넌트별 인터랙티브 플레이그라운드(모든 variant/props 조합)는 계속 `apps/docs`(Storybook)가 담당함 — 여기 `docs/`는 컴포넌트를 하나씩 채워나가는 설명 + 라이브 데모 위주 문서이고, 전수 커버리지를 목표로 하지 않음
-- 새 컴포넌트 문서 페이지 추가 패턴: `packages/ui/src/components`와 동일한 계층(atoms/molecules/organisms/templates)으로 `docs/components/{tier}/{kebab-case-name}.mdx` 작성 + 필요하면 `src/demo/{kebab-case-name}-demo.tsx`에 라이브 데모 컴포넌트 작성 + `sidebars.ts`에 항목 추가. `docs/components/atoms/tag.mdx` + `src/demo/tag-demo.tsx`가 참고할 템플릿
+- 새 컴포넌트 문서 페이지 추가 패턴: **파일 경로**는 `packages/ui/src/components`와 동일한 계층(atoms/molecules/organisms/templates)으로 `docs/components/{tier}/{kebab-case-name}.mdx` 작성 + 필요하면 `src/demo/{kebab-case-name}-demo.tsx`에 라이브 데모 컴포넌트 작성. **사이드바 그룹핑**은 파일 경로의 계층이 아니라 해당 컴포넌트의 Storybook story `title` 프리픽스(예: `Data Entry/Select`)를 따라 `sidebars.ts`에 항목 추가 — 랜딩 페이지 `CATEGORIES`와 동일한 분류(General/Data Entry/Data Display/Feedback/Navigation/Layout). `docs/components/atoms/tag.mdx` + `src/demo/tag-demo.tsx`가 참고할 템플릿
 
 ## Key Paths
 
 - `src/pages/`: 커스텀 페이지 (현재는 홈페이지 하나)
-- `docs/`: 컴포넌트 문서 페이지 (계층별로 `components/{tier}/`)
+- `docs/`: 컴포넌트 문서 페이지. **파일 경로는 계층별**(`components/{tier}/`)이지만 **사이드바는 기능별**로 그룹핑되어 있어 둘이 일치하지 않을 수 있음 (`sidebars.ts` 참고)
 - `src/demo/`: 문서 페이지에 임베드하는 라이브 데모 컴포넌트
 - `src/components/`: `DemoTheme` 등 페이지에서 쓰는 컴포넌트
 - `src/css/custom.css`: Tailwind + `@repo/ui/style.css` 진입점

--- a/apps/web/docs/components/atoms/button.mdx
+++ b/apps/web/docs/components/atoms/button.mdx
@@ -1,0 +1,47 @@
+---
+sidebar_position: 12
+title: Button
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import ButtonDemo from '../../../src/demo/button-demo';
+
+# Button
+
+```tsx
+import { Button } from '@jbpark/ui-kit';
+
+<Button type="primary" onClick={() => console.log('clicked')}>
+  Click me
+</Button>;
+```
+
+<DemoTheme>
+
+<ButtonDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop        | Type                                                          | Default     |
+| ----------- | ----------------------------------------------------------------- | ----------- |
+| `type`      | `'primary' \| 'default' \| 'dashed' \| 'text' \| 'link'`         | `'default'` |
+| `variant`   | `'solid' \| 'outlined' \| 'dashed' \| 'filled' \| 'text' \| 'link'` | -         |
+| `size`      | `'small' \| 'middle' \| 'large'`                                  | `'middle'`  |
+| `shape`     | `'default' \| 'circle' \| 'round'`                                | `'default'` |
+| `color`     | preset color name (see below) `\| 'default' \| 'primary' \| 'danger'` | `'default'` |
+| `icon`      | `ReactNode`                                                        | -           |
+| `loading`   | `boolean \| { icon: ReactNode }`                                  | -           |
+| `block`     | `boolean`                                                          | -           |
+| `danger`    | `boolean`                                                          | -           |
+| `disabled`  | `boolean`                                                          | -           |
+| `htmlType`  | `'button' \| 'submit' \| 'reset'`                                 | `'button'`  |
+| `className` | `string`                                                           | -           |
+
+`type` is an antd-style preset that maps to `variant` internally — pass
+`variant` directly to override it for a one-off case. Preset `color` names:
+`blue`, `purple`, `cyan`, `green`, `magenta`, `pink`, `red`, `orange`,
+`yellow`, `volcano`, `geekblue`, `lime`, `gold`, in addition to `default`,
+`primary`, `danger`. `Button` also accepts the rest of Radix UI's `Slot`
+props via `asChild`, and the native `<button>` attributes.

--- a/apps/web/docs/components/atoms/checkbox.mdx
+++ b/apps/web/docs/components/atoms/checkbox.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_position: 14
+title: Checkbox
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import CheckboxDemo from '../../../src/demo/checkbox-demo';
+
+# Checkbox
+
+A single checkbox, or `Checkbox.Group` for a list of options with a shared
+selected-values array.
+
+```tsx
+import { Checkbox } from '@jbpark/ui-kit';
+
+<Checkbox checked={checked} onChange={setChecked}>
+  Label
+</Checkbox>
+<Checkbox.Group
+  options={[{ label: 'React', value: 'react' }]}
+  value={values}
+  onChange={setValues}
+/>;
+```
+
+<DemoTheme>
+
+<CheckboxDemo />
+
+</DemoTheme>
+
+## Checkbox {/* #checkbox */}
+
+| Prop             | Type                                            | Default  |
+| ---------------- | -------------------------------------------------- | -------- |
+| `checked`        | `boolean`                                          | -        |
+| `defaultChecked` | `boolean`                                          | `false`  |
+| `value`          | `string \| number \| boolean`                     | -        |
+| `name`           | `string`                                           | -        |
+| `placement`      | `'left' \| 'right'`                                | `'left'` |
+| `disabled`       | `boolean`                                          | -        |
+| `icons`          | `{ checked?: ReactNode; unchecked?: ReactNode }`  | -        |
+| `onChange`       | `(checked: boolean) => void`                       | -        |
+
+Works both controlled (pass `checked` + `onChange`) and uncontrolled (pass
+`defaultChecked`, or neither). `icons` swaps the default check-square icons
+for custom ones. Also accepts the rest of
+`React.ComponentPropsWithoutRef<'div'>` except `onChange`.
+
+## Checkbox.Group {/* #checkbox-group */}
+
+| Prop           | Type                                        | Default        |
+| -------------- | ---------------------------------------------- | -------------- |
+| `options`      | `(string \| number \| boolean \| Option)[]`    | `[]`           |
+| `value`        | `OptionValue[]`                                 | -              |
+| `defaultValue` | `OptionValue[]`                                 | `[]`           |
+| `orientation`  | `'vertical' \| 'horizontal'`                   | `'vertical'`   |
+| `placement`    | `'left' \| 'right'`                             | `'left'`       |
+| `name`         | `string`                                        | -              |
+| `disabled`     | `boolean`                                       | -              |
+| `classNames`   | `{ wrapper?: string; item?: string }`          | -              |
+| `onChange`     | `(values: OptionValue[]) => void`               | -              |
+
+```ts
+interface Option {
+  label: string;
+  value: string | number | boolean;
+  disabled?: boolean;
+}
+```
+
+A plain `string`/`number`/`boolean` in `options` is shorthand for
+`{ label: String(v), value: v }`.

--- a/apps/web/docs/components/atoms/float-button.mdx
+++ b/apps/web/docs/components/atoms/float-button.mdx
@@ -40,10 +40,9 @@ corner of your viewport; clicking it scrolls back to the top.
 
 ## Props
 
-`FloatButton` accepts the same props as `Button` (icon, loading, shape,
-color, etc. — see its own docs page once added), plus fixed
-positioning/size/shape styling applied by default (all overridable via
-`className`).
+`FloatButton` accepts the same props as [`Button`](./button) (icon, loading,
+shape, color, etc.), plus fixed positioning/size/shape styling applied by
+default (all overridable via `className`).
 
 `FloatButton.BackTop` additionally accepts:
 

--- a/apps/web/docs/components/atoms/input.mdx
+++ b/apps/web/docs/components/atoms/input.mdx
@@ -1,0 +1,46 @@
+---
+sidebar_position: 11
+title: Input
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import InputDemo from '../../../src/demo/input-demo';
+
+# Input
+
+A text input. `Input.Search` adds a clear button and a search action;
+`Input.TextArea` is the multi-line variant.
+
+```tsx
+import { Input } from '@jbpark/ui-kit';
+
+<Input placeholder="Basic input" />
+<Input.Search placeholder="Search..." onSearch={value => console.log(value)} />
+<Input.TextArea placeholder="Text area" rows={3} />;
+```
+
+<DemoTheme>
+
+<InputDemo />
+
+</DemoTheme>
+
+## Input {/* #input */}
+
+A thin wrapper with no props beyond `React.ComponentPropsWithRef<'input'>`.
+
+## Input.Search {/* #input-search */}
+
+| Prop         | Type                                                | Default |
+| ------------ | ------------------------------------------------------ | ------- |
+| `allowClear` | `boolean`                                               | `true`  |
+| `onChange`   | `(e: ChangeEvent<HTMLInputElement> \| { target: { value: string } }) => void` | - |
+| `onSearch`   | `(value: string) => void`                               | -       |
+
+`onSearch` fires on pressing Enter or clicking the search button. Also
+accepts the rest of `React.ComponentPropsWithRef<'input'>`.
+
+## Input.TextArea {/* #input-textarea */}
+
+A thin wrapper with no props beyond
+`React.ComponentPropsWithRef<'textarea'>`.

--- a/apps/web/docs/components/atoms/popover.mdx
+++ b/apps/web/docs/components/atoms/popover.mdx
@@ -1,0 +1,46 @@
+---
+sidebar_position: 13
+title: Popover
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import PopoverDemo from '../../../src/demo/popover-demo';
+
+# Popover
+
+A floating panel anchored to a trigger element, built on Radix UI's Popover
+primitive. Click each button below to open it.
+
+```tsx
+import { Button, Popover } from '@jbpark/ui-kit';
+
+<Popover title="Title" content={<p>Content</p>}>
+  <Button>Open</Button>
+</Popover>;
+```
+
+<DemoTheme>
+
+<PopoverDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop           | Type                        | Default |
+| -------------- | ------------------------------ | ------- |
+| `title`        | `ReactNode`                    | -       |
+| `content`      | `ReactNode`                    | -       |
+| `placement`    | placement name (see below)     | `'top'` |
+| `open`         | `boolean`                      | -       |
+| `defaultOpen`  | `boolean`                      | -       |
+| `onOpenChange` | `(open: boolean) => void`      | -       |
+| `children`     | `ReactNode` (the trigger)      | -       |
+
+`placement`: `'top' | 'left' | 'right' | 'bottom' | 'topLeft' | 'topRight' |
+'bottomLeft' | 'bottomRight' | 'leftTop' | 'leftBottom' | 'rightTop' |
+'rightBottom'`.
+
+Works both controlled (pass `open` + `onOpenChange`) and uncontrolled (pass
+`defaultOpen`, or neither). `Popover` also accepts the rest of
+`React.ComponentPropsWithoutRef<'div'>` (applied to the content panel).

--- a/apps/web/docs/components/atoms/radio.mdx
+++ b/apps/web/docs/components/atoms/radio.mdx
@@ -1,0 +1,71 @@
+---
+sidebar_position: 15
+title: Radio
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import RadioDemo from '../../../src/demo/radio-demo';
+
+# Radio
+
+A single radio button, or `Radio.Group` for a mutually-exclusive list of
+options. `Radio.Group` also has a segmented-button style
+(`optionType="button"`).
+
+```tsx
+import { Radio } from '@jbpark/ui-kit';
+
+<Radio.Group
+  options={[
+    { label: 'Small', value: 'small' },
+    { label: 'Medium', value: 'medium' },
+  ]}
+  value={value}
+  onChange={setValue}
+/>;
+```
+
+<DemoTheme>
+
+<RadioDemo />
+
+</DemoTheme>
+
+## Radio {/* #radio */}
+
+| Prop             | Type                                            | Default  |
+| ---------------- | -------------------------------------------------- | -------- |
+| `checked`        | `boolean`                                          | -        |
+| `defaultChecked` | `boolean`                                          | `false`  |
+| `value`          | `string \| number \| boolean`                     | -        |
+| `name`           | `string`                                           | -        |
+| `placement`      | `'left' \| 'right'`                                | `'left'` |
+| `disabled`       | `boolean`                                          | -        |
+| `icons`          | `{ checked?: ReactNode; unchecked?: ReactNode }`  | -        |
+| `onChange`       | `(checked: boolean) => void`                       | -        |
+
+A standalone `Radio` (not inside `Radio.Group`) manages its own single-item
+group, so `checked`/`onChange` behave like a checkbox rather than
+participating in a shared selection.
+
+## Radio.Group {/* #radio-group */}
+
+| Prop           | Type                                        | Default        |
+| -------------- | ---------------------------------------------- | -------------- |
+| `options`      | `(string \| number \| boolean \| Option)[]`    | `[]`           |
+| `value`        | `OptionValue`                                   | -              |
+| `defaultValue` | `OptionValue`                                   | -              |
+| `orientation`  | `'vertical' \| 'horizontal'`                   | `'horizontal'` |
+| `placement`    | `'left' \| 'right'`                             | `'left'`       |
+| `optionType`   | `'default' \| 'button'`                         | `'default'`    |
+| `buttonStyle`  | `'solid' \| 'outlined'`                         | `'solid'`      |
+| `size`         | `'small' \| 'middle' \| 'large'`               | -              |
+| `name`         | `string`                                        | -              |
+| `disabled`     | `boolean`                                       | -              |
+| `classNames`   | `{ wrapper?: string; item?: string }`          | -              |
+| `onChange`     | `(value: OptionValue) => void`                  | -              |
+
+`optionType="button"` renders each option as a segmented `Button` (real
+radio semantics via Radix, not just styled buttons) instead of the default
+circle-and-label. `buttonStyle` only affects the checked option's variant in
+that mode.

--- a/apps/web/docs/components/atoms/skeleton.mdx
+++ b/apps/web/docs/components/atoms/skeleton.mdx
@@ -1,0 +1,51 @@
+---
+sidebar_position: 10
+title: Skeleton
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SkeletonDemo from '../../../src/demo/skeleton-demo';
+
+# Skeleton
+
+A placeholder that mimics the shape of content while it loads.
+`Skeleton.Button` and `Skeleton.Node` are preset shapes for common cases.
+
+```tsx
+import { Skeleton } from '@jbpark/ui-kit';
+
+<Skeleton loading={isLoading} avatar count={3}>
+  <RealContent />
+</Skeleton>;
+```
+
+<DemoTheme>
+
+<SkeletonDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop        | Type                                       | Default     |
+| ----------- | --------------------------------------------- | ----------- |
+| `loading`   | `boolean`                                     | `true`      |
+| `active`    | `boolean`                                      | `true`      |
+| `avatar`    | `boolean`                                      | -           |
+| `size`      | `'small' \| 'default' \| 'large'`             | `'default'` |
+| `count`     | `number`                                       | `1`         |
+| `gap`       | `number`                                       | `6`         |
+| `direction` | `'horizontal' \| 'vertical'`                  | `'vertical'` |
+| `width`     | `string \| number \| (string \| number)[]`    | -           |
+| `height`    | `string \| number \| (string \| number)[]`    | -           |
+| `classNames` | `{ wrapper?, avatar?, item?: string }`       | -           |
+| `children`  | `ReactNode`                                    | -           |
+
+When `loading` is `false`, `children` renders as-is (no wrapper). `active`
+toggles the shimmer animation. `width`/`height` accept an array to size
+each of the `count` placeholder items individually. `Skeleton` also accepts
+the rest of `React.ComponentPropsWithoutRef<'div'>`.
+
+`Skeleton.Button` and `Skeleton.Node` accept the same props (minus their own
+preset shape) as shortcuts for a button-sized and a large card-sized
+placeholder, respectively.

--- a/apps/web/docs/intro.md
+++ b/apps/web/docs/intro.md
@@ -15,10 +15,10 @@ npm install @jbpark/ui-kit
 
 ## Components
 
-Pages here are being added one component at a time, grouped by the same
-atomic-design tiers as the source (atoms/molecules/organisms/templates). For
-the full interactive catalog of every component right now, see
-[Storybook](https://ui-kit-docs-lab.vercel.app).
+Pages here are being added one component at a time, grouped the same way as
+Storybook and the landing page (General/Data Entry/Data Display/Feedback/
+Navigation/Layout). For the full interactive catalog of every component
+right now, see [Storybook](https://ui-kit-docs-lab.vercel.app).
 
 ## Links
 

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/skeleton',
         'components/atoms/input',
         'components/atoms/button',
+        'components/atoms/popover',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -23,6 +23,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/switch',
         'components/atoms/skeleton',
         'components/atoms/input',
+        'components/atoms/button',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/switch',
         'components/atoms/input',
         'components/atoms/checkbox',
+        'components/atoms/radio',
       ],
     },
     {

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/color-picker',
         'components/atoms/switch',
         'components/atoms/input',
+        'components/atoms/checkbox',
       ],
     },
     {

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/color-picker',
         'components/atoms/typography',
         'components/atoms/switch',
+        'components/atoms/skeleton',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/typography',
         'components/atoms/switch',
         'components/atoms/skeleton',
+        'components/atoms/input',
       ],
     },
   ],

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -1,31 +1,59 @@
 import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 
 // Pages are added one component at a time — see AGENTS.md. Grouped by the
-// same atomic-design tiers as packages/ui/src/components (atoms/molecules/
-// organisms/templates), so a new page's place in the sidebar matches where
-// its source lives.
+// same functional categories Storybook stories use (each story's `title`
+// prefix, e.g. 'Data Entry/Select') and the landing page's own CATEGORIES
+// list (General/Data Entry/Data Display/Feedback/Navigation/Layout), not
+// by atomic-design tier — a category only appears here once it has a page.
+// File paths under docs/components/ still mirror packages/ui/src/components'
+// tier structure (atoms/molecules/organisms/templates); only this sidebar's
+// grouping/labels differ from that.
 const sidebars: SidebarsConfig = {
   docsSidebar: [
     'intro',
     {
       type: 'category',
-      label: 'Atoms',
+      label: 'General',
       collapsed: false,
       items: [
         'components/atoms/tag',
-        'components/atoms/progress',
-        'components/atoms/spin',
+        'components/atoms/typography',
+        'components/atoms/button',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Data Entry',
+      collapsed: false,
+      items: [
         'components/atoms/select',
         'components/atoms/date-picker',
-        'components/atoms/float-button',
         'components/atoms/color-picker',
-        'components/atoms/typography',
         'components/atoms/switch',
-        'components/atoms/skeleton',
         'components/atoms/input',
-        'components/atoms/button',
-        'components/atoms/popover',
       ],
+    },
+    {
+      type: 'category',
+      label: 'Data Display',
+      collapsed: false,
+      items: ['components/atoms/popover'],
+    },
+    {
+      type: 'category',
+      label: 'Feedback',
+      collapsed: false,
+      items: [
+        'components/atoms/progress',
+        'components/atoms/spin',
+        'components/atoms/skeleton',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Navigation',
+      collapsed: false,
+      items: ['components/atoms/float-button'],
     },
   ],
 };

--- a/apps/web/src/demo/button-demo.tsx
+++ b/apps/web/src/demo/button-demo.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+import { Heart } from 'lucide-react';
+
+import { Button, Space } from '@repo/ui';
+
+const TYPES = ['primary', 'default', 'dashed', 'text', 'link'] as const;
+const COLORS = ['default', 'primary', 'danger', 'blue', 'green'] as const;
+
+export default function ButtonDemo() {
+  const [loading, setLoading] = useState(false);
+
+  const onClickLoad = () => {
+    setLoading(true);
+    setTimeout(() => setLoading(false), 1500);
+  };
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Space wrap align="center">
+        {TYPES.map(type => (
+          <Button key={type} type={type}>
+            {type}
+          </Button>
+        ))}
+      </Space>
+      <Space wrap align="center">
+        {COLORS.map(color => (
+          <Button key={color} type="primary" color={color}>
+            {color}
+          </Button>
+        ))}
+      </Space>
+      <Space wrap align="center">
+        <Button shape="circle" icon={<Heart />} aria-label="Like" />
+        <Button shape="round">Round</Button>
+        <Button icon={<Heart />}>With icon</Button>
+        <Button loading={loading} onClick={onClickLoad}>
+          {loading ? 'Loading' : 'Click to load'}
+        </Button>
+      </Space>
+    </Space>
+  );
+}

--- a/apps/web/src/demo/checkbox-demo.tsx
+++ b/apps/web/src/demo/checkbox-demo.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+import { Checkbox, Space, Typography } from '@repo/ui';
+
+const OPTIONS = [
+  { label: 'React', value: 'react' },
+  { label: 'Vue', value: 'vue' },
+  { label: 'Svelte', value: 'svelte' },
+];
+
+export default function CheckboxDemo() {
+  const [checked, setChecked] = useState(true);
+  const [values, setValues] = useState<(string | number | boolean)[]>([
+    'react',
+  ]);
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Checkbox checked={checked} onChange={setChecked}>
+        Single checkbox
+      </Checkbox>
+      <Space orientation="vertical" align="start" size="small">
+        <Checkbox.Group options={OPTIONS} value={values} onChange={setValues} />
+        <Typography.Text className="text-muted-foreground text-sm">
+          Selected: {values.length ? values.join(', ') : 'none'}
+        </Typography.Text>
+      </Space>
+    </Space>
+  );
+}

--- a/apps/web/src/demo/input-demo.tsx
+++ b/apps/web/src/demo/input-demo.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+import { Input, Space, Typography } from '@repo/ui';
+
+export default function InputDemo() {
+  const [searched, setSearched] = useState('');
+
+  return (
+    <Space
+      orientation="vertical"
+      align="start"
+      size="middle"
+      className="w-full"
+    >
+      <Input placeholder="Basic input" className="max-w-64" />
+      <Space orientation="vertical" align="start" size="small">
+        <Input.Search
+          placeholder="Search..."
+          className="max-w-64"
+          onSearch={setSearched}
+        />
+        <Typography.Text className="text-muted-foreground text-sm">
+          Last search: {searched || 'none'}
+        </Typography.Text>
+      </Space>
+      <Input.TextArea placeholder="Text area" className="max-w-64" rows={3} />
+    </Space>
+  );
+}

--- a/apps/web/src/demo/popover-demo.tsx
+++ b/apps/web/src/demo/popover-demo.tsx
@@ -1,0 +1,26 @@
+import { Button, Popover, Space, Typography } from '@repo/ui';
+
+const PLACEMENTS = ['top', 'bottom', 'left', 'right'] as const;
+
+export default function PopoverDemo() {
+  return (
+    <Space wrap size="middle">
+      {PLACEMENTS.map(placement => (
+        <Popover
+          key={placement}
+          placement={placement}
+          title="Title"
+          content={
+            <Typography.Paragraph
+              className="text-muted-foreground m-0 max-w-48 text-sm"
+            >
+              Some content inside the popover.
+            </Typography.Paragraph>
+          }
+        >
+          <Button>{placement}</Button>
+        </Popover>
+      ))}
+    </Space>
+  );
+}

--- a/apps/web/src/demo/radio-demo.tsx
+++ b/apps/web/src/demo/radio-demo.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+import { Radio, Space, Typography } from '@repo/ui';
+
+const OPTIONS = [
+  { label: 'Small', value: 'small' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'Large', value: 'large' },
+];
+
+export default function RadioDemo() {
+  const [value, setValue] = useState<string | number | boolean>('medium');
+  const [buttonValue, setButtonValue] = useState<string | number | boolean>(
+    'medium',
+  );
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Space orientation="vertical" align="start" size="small">
+        <Radio.Group options={OPTIONS} value={value} onChange={setValue} />
+        <Typography.Text className="text-muted-foreground text-sm">
+          Selected: {String(value)}
+        </Typography.Text>
+      </Space>
+      <Radio.Group
+        options={OPTIONS}
+        value={buttonValue}
+        onChange={setButtonValue}
+        optionType="button"
+      />
+    </Space>
+  );
+}

--- a/apps/web/src/demo/skeleton-demo.tsx
+++ b/apps/web/src/demo/skeleton-demo.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+import { Button, Card, Skeleton, Space, Typography } from '@repo/ui';
+
+export default function SkeletonDemo() {
+  const [loading, setLoading] = useState(true);
+
+  return (
+    <Space orientation="vertical" align="start" size="middle">
+      <Button onClick={() => setLoading(l => !l)}>
+        {loading ? 'Show content' : 'Show skeleton'}
+      </Button>
+      <Card className="w-80">
+        <Skeleton loading={loading} avatar count={3}>
+          <Typography.Title level={5} className="mb-2">
+            Loaded content
+          </Typography.Title>
+          <Typography.Paragraph>
+            This is the real content that replaces the skeleton once loading
+            finishes.
+          </Typography.Paragraph>
+        </Skeleton>
+      </Card>
+      <Space align="start" size="middle" wrap>
+        <Skeleton.Button />
+        <div className="w-64">
+          <Skeleton.Node />
+        </div>
+      </Space>
+    </Space>
+  );
+}


### PR DESCRIPTION
## Summary
Continues the pattern from #264 — one page per component, description + live demo + props table. This PR finishes every remaining atom:

- Skeleton (+ Skeleton.Button / Skeleton.Node)
- Input (+ Input.Search / Input.TextArea)
- Button
- Popover
- Checkbox (+ Checkbox.Group)
- Radio (+ Radio.Group, including the `optionType="button"` segmented style)

Also regroups the docs sidebar (`sidebars.ts`) from a single flat "Atoms" bucket into the same functional categories Storybook stories use (each story's `title` prefix) and the landing page's own `CATEGORIES` list — General / Data Entry / Data Display / Feedback / Navigation. File paths under `docs/components/atoms/` are unchanged; only the sidebar's grouping/labels changed. `intro.md` and `AGENTS.md` updated to match.

## Test plan
- [x] `pnpm --filter=web lint` / `check-types` / `build` after every page
- [x] `pnpm exec turbo run build --filter=web --filter=@repo/ui`
- [x] served locally after every page, verified title/demo content/props tables
- [x] verified the full sidebar renders as General → Data Entry → Data Display → Feedback → Navigation with the right pages under each