### PR TITLE
♻️ refactor(ui): deprecate Button's type prop in favour of variant

### DIFF
--- a/.changeset/button-deprecate-type-prop.md
+++ b/.changeset/button-deprecate-type-prop.md
@@ -1,0 +1,29 @@
+---
+'@repo/ui': patch
+---
+
+Deprecate `Button`'s `type` prop in favour of `variant` (ui-kit#278 follow-up).
+
+The two props address the same axis and largely duplicate each other: 3 of the 5
+`type` values (`dashed`, `text`, `link`) are spelled identically to their
+`variant` counterparts, so `<Button type="text">` and `<Button variant="text">`
+already render the same thing. `type` only contributes the aliases
+`primary` → `solid` and `default` → `outlined`, while `variant` additionally
+offers `filled`, which `type` cannot express.
+
+`type` is now marked `@deprecated` with an in-editor migration table. **Nothing
+changes at runtime** — passing both still lets `variant` win, and every
+`type`/`variant` combination resolves to exactly the same variant as before.
+The default moved off the deprecated prop (`type = 'default'` on the parameter)
+onto the resolution itself (`?? 'outlined'`), so a Button with neither prop no
+longer routes through the deprecated path.
+
+| `type`    | use instead                                        |
+| --------- | -------------------------------------------------- |
+| `primary` | `solid`                                            |
+| `default` | `outlined` (now the default, so it can be omitted) |
+| `dashed`  | `dashed`                                           |
+| `text`    | `text`                                             |
+| `link`    | `link`                                             |
+
+`type` will be removed in the next major.

--- a/apps/docs/stories/organisms/drawer/index.stories.tsx
+++ b/apps/docs/stories/organisms/drawer/index.stories.tsx
@@ -120,7 +120,7 @@ export const WithExtra: Story = {
                 취소
               </Button>
               <Button
-                type="primary"
+                variant="solid"
                 size="small"
                 onClick={() => setOpen(false)}
               >

--- a/apps/web/docs/components/atoms/button.mdx
+++ b/apps/web/docs/components/atoms/button.mdx
@@ -11,7 +11,7 @@ import ButtonDemo from '../../../src/demo/button-demo';
 ```tsx
 import { Button } from '@jbpark/ui-kit';
 
-<Button type="primary" onClick={() => console.log('clicked')}>
+<Button variant="solid" onClick={() => console.log('clicked')}>
   Click me
 </Button>;
 ```
@@ -26,8 +26,8 @@ import { Button } from '@jbpark/ui-kit';
 
 | Prop        | Type                                                          | Default     |
 | ----------- | ----------------------------------------------------------------- | ----------- |
-| `type`      | `'primary' \| 'default' \| 'dashed' \| 'text' \| 'link'`         | `'default'` |
-| `variant`   | `'solid' \| 'outlined' \| 'dashed' \| 'filled' \| 'text' \| 'link'` | -         |
+| `variant`   | `'solid' \| 'outlined' \| 'dashed' \| 'filled' \| 'text' \| 'link'` | `'outlined'` |
+| ~~`type`~~  | `'primary' \| 'default' \| 'dashed' \| 'text' \| 'link'`         | -           |
 | `size`      | `'small' \| 'middle' \| 'large'`                                  | `'middle'`  |
 | `shape`     | `'default' \| 'circle' \| 'round'`                                | `'default'` |
 | `color`     | preset color name (see below) `\| 'default' \| 'primary' \| 'danger'` | `'default'` |
@@ -39,8 +39,22 @@ import { Button } from '@jbpark/ui-kit';
 | `htmlType`  | `'button' \| 'submit' \| 'reset'`                                 | `'button'`  |
 | `className` | `string`                                                           | -           |
 
-`type` is an antd-style preset that maps to `variant` internally — pass
-`variant` directly to override it for a one-off case. Preset `color` names:
+`type` is **deprecated** — use `variant`. The two props address the same axis,
+and 3 of the 5 values (`dashed`, `text`, `link`) are spelled identically, so
+`<Button type="text">` and `<Button variant="text">` already render the same
+thing. `type` only adds the aliases `primary` → `solid` and `default` →
+`outlined`, while `variant` additionally offers `filled`. Passing both still
+lets `variant` win. `type` will be removed in the next major.
+
+| `type`    | use instead  |
+| --------- | ------------ |
+| `primary` | `solid`      |
+| `default` | `outlined` (the default, so it can just be omitted) |
+| `dashed`  | `dashed`     |
+| `text`    | `text`       |
+| `link`    | `link`       |
+
+Preset `color` names:
 `blue`, `purple`, `cyan`, `green`, `magenta`, `pink`, `red`, `orange`,
 `yellow`, `volcano`, `geekblue`, `lime`, `gold`, in addition to `default`,
 `primary`, `danger`. `Button` also accepts the rest of Radix UI's `Slot`

--- a/apps/web/docs/components/templates/empty.mdx
+++ b/apps/web/docs/components/templates/empty.mdx
@@ -16,7 +16,7 @@ import { Empty } from '@jbpark/ui-kit';
 <Empty
   title="No projects yet"
   description="Create your first project to get started."
-  action={<Button type="primary">New project</Button>}
+  action={<Button variant="solid">New project</Button>}
 />;
 ```
 

--- a/apps/web/docs/components/templates/page-header.mdx
+++ b/apps/web/docs/components/templates/page-header.mdx
@@ -17,7 +17,7 @@ import { PageHeader } from '@jbpark/ui-kit';
   title="Project settings"
   subTitle="Manage your project configuration"
   onBack={() => history.back()}
-  extra={<Button type="primary">Save</Button>}
+  extra={<Button variant="solid">Save</Button>}
 />;
 ```
 

--- a/apps/web/docs/components/templates/result.mdx
+++ b/apps/web/docs/components/templates/result.mdx
@@ -17,7 +17,7 @@ import { Result } from '@jbpark/ui-kit';
   status="success"
   title="Payment successful"
   subTitle="Order #2024-0815 has been confirmed."
-  extra={<Button type="primary">Back home</Button>}
+  extra={<Button variant="solid">Back home</Button>}
 />;
 ```
 

--- a/apps/web/src/demo/button-demo.tsx
+++ b/apps/web/src/demo/button-demo.tsx
@@ -26,7 +26,7 @@ export default function ButtonDemo() {
       </Space>
       <Space wrap align="center">
         {COLORS.map(color => (
-          <Button key={color} type="primary" color={color}>
+          <Button key={color} variant="solid" color={color}>
             {color}
           </Button>
         ))}

--- a/apps/web/src/demo/drawer-demo.tsx
+++ b/apps/web/src/demo/drawer-demo.tsx
@@ -7,7 +7,7 @@ export default function DrawerDemo() {
 
   return (
     <>
-      <Button type="primary" onClick={() => setOpen(true)}>
+      <Button variant="solid" onClick={() => setOpen(true)}>
         Open drawer
       </Button>
       <Drawer
@@ -17,7 +17,7 @@ export default function DrawerDemo() {
         direction="right"
         size="small"
         footer={
-          <Button type="primary" onClick={() => setOpen(false)}>
+          <Button variant="solid" onClick={() => setOpen(false)}>
             Done
           </Button>
         }

--- a/apps/web/src/demo/empty-demo.tsx
+++ b/apps/web/src/demo/empty-demo.tsx
@@ -5,7 +5,7 @@ export default function EmptyDemo() {
     <Empty
       title="No projects yet"
       description="Create your first project to get started."
-      action={<Button type="primary">New project</Button>}
+      action={<Button variant="solid">New project</Button>}
     />
   );
 }

--- a/apps/web/src/demo/modal-demo.tsx
+++ b/apps/web/src/demo/modal-demo.tsx
@@ -7,7 +7,7 @@ export default function ModalDemo() {
 
   return (
     <Space>
-      <Button type="primary" onClick={() => setOpen(true)}>
+      <Button variant="solid" onClick={() => setOpen(true)}>
         Open modal
       </Button>
       <Button

--- a/apps/web/src/demo/page-header-demo.tsx
+++ b/apps/web/src/demo/page-header-demo.tsx
@@ -6,7 +6,7 @@ export default function PageHeaderDemo() {
       title="Project settings"
       subTitle="Manage your project configuration"
       onBack={() => {}}
-      extra={<Button type="primary">Save</Button>}
+      extra={<Button variant="solid">Save</Button>}
     />
   );
 }

--- a/apps/web/src/demo/result-demo.tsx
+++ b/apps/web/src/demo/result-demo.tsx
@@ -6,7 +6,7 @@ export default function ResultDemo() {
       status="success"
       title="Payment successful"
       subTitle="Order #2024-0815 has been confirmed."
-      extra={<Button type="primary">Back home</Button>}
+      extra={<Button variant="solid">Back home</Button>}
     />
   );
 }

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -128,7 +128,7 @@ export default function Home() {
               <InstallCommand />
               <div className="flex gap-3">
                 <Button
-                  type="primary"
+                  variant="solid"
                   icon={<BookOpen size={16} />}
                   onClick={() => window.open(DOCS_URL, '_blank')}
                 >

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -39,11 +39,32 @@ export interface Props extends Omit<
   disabled?: boolean;
   size?: 'small' | 'middle' | 'large';
   /**
-   * antd-style visual preset. Maps to a `variant` internally — passing
-   * both `type` and `variant` lets `variant` win, so it can override the
-   * preset for one-off cases without needing every value duplicated here.
+   * @deprecated Use `variant` instead. `type` is an alias kept for backwards
+   * compatibility and will be removed in the next major.
+   *
+   * The two props address the same axis, and 3 of the 5 values (`dashed`,
+   * `text`, `link`) are already spelled identically — `<Button type="text">`
+   * and `<Button variant="text">` render the same thing. The only values
+   * `type` contributes are the aliases `primary` → `solid` and
+   * `default` → `outlined`. `variant` additionally offers `filled`, which
+   * `type` cannot express.
+   *
+   * Migration:
+   * | `type`    | `variant`   |
+   * | --------- | ----------- |
+   * | `primary` | `solid`     |
+   * | `default` | `outlined`  |
+   * | `dashed`  | `dashed`    |
+   * | `text`    | `text`      |
+   * | `link`    | `link`      |
+   *
+   * Passing both still lets `variant` win.
    */
   type?: 'primary' | 'default' | 'dashed' | 'text' | 'link';
+  /**
+   * Visual fill style. This is the canonical prop — prefer it over `type`.
+   * Defaults to `'outlined'` (matching the legacy `type="default"`).
+   */
   variant?: 'solid' | 'outlined' | 'dashed' | 'filled' | 'text' | 'link';
   /**
    * Native `<button>` `type` (`button`/`submit`/`reset`), kept separate
@@ -131,7 +152,7 @@ const shapesClasses = {
 const Button = ({
   icon,
   className,
-  type = 'default',
+  type,
   variant,
   htmlType = 'button',
   size,
@@ -154,7 +175,12 @@ const Button = ({
   const iconOnly = icon && !children;
   const computedColor = danger ? 'danger' : color;
   const colored = computedColor && computedColor !== 'default';
-  const resolvedVariant = variant ?? typeToVariant[type] ?? 'solid';
+  // `variant` is canonical; `type` is a deprecated alias resolved through
+  // typeToVariant. The default lives here (not on the `type` parameter) so the
+  // deprecated prop stays off the default path — a Button with neither prop
+  // resolves straight to 'outlined'.
+  const resolvedVariant =
+    variant ?? (type ? typeToVariant[type] : undefined) ?? 'outlined';
   const isLoading = !!loading;
 
   const Comp = asChild ? Slot : 'button';

--- a/packages/ui/src/components/atoms/date-picker.tsx
+++ b/packages/ui/src/components/atoms/date-picker.tsx
@@ -55,7 +55,6 @@ const DatePicker = ({
       }
     >
       <Button
-        type="default"
         icon={<CalendarIcon />}
         data-empty={!value}
         disabled={disabled}

--- a/packages/ui/src/components/molecules/upload.tsx
+++ b/packages/ui/src/components/molecules/upload.tsx
@@ -193,7 +193,7 @@ const Upload = ({
               )}
               <span className="flex-1 truncate text-sm">{file.name}</span>
               <Button
-                type="text"
+                variant="text"
                 shape="circle"
                 size="small"
                 icon={<X className="size-4" />}

--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -201,7 +201,7 @@ const Drawer = ({
           <div className="flex items-start gap-2">
             {closable && (
               <Button
-                type="text"
+                variant="text"
                 shape="circle"
                 size="small"
                 aria-label={locale.close ?? DEFAULT_LOCALE.close}

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -78,7 +78,7 @@ const Toast = ({
       </div>
       {closable && (
         <Button
-          type="text"
+          variant="text"
           shape="circle"
           size="small"
           aria-label={locale.close ?? DEFAULT_LOCALE.close}

--- a/packages/ui/src/components/templates/page-header.tsx
+++ b/packages/ui/src/components/templates/page-header.tsx
@@ -42,7 +42,7 @@ const PageHeader = ({
       <div className="flex items-start gap-2">
         {onBack && (
           <Button
-            type="text"
+            variant="text"
             shape="circle"
             size="small"
             aria-label={locale.back ?? DEFAULT_LOCALE.back}


### PR DESCRIPTION
Follow-up to #278. Option A from the discussion — deprecate rather than remove, so this stays non-breaking.

## Problem

`type` and `variant` address the same axis and largely duplicate each other:

| `type` | → `variant` | relationship |
| --- | --- | --- |
| `primary` | `solid` | alias |
| `default` | `outlined` | alias |
| `dashed` | `dashed` | **identical** |
| `text` | `text` | **identical** |
| `link` | `link` | **identical** |

3 of the 5 values are spelled identically, so `<Button type="text">` and `<Button variant="text">` already render exactly the same thing. `type` only contributes the two aliases `primary` → `solid` and `default` → `outlined`, while `variant` additionally offers `filled`, which `type` cannot express.

The result is that a new user has to stop and ask which of the two to reach for, with no answer that holds.

## Change

- `type` is marked `@deprecated` with an in-editor migration table; `variant` is documented as canonical.
- **The default moved off the deprecated prop.** It used to sit on the parameter (`type = 'default'`), which meant every Button with no props at all routed through the deprecated path. Resolution now falls back directly:

```diff
-  const resolvedVariant = variant ?? typeToVariant[type] ?? 'solid';
+  const resolvedVariant =
+    variant ?? (type ? typeToVariant[type] : undefined) ?? 'outlined';
```

- The 18 internal `type=` usages across `packages/ui`, `apps/web` and `apps/docs` are migrated to `variant=`, dropped entirely where they matched the default (`date-picker.tsx` had `type="default"`).
- `apps/web`'s Button docs: props table reordered with `variant` first and `type` struck through, plus a migration table.

## Runtime behaviour is unchanged

Verified by rendering both spellings and comparing the emitted class strings:

```
✓ no props            === variant=outlined
✓ type=default        === variant=outlined
✓ type=primary        === variant=solid
✓ type=text           === variant=text
✓ type=link           === variant=link
✓ type=dashed         === variant=dashed
✓ type=primary + variant=filled === variant=filled   (variant still wins)
```

The `'solid'` → `'outlined'` change in the fallback literal looks like a behaviour change but is not: the old code only reached that fallback when `type` was an unknown value, and `type = 'default'` on the parameter meant the real default was always `typeToVariant['default']` = `'outlined'`. Every combination was enumerated and compared before and after.

## Why deprecate instead of remove

Removing `type` now would be breaking, and `6.0.0` shipped hours ago — that would mean a second major immediately. Deprecating costs nothing at runtime, surfaces the guidance in editors today, and leaves removal for the next major.

Worth noting no code in this repo ever passed both props together, so the "`variant` wins" precedence rule has never actually fired in practice.

## Verification

- `pnpm lint`, `pnpm check-types`, `pnpm build` pass across all 3 workspaces
- Regression net passes — `api-surface` (41 names, 12 subpaths), `preflight-reset`, `ssr-smoke` with `data-slot [button, col] present, Button/Tag chassis intact`
- Rendered-output equivalence table above
