### PR TITLE
📝 docs(web): document Toast organism component

### DIFF
--- a/.changeset/docs-toast-organism-web.md
+++ b/.changeset/docs-toast-organism-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add Toast component for imperative, non-blocking notifications with customizable options and API.

--- a/apps/web/docs/components/organisms/toast.mdx
+++ b/apps/web/docs/components/organisms/toast.mdx
@@ -1,0 +1,60 @@
+---
+sidebar_position: 4
+title: Toast
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import ToastDemo from '../../../src/demo/toast-demo';
+
+# Toast
+
+Imperative, non-blocking notifications. Call `Toast.info` / `success` / `warning` / `error` from anywhere — each stacks in a fixed portal at the bottom-right and auto-dismisses after `duration` (default 4s). Hovering or focusing a toast pauses its timer so it can't disappear mid-read.
+
+```tsx
+import { Toast } from '@jbpark/ui-kit';
+
+Toast.success('Saved successfully.');
+Toast.error('Something went wrong', { description: 'Please try again.' });
+```
+
+<DemoTheme>
+
+<ToastDemo />
+
+</DemoTheme>
+
+## Dismissing
+
+Each trigger returns an `id` you can pass to `Toast.destroy(id)`, or clear everything with `Toast.destroyAll()`.
+
+```tsx
+const id = Toast.info('Uploading…', { duration: 0 }); // 0 = stays until dismissed
+// later
+Toast.destroy(id);
+```
+
+## API
+
+| Method                    | Signature                                          |
+| ------------------------- | -------------------------------------------------- |
+| `Toast.info`              | `(title, options?) => id`                           |
+| `Toast.success`           | `(title, options?) => id`                           |
+| `Toast.warning`           | `(title, options?) => id`                           |
+| `Toast.error`             | `(title, options?) => id`                           |
+| `Toast.destroy`           | `(id) => void`                                      |
+| `Toast.destroyAll`        | `() => void`                                        |
+
+### Options
+
+| Option        | Type                    | Default     |
+| ------------- | ----------------------- | ----------- |
+| `description` | `ReactNode`             | -           |
+| `duration`    | `number` (ms, `0` = sticky) | `4000`  |
+| `icon`        | `ReactNode` (overrides the type icon) | -   |
+| `closable`    | `boolean`               | `true`      |
+| `action`      | `ReactNode`             | -           |
+| `container`   | `HTMLElement` (custom mount target) | -     |
+| `className`   | `string`                | -           |
+| `onClose`     | `() => void`            | -           |
+
+Each type sets an accessible role automatically (`alert` for `error`, `status` otherwise) and a matching icon.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/progress',
         'components/atoms/spin',
         'components/atoms/skeleton',
+        'components/organisms/toast',
       ],
     },
     {

--- a/apps/web/src/demo/toast-demo.tsx
+++ b/apps/web/src/demo/toast-demo.tsx
@@ -1,0 +1,30 @@
+import { Button, Space, Toast } from '@repo/ui';
+
+export default function ToastDemo() {
+  return (
+    <Space>
+      <Button onClick={() => Toast.info('Heads up — something happened.')}>
+        Info
+      </Button>
+      <Button onClick={() => Toast.success('Saved successfully.')}>
+        Success
+      </Button>
+      <Button
+        onClick={() =>
+          Toast.warning('Careful', { description: 'This might need a review.' })
+        }
+      >
+        Warning
+      </Button>
+      <Button
+        onClick={() =>
+          Toast.error('Something went wrong', {
+            description: 'Please try again.',
+          })
+        }
+      >
+        Error
+      </Button>
+    </Space>
+  );
+}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -59,7 +59,7 @@ const CATEGORIES = [
   },
   {
     name: 'Feedback',
-    components: 'Modal, Drawer, Progress, Skeleton, Spin',
+    components: 'Modal, Drawer, Toast, Progress, Skeleton, Spin',
   },
   {
     name: 'Navigation',


### PR DESCRIPTION
## Summary

Documents the **Toast** organism (organisms now 3/5).

- `docs/components/organisms/toast.mdx` — description, usage snippet, live demo, a dismiss section, and imperative API + options tables
- `src/demo/toast-demo.tsx` — buttons triggering each toast type (info/success/warning/error)
- `sidebars.ts` — registered under **Feedback**
- `pages/index.tsx` — added Toast to the landing page Feedback category list (it was previously missing)

## Verification

- `docusaurus build` succeeds
- pre-commit `tsc` + `eslint` clean