### PR TITLE
♻️ refactor(ui): absorb Button/Tag primitives into a shared chassis (Phase 4)

### DIFF
--- a/.changeset/absorb-button-tag-chassis.md
+++ b/.changeset/absorb-button-tag-chassis.md
@@ -1,0 +1,17 @@
+---
+'@repo/ui': patch
+---
+
+Absorb the `Button` and `Tag` single-element primitives (ui-kit#278 ③, #294
+Phase 4). Both atoms now render their own native element instead of wrapping
+`core/button` / `core/badge`, and the shared a11y/state chassis (focus ring,
+`aria-invalid`, flex centering) is extracted to `INTERACTIVE_CHASSIS` so the
+absorb relocates that treatment rather than dropping it. `Button` extends the
+chassis with `disabled:*`, `outline-none` and icon sizing; `Tag` does not (it is
+not disableable). `solid` now carries its `bg-primary` fill explicitly instead
+of inheriting it from the core default variant.
+
+Pure refactor: rendered output is byte-identical across the full Button matrix
+(6 variants × 3 sizes × 3 shapes × colors + states) and every Tag variant/color,
+verified against a pre-refactor render capture. `core/button` stays (its
+`buttonVariants` is still used by `core/calendar`); `./core` remains public.

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -1,13 +1,18 @@
 'use client';
 
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
 import { LoaderCircle } from 'lucide-react';
 
-import { button } from '@repo/ui/core';
 import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
-const Core = button.Button;
-type ButtonProps = button.Props;
+import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
+
+type NativeButtonProps = React.ComponentProps<'button'> & {
+  asChild?: boolean;
+};
 
 type PresetColors =
   | 'blue'
@@ -24,7 +29,10 @@ type PresetColors =
   | 'lime'
   | 'gold';
 
-export interface Props extends Omit<ButtonProps, 'size' | 'variant' | 'type'> {
+export interface Props extends Omit<
+  NativeButtonProps,
+  'size' | 'variant' | 'type'
+> {
   icon?: React.ReactNode;
   block?: boolean;
   danger?: boolean;
@@ -48,8 +56,33 @@ export interface Props extends Omit<ButtonProps, 'size' | 'variant' | 'type'> {
   loading?: boolean | { icon: React.ReactNode };
 }
 
+// Chassis absorbed from core/button's cva base (#278 ③ / #294 Phase 4). The
+// shared focus/aria set lives in INTERACTIVE_CHASSIS; a Button additionally
+// disables and sizes its icons. Kept as constants so the absorb relocates this
+// treatment rather than dropping it (the #177 class of silent regression the
+// #300/#301 net guards).
+const BUTTON_CHASSIS = cn(
+  INTERACTIVE_CHASSIS,
+  'outline-none',
+  'disabled:pointer-events-none disabled:opacity-50',
+  "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+);
+
+// Presentation the atom builds on. The size/variant/shape classes below still
+// override the incidental leftovers exactly as they did when this wrapped
+// core/button, so the rendered output is unchanged (verified against a
+// pre-refactor render matrix).
+const BUTTON_BASE = cn(
+  BUTTON_CHASSIS,
+  'gap-2 whitespace-nowrap font-medium transition-all',
+  'has-[>svg]:px-3',
+);
+
 const variantClasses: Record<string, string> = {
-  solid: '',
+  // solid used to inherit its fill from core/button's default variant; carry it
+  // explicitly now that the primitive is absorbed. A colored solid overrides
+  // this with the --btn-* custom properties further down.
+  solid: cn('bg-primary text-primary-foreground', 'hover:bg-primary/90'),
   outlined: cn(
     'border border-[color-mix(in_oklch,var(--btn-border),transparent_50%)]',
     'bg-background text-foreground',
@@ -108,14 +141,14 @@ const Button = ({
   disabled,
   loading,
   danger,
+  asChild = false,
   children,
   onMouseDown,
   ...props
 }: Props) => {
   const { componentSize, defaultProps } = useConfig();
   const buttonDefaults = defaultProps?.button as
-    | Partial<Pick<Props, 'shape'>>
-    | undefined;
+    Partial<Pick<Props, 'shape'>> | undefined;
   const resolvedSize = size ?? componentSize ?? 'middle';
   const resolvedShape = shape ?? buttonDefaults?.shape ?? 'default';
   const iconOnly = icon && !children;
@@ -123,6 +156,8 @@ const Button = ({
   const colored = computedColor && computedColor !== 'default';
   const resolvedVariant = variant ?? typeToVariant[type] ?? 'solid';
   const isLoading = !!loading;
+
+  const Comp = asChild ? Slot : 'button';
 
   const displayIcon = loading ? (
     typeof loading === 'object' ? (
@@ -135,13 +170,12 @@ const Button = ({
   );
 
   return (
-    <Core
-      type={htmlType}
-      disabled={disabled || isLoading}
-      aria-busy={isLoading}
-      variant="default"
-      data-color={computedColor}
+    <Comp
+      data-slot="button"
+      data-variant="default"
+      data-size="default"
       className={cn(
+        BUTTON_BASE,
         'inline-flex items-center justify-center gap-x-2',
         'rounded-lg',
         'cursor-pointer',
@@ -169,6 +203,10 @@ const Button = ({
         className,
         //
       )}
+      type={htmlType}
+      disabled={disabled || isLoading}
+      aria-busy={isLoading}
+      data-color={computedColor}
       onMouseDown={e => {
         onMouseDown?.(e);
       }}
@@ -176,7 +214,7 @@ const Button = ({
     >
       {displayIcon}
       {children}
-    </Core>
+    </Comp>
   );
 };
 

--- a/packages/ui/src/components/atoms/tag.tsx
+++ b/packages/ui/src/components/atoms/tag.tsx
@@ -1,13 +1,34 @@
-import { badge } from '@repo/ui/core';
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+
 import { cn } from '@repo/ui/utils';
 
-const Core = badge.Badge;
-type BadgeProps = badge.Props;
+import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
 
-export interface Props extends Omit<BadgeProps, 'variant'> {
+type NativeSpanProps = React.ComponentProps<'span'> & {
+  asChild?: boolean;
+};
+
+export interface Props extends Omit<NativeSpanProps, 'variant'> {
   variant?: 'default' | 'outlined';
   color?: 'default' | 'primary' | 'success' | 'warning' | 'danger';
 }
+
+// Base absorbed from core/badge's cva base + its `outline` variant, which Tag
+// always rendered as (#278 ③ / #294 Phase 4). The shared focus/aria/centering
+// set lives in INTERACTIVE_CHASSIS; a Tag adds badge geometry and its svg
+// sizing but — unlike Button — no `disabled:*` (a Tag is not disableable). The
+// rounded/padding leftovers are overridden by the atom classes below exactly as
+// before, so the rendered output is unchanged (verified against a pre-refactor
+// render matrix).
+const TAG_BASE = cn(
+  INTERACTIVE_CHASSIS,
+  'border w-fit whitespace-nowrap overflow-hidden',
+  'text-xs font-medium gap-1 transition-[color,box-shadow]',
+  '[&>svg]:size-3 [&>svg]:pointer-events-none',
+  'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+);
 
 const fillColorClasses: Record<string, string> = {
   default: 'border-transparent bg-muted text-muted-foreground',
@@ -31,13 +52,17 @@ const Tag = ({
   className,
   variant = 'default',
   color = 'default',
+  asChild = false,
   children,
   ...props
 }: Props) => {
+  const Comp = asChild ? Slot : 'span';
+
   return (
-    <Core
-      variant="outline"
+    <Comp
+      data-slot="badge"
       className={cn(
+        TAG_BASE,
         'rounded-full px-2.5 py-1',
         'text-xs font-medium',
         variant === 'default' && fillColorClasses[color],
@@ -48,7 +73,7 @@ const Tag = ({
       {...props}
     >
       {children}
-    </Core>
+    </Comp>
   );
 };
 

--- a/packages/ui/src/lib/chassis.ts
+++ b/packages/ui/src/lib/chassis.ts
@@ -1,0 +1,23 @@
+import { cn } from '@repo/ui/utils';
+
+/**
+ * Shared a11y/state chassis for interactive single-element atoms (Button, Tag).
+ *
+ * Extracted from `core/button` and `core/badge`'s cva base strings during the
+ * #278 step ③ absorb (see #294 Phase 4). When an atom stops wrapping its core
+ * primitive it must carry this chassis itself — the focus ring, the
+ * `aria-invalid` treatment and the flex centering are load-bearing and have no
+ * type- or lint-level signal, so dropping them regresses silently (the #177
+ * class of bug the regression net in #300/#301 guards).
+ *
+ * Common set only. A Tag is not disableable, does not size icons and (as a
+ * non-focusable `span`) carries no `outline-none`, so those live on the Button
+ * extension in `atoms/button`, NOT here — folding them into one shared constant
+ * would push `disabled:*` onto Tag, which is semantically wrong (#301's
+ * per-component chassis finding).
+ */
+export const INTERACTIVE_CHASSIS = cn(
+  'inline-flex items-center justify-center shrink-0',
+  'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+  'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+);


### PR DESCRIPTION
Phase 4 of the `packages/ui` roadmap (#294) — #278 step ③. Now unblocked: the regression net that guards this exact refactor landed in #302 (data-slot + chassis contracts) and #303 (Tag's non-keyed `data-slot`).

## What

`atoms/button` and `atoms/tag` no longer wrap `core/button` / `core/badge`. They render their own native `<button>` / `<span>` (with `asChild → Slot` preserved), and the shared a11y/state chassis is extracted to `src/lib/chassis.ts`.

- **`INTERACTIVE_CHASSIS`** (shared): flex centering + focus ring + `aria-invalid` treatment — the classes that survive `tailwind-merge` from core's cva base ([#278 measurement](https://github.com/pjb0811/ui-kit/issues/278#issuecomment-5424506453)).
- **Button** extends it with `outline-none`, `disabled:*` and icon sizing.
- **Tag** does not — a Tag is not disableable and (as a non-focusable `span`) has no `outline-none`, per [#301's per-component chassis finding](https://github.com/pjb0811/ui-kit/issues/301).
- `solid` now carries its `bg-primary text-primary-foreground hover:bg-primary/90` fill **explicitly**, instead of inheriting it from core's default variant (a colored `solid` still overrides it via the `--btn-*` custom properties).

## "Absorb = relocate, not delete" — verified byte-identical

Per #294's warning (this is the #177 profile: a pure refactor with no type/lint signal, the class that shipped a regression to npm). Verification method matches #278's own: render and diff.

Captured the rendered SSR markup **before and after** across the full matrix:

- **Button** — 6 variants × 3 sizes × 3 shapes × 6 colors + `disabled`/`loading`/`block`/`iconOnly`/`type`/`htmlType`
- **Tag** — every variant × color, plus icon

**346 / 346 cases byte-identical.** The first pass surfaced two real deltas, both fixed so the diff is now zero: `outline-none` was being added to Tag (moved to the Button-only extension), and the `class` attribute position (reordered to match).

## Scope / safety

- `core/button` **kept** — its `buttonVariants` is still consumed by `core/calendar`.
- `core/badge` **kept** — `./core` stays public until #278 ④ / Phase 5.
- No public API change — `check-api-surface`: 41 names, 13 subpaths, unchanged.
- `check-types`, `lint`, and the full regression net (`api-surface` / `preflight-reset` / `ssr-smoke`) all pass; `ssr-smoke` confirms Button/Tag chassis + `data-slot` intact.
- Changeset: `@repo/ui` **patch** (implementation-only; output unchanged).

Closes the Phase 4 item in #294. Refs #278, #301, #302, #303.