### PR TITLE
📝 docs(web): document Menu molecule component

### DIFF
--- a/.changeset/docs-molecules-menu-web.md
+++ b/.changeset/docs-molecules-menu-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new Menu component with a navigation menu driven by an items array, and update the dropdown documentation to link to the new Menu page.

--- a/apps/web/docs/components/molecules/dropdown.mdx
+++ b/apps/web/docs/components/molecules/dropdown.mdx
@@ -54,4 +54,4 @@ import { Button, Dropdown } from '@jbpark/ui-kit';
 | `mode`      | `'horizontal' \| 'vertical' \| 'inline'`          | -                              |
 | `classNames`| `{ rootItem?; subMenu?; item?; label? }`          | -                              |
 
-The `menu` prop is forwarded directly to the underlying `Menu` component, so any `MenuProps` are accepted (a dedicated Menu page will cover the full API).
+The `menu` prop is forwarded directly to the underlying `Menu` component, so any `MenuProps` are accepted — see [Menu](./menu) for the full API.

--- a/apps/web/docs/components/molecules/menu.mdx
+++ b/apps/web/docs/components/molecules/menu.mdx
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+title: Menu
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import MenuDemo from '../../../src/demo/menu-demo';
+
+# Menu
+
+A navigation menu driven by an `items` array with nested submenus. Lay it out as a horizontal bar, a vertical list, or an `inline` tree that expands submenus in place.
+
+```tsx
+import { Menu } from '@jbpark/ui-kit';
+
+<Menu
+  mode="inline"
+  defaultSelectedKeys={['home']}
+  items={[
+    { key: 'home', label: 'Home' },
+    {
+      key: 'products',
+      label: 'Products',
+      children: [{ key: 'products-web', label: 'Web' }],
+    },
+  ]}
+/>;
+```
+
+<DemoTheme>
+
+<MenuDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop                  | Type                                        | Default        |
+| --------------------- | ------------------------------------------- | -------------- |
+| `items`               | `MenuItem[]`                                | -              |
+| `mode`                | `'horizontal' \| 'vertical' \| 'inline'`    | `'vertical'`   |
+| `selectedKeys`        | `Key[]` (controlled selection)              | -              |
+| `defaultSelectedKeys` | `Key[]`                                     | `[]`           |
+| `onClick`             | `(params) => void`                          | -              |
+| `onSelect`            | `(params) => void`                          | -              |
+| `offset`              | `[number, number]` (submenu popup offset)   | -              |
+| `inlineOffset`        | `number` (inline indent per depth)          | -              |
+| `classNames`          | `{ rootItem?; subMenu?; item?; label? }`    | -              |
+| `styles`              | `{ rootItem?; subMenu?; item?; label? }`    | -              |
+| `className`           | `string`                                    | -              |
+
+`MenuItem` is `{ key: Key; label: ReactNode; children?: MenuItem[] }`. The `onClick` / `onSelect` handlers receive `{ domEvent, key, keyPath, item }`. `Menu` also accepts the rest of `React.ComponentProps<'ul'>`.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -61,7 +61,11 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Navigation',
       collapsed: false,
-      items: ['components/atoms/float-button', 'components/molecules/dropdown'],
+      items: [
+        'components/atoms/float-button',
+        'components/molecules/dropdown',
+        'components/molecules/menu',
+      ],
     },
     {
       type: 'category',

--- a/apps/web/src/demo/menu-demo.tsx
+++ b/apps/web/src/demo/menu-demo.tsx
@@ -1,0 +1,33 @@
+import { Menu } from '@repo/ui';
+
+const items = [
+  { key: 'home', label: 'Home' },
+  {
+    key: 'products',
+    label: 'Products',
+    children: [
+      { key: 'products-web', label: 'Web' },
+      { key: 'products-mobile', label: 'Mobile' },
+    ],
+  },
+  {
+    key: 'services',
+    label: 'Services',
+    children: [
+      { key: 'services-design', label: 'Design' },
+      { key: 'services-dev', label: 'Development' },
+    ],
+  },
+  { key: 'contact', label: 'Contact' },
+];
+
+export default function MenuDemo() {
+  return (
+    <Menu
+      mode="inline"
+      items={items}
+      defaultSelectedKeys={['home']}
+      className="w-56"
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Docusaurus documentation page for the **Menu** molecule component (Navigation), and links the previously-added Dropdown page to it.

## Changes

- Add `docs/components/molecules/menu.mdx` — description, usage snippet, embedded live demo, and props table (including `MenuItem` and `onClick` / `onSelect` handler shapes).
- Add `src/demo/menu-demo.tsx` — an inline menu with nested submenus (rendered inside `<DemoTheme>`).
- Register the page in `sidebars.ts` under Navigation, matching the component's Storybook story `title` (`Navigation/Menu`).
- Update the Dropdown page's `menu` prop note to link to the new Menu page.

## Verification

- `pnpm build` (docusaurus build) passes.
- pre-commit `lint` + `check-types` pass.