### PR TITLE
📝 docs(web): document Upload molecule component

### DIFF
--- a/.changeset/docs-molecules-upload-web.md
+++ b/.changeset/docs-molecules-upload-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new Upload component with a click-or-drag dropzone that reads selected files into data URLs and renders a removable list, with image previews.

--- a/apps/web/docs/components/molecules/upload.mdx
+++ b/apps/web/docs/components/molecules/upload.mdx
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+title: Upload
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import UploadDemo from '../../../src/demo/upload-demo';
+
+# Upload
+
+A click-or-drag dropzone that reads selected files into data URLs and renders a removable list, with image previews. Uncontrolled by default; pass `value` + `onChange` to control it.
+
+```tsx
+import { Upload } from '@jbpark/ui-kit';
+
+<Upload accept="image/*" maxCount={3} />;
+```
+
+<DemoTheme>
+
+<UploadDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop           | Type                                                    | Default     |
+| -------------- | ------------------------------------------------------- | ----------- |
+| `multiple`     | `boolean`                                               | `true`      |
+| `accept`       | `string` (input `accept`, e.g. `'image/*'`)             | `'image/*'` |
+| `maxCount`     | `number` (max files; omit for unlimited)                | -           |
+| `disabled`     | `boolean`                                               | -           |
+| `value`        | `UploadFile[]` (controlled)                             | -           |
+| `defaultValue` | `UploadFile[]`                                          | `[]`        |
+| `onChange`     | `(files: UploadFile[]) => void`                         | -           |
+| `onReject`     | `(info: { file: File; reason: 'max-count' \| 'read-error' }) => void` | - |
+| `classNames`   | `{ dropzone?: string; list?: string; item?: string }`   | -           |
+| `className`    | `string`                                                | -           |
+
+`UploadFile` is `{ uid: string; name: string; url: string }`, where `url` is a data URL. Files exceeding `maxCount` or that fail to read are surfaced through `onReject` rather than being added.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -34,6 +34,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/input',
         'components/atoms/checkbox',
         'components/atoms/radio',
+        'components/molecules/upload',
       ],
     },
     {

--- a/apps/web/src/demo/upload-demo.tsx
+++ b/apps/web/src/demo/upload-demo.tsx
@@ -1,0 +1,9 @@
+import { Upload } from '@repo/ui';
+
+export default function UploadDemo() {
+  return (
+    <div className="w-80">
+      <Upload accept="image/*" maxCount={3} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Docusaurus documentation page for the **Upload** molecule component (Data Entry).

## Changes

- Add `docs/components/molecules/upload.mdx` — description, usage snippet, embedded live demo, and props table (including the `UploadFile` shape and `onReject` reasons).
- Add `src/demo/upload-demo.tsx` — an image dropzone with `maxCount` (rendered inside `<DemoTheme>`).
- Register the page in `sidebars.ts` under Data Entry, matching the component's Storybook story `title` (`Data Entry/Upload`).

## Verification

- `pnpm build` (docusaurus build) passes.
- pre-commit `lint` + `check-types` pass.