### PR TITLE
📝 docs(web): document Card, Space, and Collapse molecule components

### DIFF
--- a/.changeset/docs-molecules-card-web.md
+++ b/.changeset/docs-molecules-card-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+New UI components, including Card, Collapse, and Space, have been added to the library, providing users with a set of reusable and customizable UI elements to enhance their application's user interface.

--- a/apps/web/docs/components/molecules/card.mdx
+++ b/apps/web/docs/components/molecules/card.mdx
@@ -1,0 +1,35 @@
+---
+sidebar_position: 1
+title: Card
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import CardDemo from '../../../src/demo/card-demo';
+
+# Card
+
+A simple content container with an optional title, used to group related information.
+
+```tsx
+import { Card } from '@jbpark/ui-kit';
+
+<Card title="Card title">A card with an outlined border.</Card>;
+```
+
+<DemoTheme>
+
+<CardDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop         | Type                         | Default      |
+| ------------ | ---------------------------- | ------------ |
+| `title`      | `ReactNode`                  | -            |
+| `variant`    | `'outlined' \| 'borderless'` | `'outlined'` |
+| `classNames` | `{ title?: string; body?: string }` | -    |
+| `className`  | `string`                     | -            |
+| `children`   | `ReactNode`                  | -            |
+
+`Card` also accepts the rest of `React.ComponentProps<'div'>` (e.g. `onClick`, `style`), except `title`.

--- a/apps/web/docs/components/molecules/collapse.mdx
+++ b/apps/web/docs/components/molecules/collapse.mdx
@@ -1,0 +1,44 @@
+---
+sidebar_position: 2
+title: Collapse
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import CollapseDemo from '../../../src/demo/collapse-demo';
+
+# Collapse
+
+A set of expandable panels, driven by an `items` array. Use `accordion` to keep only one panel open at a time.
+
+```tsx
+import { Collapse } from '@jbpark/ui-kit';
+
+<Collapse
+  defaultActiveKey={['0']}
+  items={[
+    { key: '0', label: 'What is this?', children: 'An answer.' },
+    { key: '1', label: 'How does it work?', children: 'Another answer.' },
+  ]}
+/>;
+```
+
+<DemoTheme>
+
+<CollapseDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop               | Type                                                  | Default |
+| ------------------ | ----------------------------------------------------- | ------- |
+| `items`            | `{ key: Key; label: ReactNode; children: ReactNode; disabled?: boolean }[]` | `[]` |
+| `accordion`        | `boolean`                                             | `false` |
+| `expandIcon`       | `ReactNode`                                           | -       |
+| `defaultActiveKey` | `string[] \| number[]`                                | -       |
+| `activeKey`        | `string[] \| number[]`                                | -       |
+| `onChange`         | `(keys: string[]) => void`                            | -       |
+| `classNames`       | `{ item?: string; header?: string; body?: string }`   | -       |
+| `className`        | `string`                                              | -       |
+
+Pass `activeKey` together with `onChange` for controlled usage; otherwise use `defaultActiveKey`. `Collapse` also accepts the rest of `React.ComponentProps<'div'>`.

--- a/apps/web/docs/components/molecules/space.mdx
+++ b/apps/web/docs/components/molecules/space.mdx
@@ -1,0 +1,43 @@
+---
+sidebar_position: 1
+title: Space
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SpaceDemo from '../../../src/demo/space-demo';
+
+# Space
+
+Lays out its children in a row or column with consistent gaps, optional wrapping, and separators.
+
+```tsx
+import { Space, Tag } from '@jbpark/ui-kit';
+
+<Space size="middle">
+  <Tag>One</Tag>
+  <Tag>Two</Tag>
+</Space>;
+```
+
+<DemoTheme>
+
+<SpaceDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop          | Type                                                | Default        |
+| ------------- | --------------------------------------------------- | -------------- |
+| `orientation` | `'horizontal' \| 'vertical'`                        | `'horizontal'` |
+| `size`        | `'small' \| 'middle' \| 'large' \| number \| number[]` | `'middle'`  |
+| `align`       | `'start' \| 'end' \| 'center' \| 'baseline'`        | `'center'`     |
+| `wrap`        | `boolean`                                           | `false`        |
+| `split`       | `ReactNode`                                         | -              |
+| `grid`        | `{ rows?: number; cols?: number }`                  | -              |
+| `loading`     | `boolean`                                           | `false`        |
+| `loader`      | `ReactNode`                                         | `<Skeleton />` |
+| `className`   | `string`                                            | -              |
+| `children`    | `ReactNode`                                         | -              |
+
+`Space` also accepts the rest of `React.ComponentProps<'div'>` (e.g. `style`, `hidden`).

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -19,6 +19,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/tag',
         'components/atoms/typography',
         'components/atoms/button',
+        'components/molecules/space',
       ],
     },
     {
@@ -39,7 +40,11 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Data Display',
       collapsed: false,
-      items: ['components/atoms/popover'],
+      items: [
+        'components/atoms/popover',
+        'components/molecules/card',
+        'components/molecules/collapse',
+      ],
     },
     {
       type: 'category',

--- a/apps/web/src/demo/card-demo.tsx
+++ b/apps/web/src/demo/card-demo.tsx
@@ -1,0 +1,15 @@
+import { Card, Space } from '@repo/ui';
+
+export default function CardDemo() {
+  return (
+    <Space orientation="vertical" align="start" size="large">
+      <Card title="Card title">
+        A card with an outlined border — the default variant.
+      </Card>
+      <Card title="Borderless" variant="borderless">
+        The same card without its border, blending into the background.
+      </Card>
+      <Card>A card with no title — body content only.</Card>
+    </Space>
+  );
+}

--- a/apps/web/src/demo/collapse-demo.tsx
+++ b/apps/web/src/demo/collapse-demo.tsx
@@ -1,0 +1,35 @@
+import { Collapse } from '@repo/ui';
+
+const items = [
+  {
+    key: '0',
+    label: 'What is this?',
+    children: (
+      <div className="p-4 text-sm">An answer to the first question.</div>
+    ),
+  },
+  {
+    key: '1',
+    label: 'How does it work?',
+    children: (
+      <div className="p-4 text-sm">An answer to the second question.</div>
+    ),
+  },
+  {
+    key: '2',
+    label: 'Anything else?',
+    children: (
+      <div className="p-4 text-sm">An answer to the third question.</div>
+    ),
+  },
+];
+
+export default function CollapseDemo() {
+  return (
+    <Collapse
+      defaultActiveKey={['0']}
+      className="border-border w-100 rounded-md border p-4"
+      items={items}
+    />
+  );
+}

--- a/apps/web/src/demo/space-demo.tsx
+++ b/apps/web/src/demo/space-demo.tsx
@@ -1,0 +1,27 @@
+import { Space, Tag } from '@repo/ui';
+
+const items = ['One', 'Two', 'Three'];
+
+export default function SpaceDemo() {
+  return (
+    <Space orientation="vertical" align="start" size="large">
+      <Space>
+        {items.map(label => (
+          <Tag key={label}>{label}</Tag>
+        ))}
+      </Space>
+
+      <Space orientation="vertical" align="start">
+        {items.map(label => (
+          <Tag key={label}>{label}</Tag>
+        ))}
+      </Space>
+
+      <Space size="large" split={<span>|</span>}>
+        {items.map(label => (
+          <Tag key={label}>{label}</Tag>
+        ))}
+      </Space>
+    </Space>
+  );
+}


### PR DESCRIPTION
## Summary

Adds Docusaurus documentation pages for the first three **molecule** components, continuing the one-component-at-a-time docs effort (atoms are already covered).

- **Card** (Data Display)
- **Space** (General)
- **Collapse** (Data Display)

## Changes

- Add `docs/components/molecules/{card,space,collapse}.mdx` — each with a description, usage snippet, embedded live demo, and a props table.
- Add `src/demo/{card,space,collapse}-demo.tsx` live demos, following the existing `tag-demo` pattern (rendered inside `<DemoTheme>`).
- Register the three pages in `sidebars.ts` (Card/Collapse under Data Display, Space under General), matching each component's Storybook story `title` category per `apps/web/AGENTS.md`.

## Notes

- Also removed stray `.next/` build artifacts and `next-env.d.ts` left over from the pre-Docusaurus setup, which the pre-commit ESLint hook was scanning.

## Verification

- `pnpm build` (docusaurus build) passes.
- pre-commit `lint` + `check-types` pass.