### PR TITLE
📝 docs(web): document Dropdown molecule component

### DIFF
--- a/.changeset/docs-molecules-dropdown-web.md
+++ b/.changeset/docs-molecules-dropdown-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new Dropdown component with hover and click triggers, and a demo page showcasing its usage.

--- a/apps/web/docs/components/molecules/dropdown.mdx
+++ b/apps/web/docs/components/molecules/dropdown.mdx
@@ -1,0 +1,57 @@
+---
+sidebar_position: 1
+title: Dropdown
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import DropdownDemo from '../../../src/demo/dropdown-demo';
+
+# Dropdown
+
+Wraps a trigger element and reveals a floating `Menu` on hover or click. Pass the trigger as `children` and the menu via the `menu` prop (its `items` support nested submenus).
+
+```tsx
+import { Button, Dropdown } from '@jbpark/ui-kit';
+
+<Dropdown
+  trigger="click"
+  menu={{
+    items: [
+      { key: 'edit', label: 'Edit' },
+      { key: 'delete', label: 'Delete' },
+    ],
+  }}
+>
+  <Button>Menu</Button>
+</Dropdown>;
+```
+
+<DemoTheme>
+
+<DropdownDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop           | Type                        | Default   |
+| -------------- | --------------------------- | --------- |
+| `trigger`      | `'hover' \| 'click'`        | `'hover'` |
+| `menu`         | `MenuProps`                 | -         |
+| `open`         | `boolean` (controlled)      | -         |
+| `onOpenChange` | `(open: boolean) => void`   | -         |
+| `className`    | `string`                    | -         |
+| `children`     | `ReactNode` (the trigger)   | -         |
+
+`Dropdown` also accepts the rest of `React.ComponentProps<'div'>`. Provide `open` together with `onOpenChange` for controlled usage.
+
+### `menu` (`MenuProps`)
+
+| Field       | Type                                              | Notes                          |
+| ----------- | ------------------------------------------------- | ------------------------------ |
+| `items`     | `MenuItem[]`                                      | `{ key, label, children? }`    |
+| `onClick`   | `(params) => void`                                | `params.key` / `keyPath` / `item` |
+| `mode`      | `'horizontal' \| 'vertical' \| 'inline'`          | -                              |
+| `classNames`| `{ rootItem?; subMenu?; item?; label? }`          | -                              |
+
+The `menu` prop is forwarded directly to the underlying `Menu` component, so any `MenuProps` are accepted (a dedicated Menu page will cover the full API).

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -61,7 +61,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Navigation',
       collapsed: false,
-      items: ['components/atoms/float-button'],
+      items: ['components/atoms/float-button', 'components/molecules/dropdown'],
     },
     {
       type: 'category',

--- a/apps/web/src/demo/dropdown-demo.tsx
+++ b/apps/web/src/demo/dropdown-demo.tsx
@@ -1,0 +1,24 @@
+import { Button, Dropdown } from '@repo/ui';
+
+const menu = {
+  items: [
+    {
+      key: 'profile',
+      label: 'Profile',
+      children: [
+        { key: 'profile-info', label: 'My info' },
+        { key: 'profile-settings', label: 'Settings' },
+      ],
+    },
+    { key: 'help', label: 'Help' },
+    { key: 'logout', label: 'Log out' },
+  ],
+};
+
+export default function DropdownDemo() {
+  return (
+    <Dropdown trigger="click" menu={menu}>
+      <Button>Menu</Button>
+    </Dropdown>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Docusaurus documentation page for the **Dropdown** molecule component (Navigation).

## Changes

- Add `docs/components/molecules/dropdown.mdx` — description, usage snippet, embedded live demo, and props tables for `Dropdown` plus the forwarded `menu` (`MenuProps`).
- Add `src/demo/dropdown-demo.tsx` — a click-triggered dropdown with a nested menu (rendered inside `<DemoTheme>`).
- Register the page in `sidebars.ts` under Navigation, matching the component's Storybook story `title` (`Navigation/Dropdown`).

## Verification

- `pnpm build` (docusaurus build) passes.
- pre-commit `lint` + `check-types` pass.