### PR TITLE
🐛 fix(ui): drop Button's hardcoded data-variant/data-size

### DIFF
--- a/.changeset/button-drop-hardcoded-data-attrs.md
+++ b/.changeset/button-drop-hardcoded-data-attrs.md
@@ -1,0 +1,21 @@
+---
+'@repo/ui': patch
+---
+
+Stop `Button` from emitting hardcoded `data-variant="default"` / `data-size="default"`
+(ui-kit#308).
+
+The two attributes were literals that never reflected the component's actual props:
+a Button rendered with `variant="outlined" size="large"` still emitted
+`data-variant="default" data-size="default"`. They were a leftover from the Phase 4
+absorb (ui-kit#304), which inlined `core/button.tsx`'s `data-variant={variant}` /
+`data-size={size}` while the atom happened to be passing the literal `"default"`.
+
+No consumer-visible behaviour change: because the values were constant, any selector
+using them matched exactly the same elements as `[data-slot='button']`, which is
+unchanged and remains the documented styling hook. `data-slot="button"` itself is
+untouched — the 20 `[data-slot='button'][data-color=…]` rules in `globals.css` that
+define the preset-color system depend on it.
+
+This also clears a false positive in the smell check documented in `CLAUDE.md`, which
+matched `data-variant="` on the very component it exists to police.

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -172,8 +172,6 @@ const Button = ({
   return (
     <Comp
       data-slot="button"
-      data-variant="default"
-      data-size="default"
       className={cn(
         BUTTON_BASE,
         'inline-flex items-center justify-center gap-x-2',


### PR DESCRIPTION
Closes #308. Option A from that issue.

## Problem

`atoms/button.tsx` emitted two data attributes as string literals that never tracked the props:

```tsx
data-variant="default"   // even when variant="outlined"
data-size="default"      // even when size="large"
```

So they carried **wrong data**, not merely unused data. A leftover from the Phase 4 absorb (#304), which inlined `core/button.tsx`'s `data-variant={variant}` / `data-size={size}` while the atom happened to be passing the literal `"default"` — the very hardcoded-variant smell #278 was about.

## Change

```diff
   <Comp
     data-slot="button"
-    data-variant="default"
-    data-size="default"
     className={cn(
```

`data-slot="button"` stays: the 20 `[data-slot='button'][data-color=…]` rules in `globals.css` that define the `--btn-bg`/`--btn-fg`/`--btn-border` preset-color system resolve through it.

Option B (making them dynamic, `data-variant={resolvedVariant}`) was rejected for now — it would be an additive API commitment with no current use case, and can still be done later.

## Why this is not breaking

The values were constant, so any consumer selector using them (`[data-variant="default"]`) matched exactly the same element set as `[data-slot='button']`, which is unchanged and is the documented styling hook. No selector that distinguishes anything could exist. Marked `patch` because rendered markup does change.

## Verification

- **Rendered output checked directly.** `<Button variant="outlined" size="large" color="danger">` now emits `data-slot="button"` and `data-color="danger"` with no `data-variant`/`data-size`.
- **Regression net passes** — `api-surface` (41 names, 12 subpaths), `preflight-reset`, and `ssr-smoke` with `data-slot [button, col] present, Button/Tag chassis intact`.
- **Smell check from `CLAUDE.md` is now clean of `button.tsx`.** It previously false-positived on `data-variant="` — on the very component it exists to police. Remaining hits (`float-button.tsx`, `modal.tsx`) pass `variant` to our own `Button`, which the criterion allows.
- `pnpm lint`, `pnpm check-types`, `pnpm build` all pass across the 3 workspaces.
