### PR TITLE
📝 docs(web): document Layout template component

### DIFF
--- a/.changeset/docs-layout-template-web.md
+++ b/.changeset/docs-layout-template-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add a new Layout component with customizable header, sider, content, and footer sections, allowing for flexible page composition and styling.

--- a/apps/web/docs/components/templates/layout.mdx
+++ b/apps/web/docs/components/templates/layout.mdx
@@ -1,0 +1,56 @@
+---
+sidebar_position: 1
+title: Layout
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import LayoutDemo from '../../../src/demo/layout-demo';
+
+# Layout
+
+The page scaffold: `Layout` with `Layout.Header`, `Layout.Sider`, `Layout.Content`, and `Layout.Footer`. `Layout` switches its axis automatically — it lays out as a column, but flips to a row when it contains a `Sider`, so nesting a `Layout` around a `Sider` + `Content` gives the familiar header / (sider + content) / footer shell. The axis is resolved correctly from the first server paint, then stays correct for Fragment-wrapped Siders after mount.
+
+```tsx
+import { Layout } from '@jbpark/ui-kit';
+
+<Layout>
+  <Layout.Header>Header</Layout.Header>
+  <Layout>
+    <Layout.Sider collapsible>Sider</Layout.Sider>
+    <Layout.Content>Content</Layout.Content>
+  </Layout>
+  <Layout.Footer>Footer</Layout.Footer>
+</Layout>;
+```
+
+<DemoTheme>
+
+<LayoutDemo />
+
+</DemoTheme>
+
+## Composition
+
+- **`Layout`** — the flex wrapper. The outermost one is `min-h-screen`; nested ones shrink to fit.
+- **`Layout.Header`** — `sticky` by default; also accepts `position="static" | "fixed"`.
+- **`Layout.Sider`** — a side panel, optionally `collapsible` with a breakpoint that auto-collapses.
+- **`Layout.Content`** — the `<main>` landmark; use `asChild` to avoid a duplicate `<main>` when nested.
+- **`Layout.Footer`** — a full-width `<footer>`.
+
+## Sider props
+
+| Prop               | Type                          | Default  |
+| ------------------ | ----------------------------- | -------- |
+| `width`            | `number \| string`            | `200`    |
+| `collapsedWidth`   | `number \| string`            | `80`     |
+| `collapsible`      | `boolean`                     | `false`  |
+| `collapsed`        | `boolean` (controlled)        | -        |
+| `defaultCollapsed` | `boolean`                     | `false`  |
+| `placement`        | `'left' \| 'right'`           | `'left'` |
+| `breakpoint`       | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | - |
+| `reverseArrow`     | `boolean`                     | `false`  |
+| `trigger`          | `ReactNode` (custom toggle)   | -        |
+| `onCollapse`       | `(collapsed: boolean) => void` | -       |
+| `onBreakpoint`     | `(broken: boolean) => void`   | -        |
+
+`Header` takes `position`; all four sub-components forward the rest of their native element props.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -81,6 +81,7 @@ const sidebars: SidebarsConfig = {
       label: 'Layout',
       collapsed: false,
       items: [
+        'components/templates/layout',
         'components/templates/container',
         'components/templates/grid',
         'components/templates/page-header',

--- a/apps/web/src/demo/layout-demo.tsx
+++ b/apps/web/src/demo/layout-demo.tsx
@@ -1,0 +1,24 @@
+import { Layout } from '@repo/ui';
+
+export default function LayoutDemo() {
+  return (
+    <Layout
+      className="h-80! min-h-0! overflow-hidden rounded-lg border
+        border-gray-200 dark:border-gray-700"
+    >
+      <Layout.Header className="bg-blue-600 text-white">Header</Layout.Header>
+      <Layout>
+        <Layout.Sider collapsible className="bg-gray-100 p-4 dark:bg-gray-800">
+          Sider
+        </Layout.Sider>
+        <Layout.Content className="p-4">
+          Content — the main area grows to fill the space between the header and
+          footer.
+        </Layout.Content>
+      </Layout>
+      <Layout.Footer className="bg-gray-100 p-4 text-center dark:bg-gray-800">
+        Footer
+      </Layout.Footer>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Documents the **Layout** template — **completes templates 6/6** and, with it, every ui-kit component tier (atoms 15/15, molecules 9/9, organisms 5/5, templates 6/6).

- `docs/components/templates/layout.mdx` — covers the `Header` / `Sider` / `Content` / `Footer` scaffold, the automatic column↔row axis switch, a composition breakdown, and a `Sider` Props table
- `src/demo/layout-demo.tsx` — a header / (sider + content) / footer shell with a collapsible sider
- `sidebars.ts` — registered at the top of the **Layout** category (Layout was already listed on the landing page)

## Verification

- `docusaurus build` succeeds
- pre-commit `tsc` + `eslint` clean