### PR TITLE
📝 docs(web): document Swiper organism component

### DIFF
--- a/.changeset/docs-swiper-organism-web.md
+++ b/.changeset/docs-swiper-organism-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a Swiper component for rendering touch-friendly carousels from a data array.

--- a/apps/web/docs/components/organisms/swiper.mdx
+++ b/apps/web/docs/components/organisms/swiper.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 6
+title: Swiper
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SwiperDemo from '../../../src/demo/swiper-demo';
+
+# Swiper
+
+A thin wrapper around [Swiper.js](https://swiperjs.com/) that renders a touch-friendly carousel from a `data` array via `renderItem`. Each item should return a `Swiper.Slide`. Feature modules (autoplay, navigation, pagination…) are opt-in — nothing is bundled by default.
+
+```tsx
+import { Swiper } from '@jbpark/ui-kit';
+
+<Swiper
+  data={slides}
+  options={{ slidesPerView: 'auto', spaceBetween: 12 }}
+  renderItem={item => (
+    <Swiper.Slide style={{ width: 160 }}>{item.title}</Swiper.Slide>
+  )}
+/>;
+```
+
+<DemoTheme>
+
+<SwiperDemo />
+
+</DemoTheme>
+
+## Feature modules
+
+Nothing is bundled by default to keep the base carousel light. Import the modules you need from `swiper/modules` together with their stylesheets and pass them via `modules`.
+
+```tsx
+import { Autoplay, Navigation } from 'swiper/modules';
+import 'swiper/css/autoplay';
+import 'swiper/css/navigation';
+
+<Swiper
+  modules={[Autoplay, Navigation]}
+  options={{ navigation: true, autoplay: { delay: 2500 } }}
+  data={slides}
+  renderItem={renderSlide}
+/>;
+```
+
+## Props
+
+| Prop               | Type                                    | Default |
+| ------------------ | --------------------------------------- | ------- |
+| `data`             | `T[]`                                    | `[]`    |
+| `renderItem`       | `(item: T, key: number) => ReactNode`   | -       |
+| `options`          | `SwiperOptions`                          | -       |
+| `modules`          | `SwiperModule[]`                         | `[]`    |
+| `loading`          | `boolean` (renders a `Spin` placeholder) | -       |
+| `loader`           | `ReactNode` (custom loading node)        | -       |
+| `loadingClassName` | `string`                                 | -       |
+| `className`        | `string`                                 | -       |
+| `style`            | `CSSProperties`                          | -       |
+
+Any other [Swiper React props](https://swiperjs.com/react) are forwarded to the underlying instance. `initialOptions` (the baseline config: `spaceBetween: 8`, `slidesPerView: 'auto'`) is also exported, and `Swiper.Slide` wraps `SwiperSlide` for composing individual slides.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
         'components/molecules/reveals',
         'components/molecules/marquees',
         'components/organisms/list',
+        'components/organisms/swiper',
       ],
     },
     {

--- a/apps/web/src/demo/swiper-demo.tsx
+++ b/apps/web/src/demo/swiper-demo.tsx
@@ -1,0 +1,28 @@
+import { Swiper } from '@repo/ui';
+
+const slides = [
+  { title: 'Slide 1', tone: 'bg-blue-500' },
+  { title: 'Slide 2', tone: 'bg-green-500' },
+  { title: 'Slide 3', tone: 'bg-purple-500' },
+  { title: 'Slide 4', tone: 'bg-rose-500' },
+  { title: 'Slide 5', tone: 'bg-amber-500' },
+];
+
+export default function SwiperDemo() {
+  return (
+    <Swiper
+      data={slides}
+      options={{ slidesPerView: 'auto', spaceBetween: 12 }}
+      renderItem={item => (
+        <Swiper.Slide style={{ width: '160px' }}>
+          <div
+            className={`flex h-32 w-40 items-center justify-center rounded-lg
+            font-bold text-white ${item.tone}`}
+          >
+            {item.title}
+          </div>
+        </Swiper.Slide>
+      )}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Documents the **Swiper** organism (organisms now 2/5).

- `docs/components/organisms/swiper.mdx` — description, usage snippet, live demo, a feature-modules section (opt-in autoplay/navigation), and a Props table
- `src/demo/swiper-demo.tsx` — a horizontal carousel of colored slides via `data` + `renderItem`
- `sidebars.ts` — registered under **Data Display** (matches the landing page CATEGORIES mapping)

## Verification

- `docusaurus build` succeeds
- pre-commit `tsc` + `eslint` clean