### PR TITLE
🔧 chore(web): ignore .next in ESLint config

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -4,6 +4,6 @@ import { config } from '@repo/eslint-config/react-internal';
 export default [
   ...config,
   {
-    ignores: ['.docusaurus/**', 'build/**'],
+    ignores: ['.docusaurus/**', 'build/**', '.next/**'],
   },
 ];


### PR DESCRIPTION
## Summary

`apps/web` is a Docusaurus app, but leftover `.next/` build artifacts from the pre-Docusaurus (Next.js) setup can reappear. `.next/` is gitignored, but `eslint.config.mjs` only ignored `.docusaurus/**` and `build/**`, so the pre-commit hook (`eslint --max-warnings 0`) would scan `.next/` and fail with thousands of unrelated warnings.

## Changes

- Add `.next/**` to the `ignores` list in `apps/web/eslint.config.mjs`.

## Verification

- Created a dummy `.next/dummy.ts` with a deliberate `any` warning; `pnpm lint` in `apps/web` still exits 0 (the directory is now ignored).