### PR TITLE
🐛 fix(ui): correct exports map drift in published manifest

### DIFF
--- a/.changeset/fix-exports-map-drift.md
+++ b/.changeset/fix-exports-map-drift.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix the `exports` map drift between `package.json` and `package.publish.json`. The published manifest exposed a `./enums` subpath that resolved to `./dist/enums.mjs` — a file that is never built (there is no `enums` entry in `tsdown.config.ts` and no `enums` source), so importing `@jbpark/ui-kit/enums` always failed. Meanwhile `./providers` — which _is_ built (`dist/providers.mjs`) and is exported in the dev manifest — was missing from the published manifest, leaving it unreachable for published consumers. Drop the dead `./enums` subpath and add the missing `./providers` subpath so the published surface matches what is actually built.

--- a/packages/ui/package.publish.json
+++ b/packages/ui/package.publish.json
@@ -51,15 +51,15 @@
       "import": "./dist/utils.mjs",
       "default": "./dist/utils.mjs"
     },
-    "./enums": {
-      "types": "./dist/enums.d.mts",
-      "import": "./dist/enums.mjs",
-      "default": "./dist/enums.mjs"
-    },
     "./core": {
       "types": "./dist/core.d.mts",
       "import": "./dist/core.mjs",
       "default": "./dist/core.mjs"
+    },
+    "./providers": {
+      "types": "./dist/providers.d.mts",
+      "import": "./dist/providers.mjs",
+      "default": "./dist/providers.mjs"
     },
     "./style.css": {
       "import": "./dist/style.css",


### PR DESCRIPTION
Closes #277.

## Problem

`package.json` (dev) and `package.publish.json` (published) had drifted apart in their `exports` maps:

- **`./enums`** was exported *only* in the published manifest and pointed at `./dist/enums.mjs`. There is no `enums` entry in `tsdown.config.ts` and no `enums` source, so that file is **never built** — `import … from '@jbpark/ui-kit/enums'` always failed for published consumers.
- **`./providers`** was exported *only* in the dev manifest. It **is** built (`dist/providers.mjs`), but because the published manifest omitted it, published consumers **could not reach it**.

## Fix

In `package.publish.json`:
- Drop the dead `./enums` subpath
- Add `./providers` → `./dist/providers.mjs` (mirroring the dev manifest and the actual build output)

## Verification

`pnpm --filter @repo/ui run build`:
- ✅ `dist/providers.mjs` + `dist/providers.d.mts` are emitted → the new subpath resolves
- ✅ `dist/enums.*` are **not** emitted → confirms the removed subpath was dead

Non-breaking: `./enums` never resolved, and `./providers` is newly reachable.