### PR TITLE
📝 docs(web): document Marquees molecule component

### DIFF
--- a/.changeset/docs-molecules-marquees-web.md
+++ b/.changeset/docs-molecules-marquees-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add Marquees component for scrolling content and demo page to showcase its usage.

--- a/apps/web/docs/components/molecules/marquees.mdx
+++ b/apps/web/docs/components/molecules/marquees.mdx
@@ -1,0 +1,38 @@
+---
+sidebar_position: 4
+title: Marquees
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import MarqueesDemo from '../../../src/demo/marquees-demo';
+
+# Marquees
+
+Scrolls each row of content horizontally in a continuous loop. Provide rows through the `items` array; each item's `children` is one scrolling track. By default it auto-fills the width and pauses on hover.
+
+```tsx
+import { Marquees } from '@jbpark/ui-kit';
+
+<Marquees
+  speed={40}
+  items={[{ key: 0, children: <div>Scrolling content</div> }]}
+/>;
+```
+
+<DemoTheme>
+
+<MarqueesDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop           | Type                  | Default |
+| -------------- | --------------------- | ------- |
+| `items`        | `ItemProps[]`         | -       |
+| `speed`        | `number` (px/second)  | `100`   |
+| `pauseOnHover` | `boolean`             | `true`  |
+| `autoFill`     | `boolean \| number`   | `true`  |
+| `className`    | `string`              | -       |
+
+Each `ItemProps` is `{ key?; children; speed?; autoFill?; pauseOnHover? }` — per-row overrides fall back to the values set on `Marquees`. `autoFill` repeats each row enough to cover the container (pass a number to force a specific repeat count). `Marquees.Item` is also exported for rendering a single track directly. `Marquees` forwards the rest of `React.ComponentProps<'div'>`.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -46,6 +46,7 @@ const sidebars: SidebarsConfig = {
         'components/molecules/card',
         'components/molecules/collapse',
         'components/molecules/reveals',
+        'components/molecules/marquees',
       ],
     },
     {

--- a/apps/web/src/demo/marquees-demo.tsx
+++ b/apps/web/src/demo/marquees-demo.tsx
@@ -1,0 +1,21 @@
+import { Marquees } from '@repo/ui';
+
+const row = (
+  <div className="flex gap-3">
+    {['React', 'TypeScript', 'Vite', 'Tailwind', 'Docusaurus'].map(label => (
+      <span
+        key={label}
+        className="bg-accent text-accent-foreground rounded-full px-5 py-2
+          text-sm font-medium"
+      >
+        {label}
+      </span>
+    ))}
+  </div>
+);
+
+const items = [{ key: 0, children: row }];
+
+export default function MarqueesDemo() {
+  return <Marquees speed={40} items={items} />;
+}


### PR DESCRIPTION
## Summary

Adds a Docusaurus documentation page for the **Marquees** molecule component (Data Display). This completes documentation for all molecule components.

## Changes

- Add `docs/components/molecules/marquees.mdx` — description, usage snippet, embedded live demo, and props table (including `ItemProps` and `autoFill` behavior).
- Add `src/demo/marquees-demo.tsx` — a continuous horizontal scroll of pill tags (rendered inside `<DemoTheme>`).
- Register the page in `sidebars.ts` under Data Display, matching the component's Storybook story `title` (`Data Display/Marquees`).

## Verification

- `pnpm build` (docusaurus build) passes.
- pre-commit `lint` + `check-types` pass.