### PR TITLE
📝 docs(web): document Modal organism component

### DIFF
--- a/.changeset/docs-modal-organism-web.md
+++ b/.changeset/docs-modal-organism-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new Modal component with controlled and imperative usage, including a demo and documentation.

--- a/apps/web/docs/components/organisms/modal.mdx
+++ b/apps/web/docs/components/organisms/modal.mdx
@@ -1,0 +1,76 @@
+---
+sidebar_position: 6
+title: Modal
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import ModalDemo from '../../../src/demo/modal-demo';
+
+# Modal
+
+A dialog with two ways to use it: **controlled** (drive `open` yourself and handle `onOk` / `onCancel`) or **imperative** (`Modal.confirm`, `Modal.info`, … fire a self-managing modal from anywhere). The mask is not click-closable by default.
+
+```tsx
+import { Modal } from '@jbpark/ui-kit';
+
+const [open, setOpen] = useState(false);
+
+<Modal
+  open={open}
+  title="Title"
+  content="Body text"
+  onOk={() => setOpen(false)}
+  onCancel={() => setOpen(false)}
+/>;
+```
+
+<DemoTheme>
+
+<ModalDemo />
+
+</DemoTheme>
+
+## Imperative
+
+The static methods render a centered, type-styled modal and manage their own open state. `Modal.confirm` shows both OK/Cancel; the others show a single acknowledge button.
+
+```tsx
+Modal.confirm({
+  title: 'Delete this item?',
+  content: 'This action cannot be undone.',
+  onOk: handleDelete,
+});
+
+Modal.success({ title: 'Saved.' });
+```
+
+`Modal.destroy(id)` closes a specific one (each call returns an `id`); `Modal.destroyAll()` clears them all.
+
+## Props
+
+| Prop           | Type                                          | Default |
+| -------------- | --------------------------------------------- | ------- |
+| `open`         | `boolean`                                      | `false` |
+| `title`        | `ReactNode`                                    | -       |
+| `content`      | `ReactNode` (body; `children` also works)      | -       |
+| `footer`       | `ReactNode` (`null` hides the footer)          | -       |
+| `onOk`         | `() => void`                                   | -       |
+| `onCancel`     | `() => void`                                   | -       |
+| `okText`       | `string`                                       | locale  |
+| `cancelText`   | `string`                                       | locale  |
+| `closable`     | `boolean \| { closeIcon?; disabled? }`         | `false` |
+| `closeIcon`    | `ReactNode`                                    | -       |
+| `maskClosable` | `boolean`                                      | `false` |
+| `container`    | `HTMLElement` (custom portal target)           | -       |
+| `classNames`   | `{ mask?; header?; body?; footer? }`           | -       |
+| `className`    | `string`                                       | -       |
+
+### Imperative methods
+
+| Method                                            | Notes                              |
+| ------------------------------------------------- | ---------------------------------- |
+| `Modal.info` / `success` / `error` / `warning`    | single acknowledge button          |
+| `Modal.confirm`                                   | OK + Cancel                        |
+| `Modal.destroy(id)` / `Modal.destroyAll()`        | programmatic close                 |
+
+Each imperative type renders a matching icon next to the title.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/skeleton',
         'components/organisms/toast',
         'components/organisms/drawer',
+        'components/organisms/modal',
       ],
     },
     {

--- a/apps/web/src/demo/modal-demo.tsx
+++ b/apps/web/src/demo/modal-demo.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+import { Button, Modal, Space } from '@repo/ui';
+
+export default function ModalDemo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Space>
+      <Button type="primary" onClick={() => setOpen(true)}>
+        Open modal
+      </Button>
+      <Button
+        onClick={() =>
+          Modal.confirm({
+            title: 'Delete this item?',
+            content: 'This action cannot be undone.',
+            onOk: () => Modal.info({ title: 'Deleted.' }),
+          })
+        }
+      >
+        Confirm (imperative)
+      </Button>
+      <Modal
+        open={open}
+        title="Title"
+        content="A controlled modal driven by open / onOk / onCancel."
+        onOk={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+      />
+    </Space>
+  );
+}


### PR DESCRIPTION
## Summary

Documents the **Modal** organism — **completes organisms 5/5**.

- `docs/components/organisms/modal.mdx` — covers both the controlled and imperative modes, with a live demo, an imperative API section, and Props + methods tables
- `src/demo/modal-demo.tsx` — a controlled modal plus a `Modal.confirm` trigger
- `sidebars.ts` — registered under **Feedback**

## Verification

- `docusaurus build` succeeds
- pre-commit `tsc` + `eslint` clean