### PR TITLE
📝 docs(web): document List organism component

### DIFF
--- a/.changeset/docs-list-organism-web.md
+++ b/.changeset/docs-list-organism-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new List component for rendering titled, accessible collections with infinite scroll support.

--- a/apps/web/docs/components/organisms/list.mdx
+++ b/apps/web/docs/components/organisms/list.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 5
+title: List
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import ListDemo from '../../../src/demo/list-demo';
+
+# List
+
+Renders a titled, accessible (`role="list"`) collection from a `data` array via `renderItem`. Handles loading skeletons, an empty state, and optional infinite scroll — pass a `scroll` object and `List` fetches the next page when a sentinel enters the viewport.
+
+```tsx
+import { List } from '@jbpark/ui-kit';
+
+<List
+  title="People"
+  data={people}
+  itemKey={item => item.id}
+  renderItem={item => <div>{item.name}</div>}
+/>;
+```
+
+<DemoTheme>
+
+<ListDemo />
+
+</DemoTheme>
+
+## Infinite scroll
+
+Provide `scroll` to load more as the user reaches the end. `List` calls `next()` when the sentinel intersects and `hasMore` is `true`. You **must** flip `scroll.loading` back to `false` when the fetch settles (including on failure) — otherwise `List` stops requesting further pages.
+
+```tsx
+<List
+  data={items}
+  renderItem={item => <Row {...item} />}
+  scroll={{
+    hasMore,
+    loading,
+    next: fetchMore,
+  }}
+/>;
+```
+
+## Props
+
+| Prop          | Type                                                     | Default |
+| ------------- | ------------------------------------------------------- | ------- |
+| `data`        | `T[]`                                                    | -       |
+| `renderItem`  | `(item: T, index: number) => ReactNode`                 | -       |
+| `itemKey`     | `(item: T, index: number) => Key`                       | index   |
+| `title`       | `ReactNode`                                             | -       |
+| `titleLevel`  | `1 \| 2 \| 3 \| 4 \| 5 \| 6`                             | `2`     |
+| `header`      | `ReactNode`                                             | -       |
+| `empty`       | `ReactNode` (shown when `data` is empty)                | -       |
+| `loading`     | `boolean` (renders skeletons)                           | -       |
+| `loader`      | `ReactNode` (custom loading node)                       | -       |
+| `loaderProps` | `ComponentProps<typeof Skeleton>`                       | -       |
+| `scroll`      | `{ hasMore; loading; next; loader?; options? }`         | -       |
+| `classNames`  | `{ title?; header?; body? }`                            | -       |
+| `className`   | `string`                                                | -       |
+
+`scroll.options` accepts an `IntersectionObserverInit` to tune the sentinel threshold/root. `List.Item` is also exported for composing a single row directly.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -47,6 +47,7 @@ const sidebars: SidebarsConfig = {
         'components/molecules/collapse',
         'components/molecules/reveals',
         'components/molecules/marquees',
+        'components/organisms/list',
       ],
     },
     {

--- a/apps/web/src/demo/list-demo.tsx
+++ b/apps/web/src/demo/list-demo.tsx
@@ -1,0 +1,28 @@
+import { List } from '@repo/ui';
+
+const people = [
+  { id: 1, name: 'Ada Lovelace', role: 'Mathematician' },
+  { id: 2, name: 'Alan Turing', role: 'Computer Scientist' },
+  { id: 3, name: 'Grace Hopper', role: 'Rear Admiral' },
+  { id: 4, name: 'Katherine Johnson', role: 'Aerospace Engineer' },
+];
+
+export default function ListDemo() {
+  return (
+    <List
+      title="People"
+      data={people}
+      itemKey={item => item.id}
+      renderItem={item => (
+        <div
+          className="flex items-center justify-between rounded-lg border
+            border-gray-200 bg-white px-4 py-3 dark:border-gray-700
+            dark:bg-gray-800"
+        >
+          <span className="font-medium">{item.name}</span>
+          <span className="text-sm opacity-70">{item.role}</span>
+        </div>
+      )}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Documents the **List** organism — the first organism-tier component to get a docs page (molecules are now 9/9).

- `docs/components/organisms/list.mdx` — description, usage snippet, live demo, an infinite-scroll section (documenting the `scroll.loading` contract), and a Props table
- `src/demo/list-demo.tsx` — a titled list rendered from a `data` array via `renderItem`
- `sidebars.ts` — registered under **Data Display** (matches the landing page CATEGORIES mapping)

## Verification

- `docusaurus build` succeeds
- `tsc` + `eslint` clean