### PR TITLE
📝 docs(web): document Grid (Row/Col) template component

### DIFF
--- a/.changeset/docs-grid-template-web.md
+++ b/.changeset/docs-grid-template-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a 24-column responsive grid component, built from Row and Col, with mobile-first spans and per-breakpoint overrides.

--- a/apps/web/docs/components/templates/grid.mdx
+++ b/apps/web/docs/components/templates/grid.mdx
@@ -1,0 +1,50 @@
+---
+sidebar_position: 4
+title: Grid
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import GridDemo from '../../../src/demo/grid-demo';
+
+# Grid
+
+A 24-column responsive grid built from `Row` and `Col` — the same mental model as Ant Design's grid. `Row` sets the gutter and alignment; each `Col` takes a `span` (out of 24) plus optional per-breakpoint overrides (`xs`…`2xl`). The responsive math is pure CSS, so it renders correctly from the first server paint with no resize listener.
+
+```tsx
+import { Row, Col } from '@jbpark/ui-kit';
+
+<Row gutter={16}>
+  <Col span={24} md={8}>Left</Col>
+  <Col span={24} md={8}>Middle</Col>
+  <Col span={24} md={8}>Right</Col>
+</Row>;
+```
+
+<DemoTheme>
+
+<GridDemo />
+
+</DemoTheme>
+
+## Responsive spans
+
+Each `Col` is mobile-first: `span` is the base, and each breakpoint prop overrides it at and above that tier. `<Col span={24} md={8}>` is full width on small screens and one-third from `md` up.
+
+## Row props
+
+| Prop      | Type                                    | Default |
+| --------- | --------------------------------------- | ------- |
+| `gutter`  | `number \| [horizontal, vertical]`      | `0`     |
+| `align`   | `'top' \| 'middle' \| 'bottom' \| 'stretch'` | -  |
+| `justify` | `'start' \| 'end' \| 'center' \| 'space-around' \| 'space-between' \| 'space-evenly'` | - |
+| `wrap`    | `boolean`                               | `true`  |
+
+## Col props
+
+| Prop                       | Type                            | Default |
+| -------------------------- | ------------------------------- | ------- |
+| `span`                     | `number` (0–24)                 | `24`    |
+| `offset`                   | `number` (0–24)                 | `0`     |
+| `xs` / `sm` / `md` / `lg` / `xl` / `2xl` | `number \| { span?; offset? }` | - |
+
+Both forward any other `div` props to their root element.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -82,6 +82,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'components/templates/container',
+        'components/templates/grid',
         'components/templates/page-header',
         'components/molecules/splitter',
       ],

--- a/apps/web/src/demo/grid-demo.tsx
+++ b/apps/web/src/demo/grid-demo.tsx
@@ -1,0 +1,30 @@
+import { Col, Row } from '@repo/ui';
+
+const cell =
+  'rounded-md bg-blue-500 py-3 text-center text-white dark:bg-blue-600';
+
+export default function GridDemo() {
+  return (
+    <div className="w-full space-y-3">
+      <Row gutter={16}>
+        <Col span={12}>
+          <div className={cell}>span 12</div>
+        </Col>
+        <Col span={12}>
+          <div className={cell}>span 12</div>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={24} md={8}>
+          <div className={cell}>24 / md 8</div>
+        </Col>
+        <Col span={24} md={8}>
+          <div className={cell}>24 / md 8</div>
+        </Col>
+        <Col span={24} md={8}>
+          <div className={cell}>24 / md 8</div>
+        </Col>
+      </Row>
+    </div>
+  );
+}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -67,7 +67,7 @@ const CATEGORIES = [
   },
   {
     name: 'Layout',
-    components: 'Layout, Container, PageHeader, Splitter',
+    components: 'Layout, Container, Grid, PageHeader, Splitter',
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

Documents the **Grid** (`Row` / `Col`) template (templates now 5/6).

- `docs/components/templates/grid.mdx` — description, usage snippet, live demo, a responsive-span section, and separate Row/Col Props tables
- `src/demo/grid-demo.tsx` — a 24-column responsive layout with gutters
- `sidebars.ts` + landing page — registered under **Layout**

## Verification

- `docusaurus build` succeeds
- pre-commit `tsc` + `eslint` clean