### PR TITLE
👷 ci(ui): assert data-slot + a11y chassis contracts in SSR smoke

### DIFF
--- a/.changeset/ssr-data-slot-contract.md
+++ b/.changeset/ssr-data-slot-contract.md
@@ -1,0 +1,20 @@
+---
+---
+
+Extend the SSR smoke guard (ui-kit#301) — CI-only tooling, no published package change.
+
+`check-ssr-smoke.mjs` now captures the rendered markup (previously discarded)
+and asserts two rendered-output contracts, closing the gap that lets the Phase 4
+Button/Tag absorb (#278 ③) drop styling/a11y silently:
+
+- **data-slot contract** — every `[data-slot='X']` selector in `globals.css`
+  must have a matching `data-slot="X"` in some component's SSR output. Derived
+  from `globals.css`, so it self-maintains as new rules are added. Catches a
+  dropped `data-slot="button"` (which would silently unset all 16 button color
+  variables and the non-Tailwind-host reset).
+- **a11y/state chassis** — `Button` and `Tag` must keep their focus-ring /
+  aria-invalid (and, for Button, `disabled:*`) classes in the rendered markup.
+  Asserted per-component because Tag's chassis is a strict subset of Button's.
+
+No new dependency, CI step, or turbo task — the check already rendered every
+component. Scripts aren't shipped (`files: ["dist"]`), so no release.

--- a/packages/ui/scripts/check-ssr-smoke.mjs
+++ b/packages/ui/scripts/check-ssr-smoke.mjs
@@ -1,22 +1,64 @@
 #!/usr/bin/env node
-// SSR smoke test (Phase 3 regression net, ui-kit#294).
+// SSR smoke test + rendered-output contracts (Phase 3 regression net,
+// ui-kit#294; extended for #301).
 //
 // Server-renders every exported component (wrapped in <Config>) with minimal
-// valid props and fails on throw. This catches the "works in the browser,
-// explodes / diverges on the server" class (ui-kit#228) — a `'use client'`
-// component touching `window`/`document` at render, an SSR-unsafe hook, an
-// unguarded portal — none of which type-check or lint catch. Broad crash net,
-// not a snapshot: we only assert it renders without throwing.
+// valid props, then asserts three things on the result:
+//
+//   1. It renders without throwing. Catches the "works in the browser,
+//      explodes / diverges on the server" class (ui-kit#228) — a `'use client'`
+//      component touching `window`/`document` at render, an SSR-unsafe hook, an
+//      unguarded portal — none of which type-check or lint catch.
+//
+//   2. data-slot contract (#301): every `[data-slot='X']` selector in
+//      globals.css must have a matching `data-slot="X"` in some component's
+//      rendered output. globals.css keys 20+ style rules (button colors, the
+//      non-Tailwind-host reset) off these attributes; if an atom stops emitting
+//      one — e.g. the Button/Tag absorb in Phase 4 (#278 ③) drops it — those
+//      rules silently no-op (danger stops being red, presets lose their fill)
+//      and nothing else in CI notices. Derived from globals.css, so a new
+//      `[data-slot='…']` rule is covered automatically.
+//
+//   3. a11y/state chassis (#301): Button and Tag must keep their focus-ring /
+//      aria-invalid (and, for Button, disabled) classes in the rendered markup.
+//      That chassis lives in core's cva base string today; the Phase 4 absorb
+//      must carry it into the atom. Asserted per-component because Tag's chassis
+//      is a strict subset of Button's (a Tag isn't disableable) — a single
+//      shared list would false-positive on Tag.
 //
 // Run after `build`, via the css-stub loader (Swiper imports `.css`):
 //   node --import ./scripts/loaders/css-stub.mjs scripts/check-ssr-smoke.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { createElement as h } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import * as ui from '../dist/index.mjs';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GLOBALS_CSS = path.join(__dirname, '..', 'src', 'globals.css');
+
 const { Config } = ui;
+
+// a11y/state chassis that must survive the core→atom absorption (#301). The
+// six focus/aria classes are shared; Button additionally disables. Tag's set is
+// a strict subset — do NOT push disabled:* onto it. Update deliberately if the
+// design of these states changes.
+const COMMON_CHASSIS = [
+  'focus-visible:border-ring',
+  'focus-visible:ring-ring/50',
+  'focus-visible:ring-[3px]',
+  'aria-invalid:border-destructive',
+  'aria-invalid:ring-destructive/20',
+  'dark:aria-invalid:ring-destructive/40',
+];
+const CHASSIS = {
+  Button: [...COMMON_CHASSIS, 'disabled:opacity-50', 'disabled:pointer-events-none'],
+  Tag: [...COMMON_CHASSIS],
+};
 
 // Minimal valid props per component that needs them. Anything not listed is
 // rendered with no props. Keep entries tiny — just enough to render.
@@ -71,6 +113,7 @@ function isComponent(v) {
 }
 
 const results = [];
+const markupByName = {};
 for (const name of Object.keys(ui).sort()) {
   if (NON_COMPONENTS.has(name)) continue;
   const Comp = ui[name];
@@ -78,30 +121,76 @@ for (const name of Object.keys(ui).sort()) {
 
   const { children, ...props } = fixtures[name] ?? {};
   try {
-    renderToStaticMarkup(
+    const markup = renderToStaticMarkup(
       h(Config, null, h(Comp, props, children ?? undefined)),
     );
+    markupByName[name] = markup;
     results.push({ name, ok: true });
   } catch (err) {
     results.push({ name, ok: false, err });
   }
 }
 
-const failed = results.filter(r => !r.ok);
-const passed = results.filter(r => r.ok);
+const errors = [];
 
+// 1. Render throws.
+const failed = results.filter(r => !r.ok);
 if (failed.length) {
-  console.error(`✘ SSR smoke render threw for ${failed.length} component(s):\n`);
-  for (const { name, err } of failed) {
-    const msg = (err && (err.message || String(err)) || '').split('\n')[0];
-    console.error(`  - ${name}: ${msg}`);
-  }
-  console.error(
-    '\n  A component must server-render without throwing. Guard browser-only\n' +
-      '  access (`typeof window`/`useEffect`), or add minimal props to the\n' +
-      '  fixtures map in this script if the throw is just a missing required prop.',
+  const lines = failed.map(({ name, err }) => {
+    const msg = ((err && (err.message || String(err))) || '').split('\n')[0];
+    return `    - ${name}: ${msg}`;
+  });
+  errors.push(
+    `SSR render threw for ${failed.length} component(s):\n${lines.join('\n')}\n` +
+      '    A component must server-render without throwing. Guard browser-only\n' +
+      '    access (`typeof window`/`useEffect`), or add minimal props to the\n' +
+      '    fixtures map in this script if the throw is just a missing required prop.',
   );
+}
+
+// 2. data-slot contract, derived from globals.css.
+const cssSlots = new Set(
+  [...fs.readFileSync(GLOBALS_CSS, 'utf8').matchAll(/\[data-slot='([a-z-]+)'\]/g)].map(
+    m => m[1],
+  ),
+);
+const allMarkup = Object.values(markupByName).join('');
+const renderedSlots = new Set(
+  [...allMarkup.matchAll(/data-slot="([a-z-]+)"/g)].map(m => m[1]),
+);
+const missingSlots = [...cssSlots].filter(s => !renderedSlots.has(s)).sort();
+if (missingSlots.length) {
+  errors.push(
+    `data-slot contract: globals.css styles [data-slot='${missingSlots.join("'], [data-slot='")}']\n` +
+      `    but no exported component renders data-slot="${missingSlots.join('" / "')}".\n` +
+      '    Those CSS rules (button colors, the non-Tailwind-host reset) silently\n' +
+      '    no-op without the attribute. The owning component must emit it.',
+  );
+}
+
+// 3. a11y/state chassis for Button and Tag.
+for (const [name, expected] of Object.entries(CHASSIS)) {
+  const markup = markupByName[name];
+  if (markup == null) continue; // a render failure is already reported above
+  const missing = expected.filter(cls => !markup.includes(cls));
+  if (missing.length) {
+    errors.push(
+      `${name} a11y/state chassis: rendered output is missing ${missing.length} ` +
+        `class(es):\n    ${missing.join(' ')}\n` +
+        '    These focus-ring / aria-invalid / disabled treatments must survive\n' +
+        '    in the rendered markup (e.g. after absorbing the core primitive).',
+    );
+  }
+}
+
+if (errors.length) {
+  console.error('✘ SSR smoke / rendered-output contract failed:\n');
+  for (const e of errors) console.error('  - ' + e + '\n');
   process.exit(1);
 }
 
-console.log(`✓ SSR smoke render passed for ${passed.length} components.`);
+const passed = results.filter(r => r.ok);
+console.log(
+  `✓ SSR smoke + contracts passed: ${passed.length} components render, ` +
+    `data-slot [${[...cssSlots].sort().join(', ')}] present, Button/Tag chassis intact.`,
+);


### PR DESCRIPTION
Closes #301. Extends the Phase 3 SSR smoke guard (#300) to close a verified gap **before** Phase 4 (#278 ③) starts. **CI-only tooling, no published package change (empty changeset).**

## The gap (verified)

The Button/Tag absorb in Phase 4 drops `atoms/button.tsx` / `atoms/tag.tsx`'s dependency on `core`. Two things the atoms depend on implicitly live in `core`:

- **`data-slot="button"`** — `globals.css` keys **20 rules** off `[data-slot='button']` (all 16 color presets via `--btn-bg`/`--btn-fg`/`--btn-border`, plus the non-Tailwind-host reset scoped to `[data-slot]`). Drop the attribute and `danger` stops being red, every preset loses its fill.
- **the a11y/state chassis** — focus ring, `aria-invalid`, `disabled` treatments, only present in the rendered markup.

Neither is a type, import, or literal in the atom's source, so nothing in CI saw it. Reproduced: after `sed`-removing `data-slot="button"` from the built output, **all 5 existing gates pass** (lint, check-types, check-dynamic-classes, preflight-reset, and the current ssr-smoke — which discarded its markup).

## The fix

`check-ssr-smoke.mjs` now captures the rendered markup and asserts:

1. **data-slot contract** — every `[data-slot='X']` in `globals.css` (today `button`, `col`) must appear as `data-slot="X"` in some component's SSR output. Derived from `globals.css`, so a new rule is covered automatically.
2. **a11y/state chassis** — `Button` and `Tag` keep their focus/aria (+ Button `disabled:*`) classes. Per-component: Tag's chassis is a strict **subset** of Button's, so a shared list would false-positive on Tag (confirmed while prototyping — Tag has 6, Button 8, common 6).

No new dependency, CI step, or turbo task — the guard already rendered every component; it just stopped throwing the markup away.

## Verification

- Positive: passes (36 components render, `data-slot [button, col]` present, Button/Tag chassis intact).
- **Negative** (a guard that can't fail isn't a guard):
  - drop `data-slot="button"` from the build → **FAIL** (`missing button`)
  - strip a chassis class from Button → **FAIL** (`Button chassis missing …`)
- `pnpm --filter @repo/ui lint` clean; full `turbo run check-regression-net` green.

Refs #294 (Phase 3 net), blocks #278 ③ / Phase 4.