### PR TITLE
🐛 fix: normalize components in hosts without Tailwind preflight

### DIFF
--- a/.changeset/fix-ui-component-preflight-normalize.md
+++ b/.changeset/fix-ui-component-preflight-normalize.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Normalize the library's own components in hosts without Tailwind preflight (e.g. Docusaurus). Since the package intentionally ships no global preflight, bare interactive/form elements kept the host's UA defaults — a `<button>` rendered with a 2px `outset` border, native `appearance`, and the UA button font (Arial) instead of the page font. A self-scoped normalize in `@layer base`, limited to the `[data-slot]` subtree, restores just the needed preflight bits (box-sizing, border width/style, appearance, font/color inheritance) without touching the host's own elements.

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -150,6 +150,41 @@
   * {
     @apply border-border outline-ring/50;
   }
+
+  /*
+   * Self-scoped normalize for the library's own components.
+   *
+   * We intentionally ship no global preflight (see the top of this file), which
+   * means bare interactive/form elements otherwise keep the host's UA defaults —
+   * a `<button>` renders with a 2px `outset` border, native `appearance`, and
+   * the UA button font (e.g. Arial) instead of the page font. Hosts that run
+   * their own Tailwind preflight (Next/Storybook) normalize this for us, but
+   * hosts that don't (e.g. Docusaurus, which imports only our theme+utilities)
+   * leave those defaults leaking into our components.
+   *
+   * Restore just the preflight bits our components rely on, scoped to the
+   * `[data-slot]` subtree so the host's own elements stay untouched (Infima
+   * etc. are unaffected). Border *width/style* only — color still comes from the
+   * `border-border` rule above / component utilities.
+   */
+  :where([data-slot], [data-slot] *) {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
+  }
+
+  :where(
+    button[data-slot],
+    [data-slot] button,
+    [data-slot] input,
+    [data-slot] select,
+    [data-slot] textarea
+  ) {
+    appearance: none;
+    background-color: transparent;
+    color: inherit;
+    font: inherit;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

`@repo/ui` intentionally ships no global Tailwind preflight (to avoid stomping host base styles like Infima). But in hosts that don't run their own preflight — notably Docusaurus, which imports only our `theme.css` + `utilities.css` — bare interactive/form elements keep the browser's UA defaults. On the docs site the same button markup that renders cleanly under Storybook (which has preflight) showed a 2px `outset` border, native `appearance`, and the UA button font (Arial).

Computed style on the live docs button before fix: `border: 2px outset`, `appearance: auto`, `font-family: Arial`.

## Fix

Add a self-scoped normalize in `globals.css` `@layer base`, limited to the `[data-slot]` subtree:
- `box-sizing: border-box; border-width: 0; border-style: solid` on the component subtree
- `appearance: none; background-color: transparent; color: inherit; font: inherit` on interactive/form elements

Host elements (no `data-slot`) are untouched, so Infima and other host styles stay intact. Behavior converges to the known-good Storybook rendering.

## Test plan

- Rebuilt the Docusaurus site and re-read the live-equivalent computed style: `border: 0 solid`, `appearance: none`, font now inherits the page font.
- Verified no regression: outlined/dashed borders still render, text/link variants have no border, colored solid buttons unchanged.