### PR TITLE
📝 docs(web): document Reveals molecule component

### DIFF
--- a/.changeset/docs-molecules-reveals-web.md
+++ b/.changeset/docs-molecules-reveals-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new Reveals component for animating children into view as they enter the viewport, with customizable effects and staggering.

--- a/apps/web/docs/components/molecules/reveals.mdx
+++ b/apps/web/docs/components/molecules/reveals.mdx
@@ -1,0 +1,43 @@
+---
+sidebar_position: 3
+title: Reveals
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import RevealsDemo from '../../../src/demo/reveals-demo';
+
+# Reveals
+
+Animates its children into view as they enter the viewport, staggering each one by `cascade` for a sequential reveal. Accepts either `children` or an `items` array.
+
+```tsx
+import { Reveals } from '@jbpark/ui-kit';
+
+<Reveals effect="fadeInUp" cascade={0.15}>
+  <div>First</div>
+  <div>Second</div>
+  <div>Third</div>
+</Reveals>;
+```
+
+<DemoTheme>
+
+<RevealsDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop         | Type                                       | Default      |
+| ------------ | ------------------------------------------ | ------------ |
+| `effect`     | `'fadeIn' \| 'fadeInUp' \| 'slideInUp'`    | `'fadeInUp'` |
+| `cascade`    | `number` (stagger between items, seconds)  | `0.1`        |
+| `duration`   | `number` (seconds)                         | `0.6`        |
+| `delay`      | `number` (seconds, before the first item)  | `0`          |
+| `once`       | `boolean` (animate only the first time)    | -            |
+| `items`      | `ItemProps[]`                              | `[]`         |
+| `classNames` | `{ root?: string; item?: string }`         | -            |
+| `className`  | `string`                                   | -            |
+| `children`   | `ReactNode`                                | -            |
+
+`viewport`, `variants`, and `transition` are forwarded to the underlying `motion` element for fine-grained control. `Reveals.Item` is also exported for composing a single animated item directly.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -44,6 +44,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/popover',
         'components/molecules/card',
         'components/molecules/collapse',
+        'components/molecules/reveals',
       ],
     },
     {

--- a/apps/web/src/demo/reveals-demo.tsx
+++ b/apps/web/src/demo/reveals-demo.tsx
@@ -1,0 +1,20 @@
+import { Reveals } from '@repo/ui';
+
+const cards = [
+  { title: 'First', tone: 'bg-blue-500' },
+  { title: 'Second', tone: 'bg-green-500' },
+  { title: 'Third', tone: 'bg-purple-500' },
+];
+
+export default function RevealsDemo() {
+  return (
+    <Reveals effect="fadeInUp" cascade={0.15}>
+      {cards.map(({ title, tone }) => (
+        <div key={title} className={`w-40 rounded-lg p-6 text-white ${tone}`}>
+          <h3 className="font-bold">{title}</h3>
+          <p className="text-sm opacity-90">Revealed on scroll.</p>
+        </div>
+      ))}
+    </Reveals>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Docusaurus documentation page for the **Reveals** molecule component (Data Display), continuing the one-component-at-a-time docs effort.

## Changes

- Add `docs/components/molecules/reveals.mdx` — description, usage snippet, embedded live demo, and props table.
- Add `src/demo/reveals-demo.tsx` — a cascade fade-in demo, following the existing `tag-demo` pattern (rendered inside `<DemoTheme>`).
- Register the page in `sidebars.ts` under Data Display, matching the component's Storybook story `title` category.

## Verification

- `pnpm build` (docusaurus build) passes.
- pre-commit `lint` + `check-types` pass.