### PR TITLE
📝 docs(web): document Result template component

### DIFF
--- a/.changeset/docs-result-template-web.md
+++ b/.changeset/docs-result-template-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a full-page state screen for the outcome of an operation — success, failure, or a `404` / `403` / `500` page.

--- a/apps/web/docs/components/templates/result.mdx
+++ b/apps/web/docs/components/templates/result.mdx
@@ -1,0 +1,42 @@
+---
+sidebar_position: 7
+title: Result
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import ResultDemo from '../../../src/demo/result-demo';
+
+# Result
+
+A full-page state screen for the outcome of an operation — success, failure, or a `404` / `403` / `500` page. `Empty`'s larger, more prominent sibling: `Empty` says "nothing here yet" inline within a list; `Result` says "here's what happened" for an entire view. Each `status` renders a matching icon.
+
+```tsx
+import { Result } from '@jbpark/ui-kit';
+
+<Result
+  status="success"
+  title="Payment successful"
+  subTitle="Order #2024-0815 has been confirmed."
+  extra={<Button type="primary">Back home</Button>}
+/>;
+```
+
+<DemoTheme>
+
+<ResultDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop        | Type                                                              | Default  |
+| ----------- | ---------------------------------------------------------------- | -------- |
+| `status`    | `'success' \| 'error' \| 'info' \| 'warning' \| '404' \| '403' \| '500'` | `'info'` |
+| `icon`      | `ReactNode` (overrides the status icon)                          | -        |
+| `title`     | `ReactNode`                                                      | -        |
+| `subTitle`  | `ReactNode`                                                      | -        |
+| `extra`     | `ReactNode` (action area)                                        | -        |
+| `children`  | `ReactNode` (extra content below)                               | -        |
+| `className` | `string`                                                         | -        |
+
+The four shared statuses (`success` / `error` / `info` / `warning`) use the same icon set as [`Modal`](../organisms/modal)'s imperative variants, so a Result screen matches the tone of a `Modal.success()` / `error()` the user may have just seen.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -63,6 +63,7 @@ const sidebars: SidebarsConfig = {
         'components/organisms/toast',
         'components/organisms/drawer',
         'components/organisms/modal',
+        'components/templates/result',
       ],
     },
     {

--- a/apps/web/src/demo/result-demo.tsx
+++ b/apps/web/src/demo/result-demo.tsx
@@ -1,0 +1,12 @@
+import { Button, Result } from '@repo/ui';
+
+export default function ResultDemo() {
+  return (
+    <Result
+      status="success"
+      title="Payment successful"
+      subTitle="Order #2024-0815 has been confirmed."
+      extra={<Button type="primary">Back home</Button>}
+    />
+  );
+}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -59,7 +59,7 @@ const CATEGORIES = [
   },
   {
     name: 'Feedback',
-    components: 'Modal, Drawer, Toast, Progress, Skeleton, Spin',
+    components: 'Modal, Drawer, Toast, Result, Progress, Skeleton, Spin',
   },
   {
     name: 'Navigation',


### PR DESCRIPTION
## Summary

Documents the **Result** template (templates now 2/6).

- `docs/components/templates/result.mdx` — description, usage snippet, live demo, Props table
- `src/demo/result-demo.tsx` — success result screen with an action
- `sidebars.ts` + landing page — registered under **Feedback**

## Verification

- `docusaurus build` succeeds
- pre-commit `tsc` + `eslint` clean