### PR TITLE
📝 docs(web): document Splitter molecule component

### DIFF
--- a/.changeset/docs-molecules-splitter-web.md
+++ b/.changeset/docs-molecules-splitter-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a Splitter component for splitting areas into resizable panels with a draggable handle between each one.

--- a/apps/web/docs/components/molecules/splitter.mdx
+++ b/apps/web/docs/components/molecules/splitter.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 1
+title: Splitter
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SplitterDemo from '../../../src/demo/splitter-demo';
+
+# Splitter
+
+Splits an area into resizable panels with a draggable handle between each one. Compose it from `Splitter.Panel` children; the handle is inserted automatically. Give the `Splitter` a sized container (it fills 100% height/width).
+
+```tsx
+import { Splitter } from '@jbpark/ui-kit';
+
+<div style={{ height: 256 }}>
+  <Splitter>
+    <Splitter.Panel defaultSize="30%" minSize="20%">
+      Sidebar
+    </Splitter.Panel>
+    <Splitter.Panel defaultSize="70%" minSize="30%">
+      Content
+    </Splitter.Panel>
+  </Splitter>
+</div>;
+```
+
+<DemoTheme>
+
+<SplitterDemo />
+
+</DemoTheme>
+
+## Props
+
+### `Splitter`
+
+| Prop              | Type                                | Default        |
+| ----------------- | ----------------------------------- | -------------- |
+| `orientation`     | `'horizontal' \| 'vertical'`        | `'horizontal'` |
+| `withHandle`      | `boolean` (show the grip on handles) | `true`        |
+| `handle`          | `ReactNode` (custom handle content) | -              |
+| `handleClassName` | `string`                            | -              |
+| `onResize`        | `(layout) => void` (during drag)    | -              |
+| `onResizeEnd`     | `(layout) => void` (drag finished)  | -              |
+| `className`       | `string`                            | -              |
+| `children`        | `ReactNode` (`Splitter.Panel`s)     | -              |
+
+### `Splitter.Panel`
+
+| Prop          | Type                | Default |
+| ------------- | ------------------- | ------- |
+| `defaultSize` | `string \| number`  | -       |
+| `minSize`     | `string \| number`  | -       |
+| `maxSize`     | `string \| number`  | -       |
+| `className`   | `string`            | -       |
+| `children`    | `ReactNode`         | -       |
+
+`Splitter.Panel` forwards the rest of the underlying resizable panel props. The handle between adjacent panels is added automatically — you only render the panels.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -63,6 +63,12 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: ['components/atoms/float-button'],
     },
+    {
+      type: 'category',
+      label: 'Layout',
+      collapsed: false,
+      items: ['components/molecules/splitter'],
+    },
   ],
 };
 

--- a/apps/web/src/demo/splitter-demo.tsx
+++ b/apps/web/src/demo/splitter-demo.tsx
@@ -1,0 +1,27 @@
+import { Splitter } from '@repo/ui';
+
+function Pane({ label }: { label: string }) {
+  return (
+    <div
+      className="flex h-full items-center justify-center p-4 text-sm
+        font-medium"
+    >
+      {label}
+    </div>
+  );
+}
+
+export default function SplitterDemo() {
+  return (
+    <div className="h-64 w-full">
+      <Splitter>
+        <Splitter.Panel defaultSize="30%" minSize="20%">
+          <Pane label="Sidebar" />
+        </Splitter.Panel>
+        <Splitter.Panel defaultSize="70%" minSize="30%">
+          <Pane label="Content" />
+        </Splitter.Panel>
+      </Splitter>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Docusaurus documentation page for the **Splitter** molecule component, introducing a new **Layout** sidebar category.

## Changes

- Add `docs/components/molecules/splitter.mdx` — description, usage snippet, embedded live demo, and props tables for both `Splitter` and `Splitter.Panel`.
- Add `src/demo/splitter-demo.tsx` — a resizable two-panel demo (rendered inside `<DemoTheme>`).
- Add a new **Layout** category to `sidebars.ts` and register the page under it, matching the component's Storybook story `title` (`Layout/Splitter`).

## Verification

- `pnpm build` (docusaurus build) passes.
- pre-commit `lint` + `check-types` pass.