### PR TITLE
🐛 fix: activate dark mode for [data-theme='dark'] hosts

### DIFF
--- a/.changeset/fix-ui-dark-mode-data-theme.md
+++ b/.changeset/fix-ui-dark-mode-data-theme.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix dark mode not activating in `[data-theme='dark']` hosts (Docusaurus/Infima). The dark theme tokens and the `dark:` variant were gated only on the `.dark` class, so consumers that toggle dark mode via `html[data-theme='dark']` never applied them — primary/token-driven buttons and other components rendered with light values on a dark page. The `dark` custom variant and the dark token block now also match `[data-theme='dark']`, while keeping the existing `.dark` convention.

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -16,9 +16,9 @@
 @import 'tailwindcss/theme.css' layer(theme);
 @import 'tailwindcss/utilities.css' layer(utilities);
 
-@config "../tailwind.config.mjs";
+@config '../tailwind.config.mjs';
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark *, [data-theme='dark'] *));
 
 @theme inline {
   --color-background: var(--background);
@@ -98,7 +98,8 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-.dark {
+.dark,
+[data-theme='dark'] {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);


### PR DESCRIPTION
## Summary

`@repo/ui`'s dark theme tokens and the `dark:` variant were gated only on the `.dark` class. Docusaurus/Infima toggle dark mode via `html[data-theme='dark']`, so on the docs site none of ui-kit's dark tokens or `dark:` utilities activated — primary and token-driven components (buttons, outlined variants, backgrounds) rendered with light values on a dark page. Hardcoded-hex preset colors (blue/green/danger) happened to look fine, which is what made the bug intermittent.

## Fix

- Broaden the `dark` custom variant to `&:is(.dark *, [data-theme='dark'] *)`
- Add `[data-theme='dark']` alongside `.dark` on the dark token block
- Existing `.dark` convention is preserved for other consumers

## Test plan

- Rebuilt the Docusaurus site and verified the Button docs page in forced dark mode: primary button now inverts to light, outlined/dashed/text variants get dark backgrounds, all preset colors correct.
- Light mode unchanged.