### PR TITLE
📝 docs(web): document PageHeader template component

### DIFF
--- a/.changeset/docs-page-header-template-web.md
+++ b/.changeset/docs-page-header-template-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new PageHeader component with customizable title, subtitle, back button, and extra action area, along with a demo and documentation.

--- a/apps/web/docs/components/templates/page-header.mdx
+++ b/apps/web/docs/components/templates/page-header.mdx
@@ -1,0 +1,43 @@
+---
+sidebar_position: 3
+title: PageHeader
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import PageHeaderDemo from '../../../src/demo/page-header-demo';
+
+# PageHeader
+
+The header block at the top of a page or detail view — a title and subtitle, an optional back button (shown when `onBack` is provided), and an `extra` action area. Any `children` render below the header row.
+
+```tsx
+import { PageHeader } from '@jbpark/ui-kit';
+
+<PageHeader
+  title="Project settings"
+  subTitle="Manage your project configuration"
+  onBack={() => history.back()}
+  extra={<Button type="primary">Save</Button>}
+/>;
+```
+
+<DemoTheme>
+
+<PageHeaderDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop         | Type                                      | Default |
+| ------------ | ----------------------------------------- | ------- |
+| `title`      | `ReactNode`                               | -       |
+| `subTitle`   | `ReactNode`                               | -       |
+| `extra`      | `ReactNode` (action area, top-right)      | -       |
+| `onBack`     | `() => void` (renders the back button)    | -       |
+| `backIcon`   | `ReactNode`                               | arrow   |
+| `children`   | `ReactNode` (content below the header)    | -       |
+| `classNames` | `{ back?; title?; subTitle?; extra? }`    | -       |
+| `className`  | `string`                                  | -       |
+
+The back button only appears when `onBack` is set. All other `div` props are forwarded to the root.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -82,6 +82,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'components/templates/container',
+        'components/templates/page-header',
         'components/molecules/splitter',
       ],
     },

--- a/apps/web/src/demo/page-header-demo.tsx
+++ b/apps/web/src/demo/page-header-demo.tsx
@@ -1,0 +1,12 @@
+import { Button, PageHeader } from '@repo/ui';
+
+export default function PageHeaderDemo() {
+  return (
+    <PageHeader
+      title="Project settings"
+      subTitle="Manage your project configuration"
+      onBack={() => {}}
+      extra={<Button type="primary">Save</Button>}
+    />
+  );
+}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -67,7 +67,7 @@ const CATEGORIES = [
   },
   {
     name: 'Layout',
-    components: 'Layout, Container, Splitter',
+    components: 'Layout, Container, PageHeader, Splitter',
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

Documents the **PageHeader** template (templates now 4/6).

- `docs/components/templates/page-header.mdx` — description, usage snippet, live demo, Props table
- `src/demo/page-header-demo.tsx` — title/subtitle with back button and extra action
- `sidebars.ts` + landing page — registered under **Layout**

## Verification

- `docusaurus build` succeeds
- pre-commit `tsc` + `eslint` clean