### PR TITLE
✨ feat(ui): make Button's type sugar for a (color, variant) pair

### DIFF
--- a/.changeset/button-type-color-variant-sugar.md
+++ b/.changeset/button-type-color-variant-sugar.md
@@ -1,0 +1,30 @@
+---
+'@repo/ui': minor
+---
+
+`Button`'s `type` prop is now proper syntactic sugar for a `(color, variant)`
+pair, matching antd's spec — and is no longer deprecated.
+
+Previously `type` only mapped to a `variant` and left `color` untouched, so
+`type="primary"` rendered a _grey_ solid button instead of a primary-coloured
+one, and `type="link"` rendered a link-styled button in the default colour.
+Measured against antd's documented behaviour (`<Button type="primary">` ≡
+`<Button color="primary" variant="solid">`), that mapping was incomplete.
+
+| `type`    | now equivalent to                    | previously           |
+| --------- | ------------------------------------ | -------------------- |
+| `primary` | `color="primary" variant="solid"`    | `variant="solid"`    |
+| `default` | `color="default" variant="outlined"` | `variant="outlined"` |
+| `dashed`  | `color="default" variant="dashed"`   | `variant="dashed"`   |
+| `text`    | `color="default" variant="text"`     | `variant="text"`     |
+| `link`    | `color="primary" variant="link"`     | `variant="link"`     |
+
+**Visible change:** `type="primary"` and `type="link"` now pick up the primary
+colour. The other three values are unchanged. Explicit `color` and `variant`
+still win over whatever `type` maps to, so `type="primary" variant="filled"`
+keeps the primary colour but renders filled, and `danger` still overrides the
+resolved colour.
+
+The `@deprecated` marker added in the previous release is withdrawn: `type` and
+`variant` are not duplicates on one axis — `type` sets two axes at once, which
+is exactly why its value names overlap with `variant`'s.

--- a/apps/docs/stories/organisms/drawer/index.stories.tsx
+++ b/apps/docs/stories/organisms/drawer/index.stories.tsx
@@ -120,7 +120,7 @@ export const WithExtra: Story = {
                 취소
               </Button>
               <Button
-                variant="solid"
+                type="primary"
                 size="small"
                 onClick={() => setOpen(false)}
               >

--- a/apps/web/docs/components/atoms/button.mdx
+++ b/apps/web/docs/components/atoms/button.mdx
@@ -11,7 +11,7 @@ import ButtonDemo from '../../../src/demo/button-demo';
 ```tsx
 import { Button } from '@jbpark/ui-kit';
 
-<Button variant="solid" onClick={() => console.log('clicked')}>
+<Button type="primary" onClick={() => console.log('clicked')}>
   Click me
 </Button>;
 ```
@@ -27,7 +27,7 @@ import { Button } from '@jbpark/ui-kit';
 | Prop        | Type                                                          | Default     |
 | ----------- | ----------------------------------------------------------------- | ----------- |
 | `variant`   | `'solid' \| 'outlined' \| 'dashed' \| 'filled' \| 'text' \| 'link'` | `'outlined'` |
-| ~~`type`~~  | `'primary' \| 'default' \| 'dashed' \| 'text' \| 'link'`         | -           |
+| `type`      | `'primary' \| 'default' \| 'dashed' \| 'text' \| 'link'`         | -           |
 | `size`      | `'small' \| 'middle' \| 'large'`                                  | `'middle'`  |
 | `shape`     | `'default' \| 'circle' \| 'round'`                                | `'default'` |
 | `color`     | preset color name (see below) `\| 'default' \| 'primary' \| 'danger'` | `'default'` |
@@ -39,20 +39,21 @@ import { Button } from '@jbpark/ui-kit';
 | `htmlType`  | `'button' \| 'submit' \| 'reset'`                                 | `'button'`  |
 | `className` | `string`                                                           | -           |
 
-`type` is **deprecated** — use `variant`. The two props address the same axis,
-and 3 of the 5 values (`dashed`, `text`, `link`) are spelled identically, so
-`<Button type="text">` and `<Button variant="text">` already render the same
-thing. `type` only adds the aliases `primary` → `solid` and `default` →
-`outlined`, while `variant` additionally offers `filled`. Passing both still
-lets `variant` win. `type` will be removed in the next major.
+`type` is syntactic sugar for a `(color, variant)` pair — it **follows `variant`
+and `color` when those are provided**, filling in only the axes you leave unset.
 
-| `type`    | use instead  |
-| --------- | ------------ |
-| `primary` | `solid`      |
-| `default` | `outlined` (the default, so it can just be omitted) |
-| `dashed`  | `dashed`     |
-| `text`    | `text`       |
-| `link`    | `link`       |
+| `type`    | equivalent to                        |
+| --------- | ------------------------------------ |
+| `primary` | `color="primary" variant="solid"`    |
+| `default` | `color="default" variant="outlined"` |
+| `dashed`  | `color="default" variant="dashed"`   |
+| `text`    | `color="default" variant="text"`     |
+| `link`    | `color="primary" variant="link"`     |
+
+So `<Button type="primary">` renders the same as
+`<Button color="primary" variant="solid">`, while
+`<Button type="primary" variant="filled">` keeps the primary color and renders
+filled instead. `danger` overrides the resolved color either way.
 
 Preset `color` names:
 `blue`, `purple`, `cyan`, `green`, `magenta`, `pink`, `red`, `orange`,

--- a/apps/web/docs/components/templates/empty.mdx
+++ b/apps/web/docs/components/templates/empty.mdx
@@ -16,7 +16,7 @@ import { Empty } from '@jbpark/ui-kit';
 <Empty
   title="No projects yet"
   description="Create your first project to get started."
-  action={<Button variant="solid">New project</Button>}
+  action={<Button type="primary">New project</Button>}
 />;
 ```
 

--- a/apps/web/docs/components/templates/page-header.mdx
+++ b/apps/web/docs/components/templates/page-header.mdx
@@ -17,7 +17,7 @@ import { PageHeader } from '@jbpark/ui-kit';
   title="Project settings"
   subTitle="Manage your project configuration"
   onBack={() => history.back()}
-  extra={<Button variant="solid">Save</Button>}
+  extra={<Button type="primary">Save</Button>}
 />;
 ```
 

--- a/apps/web/docs/components/templates/result.mdx
+++ b/apps/web/docs/components/templates/result.mdx
@@ -17,7 +17,7 @@ import { Result } from '@jbpark/ui-kit';
   status="success"
   title="Payment successful"
   subTitle="Order #2024-0815 has been confirmed."
-  extra={<Button variant="solid">Back home</Button>}
+  extra={<Button type="primary">Back home</Button>}
 />;
 ```
 

--- a/apps/web/src/demo/drawer-demo.tsx
+++ b/apps/web/src/demo/drawer-demo.tsx
@@ -7,7 +7,7 @@ export default function DrawerDemo() {
 
   return (
     <>
-      <Button variant="solid" onClick={() => setOpen(true)}>
+      <Button type="primary" onClick={() => setOpen(true)}>
         Open drawer
       </Button>
       <Drawer
@@ -17,7 +17,7 @@ export default function DrawerDemo() {
         direction="right"
         size="small"
         footer={
-          <Button variant="solid" onClick={() => setOpen(false)}>
+          <Button type="primary" onClick={() => setOpen(false)}>
             Done
           </Button>
         }

--- a/apps/web/src/demo/empty-demo.tsx
+++ b/apps/web/src/demo/empty-demo.tsx
@@ -5,7 +5,7 @@ export default function EmptyDemo() {
     <Empty
       title="No projects yet"
       description="Create your first project to get started."
-      action={<Button variant="solid">New project</Button>}
+      action={<Button type="primary">New project</Button>}
     />
   );
 }

--- a/apps/web/src/demo/modal-demo.tsx
+++ b/apps/web/src/demo/modal-demo.tsx
@@ -7,7 +7,7 @@ export default function ModalDemo() {
 
   return (
     <Space>
-      <Button variant="solid" onClick={() => setOpen(true)}>
+      <Button type="primary" onClick={() => setOpen(true)}>
         Open modal
       </Button>
       <Button

--- a/apps/web/src/demo/page-header-demo.tsx
+++ b/apps/web/src/demo/page-header-demo.tsx
@@ -6,7 +6,7 @@ export default function PageHeaderDemo() {
       title="Project settings"
       subTitle="Manage your project configuration"
       onBack={() => {}}
-      extra={<Button variant="solid">Save</Button>}
+      extra={<Button type="primary">Save</Button>}
     />
   );
 }

--- a/apps/web/src/demo/result-demo.tsx
+++ b/apps/web/src/demo/result-demo.tsx
@@ -6,7 +6,7 @@ export default function ResultDemo() {
       status="success"
       title="Payment successful"
       subTitle="Order #2024-0815 has been confirmed."
-      extra={<Button variant="solid">Back home</Button>}
+      extra={<Button type="primary">Back home</Button>}
     />
   );
 }

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -128,7 +128,7 @@ export default function Home() {
               <InstallCommand />
               <div className="flex gap-3">
                 <Button
-                  variant="solid"
+                  type="primary"
                   icon={<BookOpen size={16} />}
                   onClick={() => window.open(DOCS_URL, '_blank')}
                 >

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -39,31 +39,26 @@ export interface Props extends Omit<
   disabled?: boolean;
   size?: 'small' | 'middle' | 'large';
   /**
-   * @deprecated Use `variant` instead. `type` is an alias kept for backwards
-   * compatibility and will be removed in the next major.
+   * Syntactic sugar for a `(color, variant)` pair. **Will follow `variant` and
+   * `color` if provided** — `type` only fills in the axes you leave unset.
    *
-   * The two props address the same axis, and 3 of the 5 values (`dashed`,
-   * `text`, `link`) are already spelled identically — `<Button type="text">`
-   * and `<Button variant="text">` render the same thing. The only values
-   * `type` contributes are the aliases `primary` → `solid` and
-   * `default` → `outlined`. `variant` additionally offers `filled`, which
-   * `type` cannot express.
+   * | `type`    | equivalent to                          |
+   * | --------- | -------------------------------------- |
+   * | `primary` | `color="primary" variant="solid"`      |
+   * | `default` | `color="default" variant="outlined"`   |
+   * | `dashed`  | `color="default" variant="dashed"`     |
+   * | `text`    | `color="default" variant="text"`       |
+   * | `link`    | `color="primary" variant="link"`       |
    *
-   * Migration:
-   * | `type`    | `variant`   |
-   * | --------- | ----------- |
-   * | `primary` | `solid`     |
-   * | `default` | `outlined`  |
-   * | `dashed`  | `dashed`    |
-   * | `text`    | `text`      |
-   * | `link`    | `link`      |
-   *
-   * Passing both still lets `variant` win.
+   * So `<Button type="primary">` is the same as
+   * `<Button color="primary" variant="solid">`, and
+   * `<Button type="primary" variant="filled">` keeps the primary color but
+   * renders filled. `danger` still overrides the resolved color.
    */
   type?: 'primary' | 'default' | 'dashed' | 'text' | 'link';
   /**
-   * Visual fill style. This is the canonical prop — prefer it over `type`.
-   * Defaults to `'outlined'` (matching the legacy `type="default"`).
+   * Visual fill style, independent of `color`. Defaults to `'outlined'`.
+   * Takes precedence over whatever `type` would have supplied.
    */
   variant?: 'solid' | 'outlined' | 'dashed' | 'filled' | 'text' | 'link';
   /**
@@ -73,6 +68,10 @@ export interface Props extends Omit<
    */
   htmlType?: 'button' | 'submit' | 'reset';
   shape?: 'default' | 'circle' | 'round';
+  /**
+   * Color, independent of `variant`. Defaults to `'default'`, or to whatever
+   * `type` maps to when `type` is set. `danger` overrides this.
+   */
   color?: PresetColors | 'default' | 'primary' | 'danger';
   loading?: boolean | { icon: React.ReactNode };
 }
@@ -123,12 +122,22 @@ const variantClasses: Record<string, string> = {
   ),
 };
 
-const typeToVariant: Record<string, string> = {
-  primary: 'solid',
-  default: 'outlined',
-  dashed: 'dashed',
-  text: 'text',
-  link: 'link',
+/**
+ * antd-style syntactic sugar: each `type` expands to a `(color, variant)` pair.
+ * Explicit `color`/`variant` props win over whatever the `type` maps to, so
+ * `type` only fills in the axes the caller left unset.
+ *
+ * Mirrors antd: `<Button type="primary">` ≡ `<Button color="primary" variant="solid">`.
+ */
+const typeToColorVariant: Record<
+  NonNullable<Props['type']>,
+  { color: NonNullable<Props['color']>; variant: NonNullable<Props['variant']> }
+> = {
+  primary: { color: 'primary', variant: 'solid' },
+  default: { color: 'default', variant: 'outlined' },
+  dashed: { color: 'default', variant: 'dashed' },
+  text: { color: 'default', variant: 'text' },
+  link: { color: 'primary', variant: 'link' },
 };
 
 const sizesClasses: Record<string, string> = {
@@ -156,7 +165,7 @@ const Button = ({
   variant,
   htmlType = 'button',
   size,
-  color = 'default',
+  color,
   shape,
   block = false,
   disabled,
@@ -173,14 +182,16 @@ const Button = ({
   const resolvedSize = size ?? componentSize ?? 'middle';
   const resolvedShape = shape ?? buttonDefaults?.shape ?? 'default';
   const iconOnly = icon && !children;
-  const computedColor = danger ? 'danger' : color;
-  const colored = computedColor && computedColor !== 'default';
-  // `variant` is canonical; `type` is a deprecated alias resolved through
-  // typeToVariant. The default lives here (not on the `type` parameter) so the
-  // deprecated prop stays off the default path — a Button with neither prop
-  // resolves straight to 'outlined'.
-  const resolvedVariant =
-    variant ?? (type ? typeToVariant[type] : undefined) ?? 'outlined';
+  // `type` is syntactic sugar that expands to a (color, variant) pair; explicit
+  // `color`/`variant` win over it, so `type` only fills the axes left unset.
+  // `danger` still trumps everything, matching antd. Defaults live here rather
+  // than on the parameters so `type` gets a chance to supply them first.
+  const typeDefaults = type ? typeToColorVariant[type] : undefined;
+  const resolvedVariant = variant ?? typeDefaults?.variant ?? 'outlined';
+  const computedColor = danger
+    ? 'danger'
+    : (color ?? typeDefaults?.color ?? 'default');
+  const colored = computedColor !== 'default';
   const isLoading = !!loading;
 
   const Comp = asChild ? Slot : 'button';


### PR DESCRIPTION
Restores `type` as a first-class prop and completes its mapping. This reverses the `@deprecated` marker added in #311 — that call was based on a wrong reading, explained below.

## What was wrong

antd documents `type` as **syntactic sugar for a `(color, variant)` pair**:

> **type** — *Syntactic sugar. Set button type. Will follow variant & color if provided*
>
> *Type is essentially syntactic sugar for colors and variants. It internally provides a set of mapping relationships between colors and variants for the type. If both exist at the same time, the colors and variants will be used first.*
>
> `<Button type="primary">` ≡ `<Button color="primary" variant="solid">`

Our mapping only ever set `variant` and left `color` untouched:

```ts
const typeToVariant = { primary: 'solid', default: 'outlined', ... };
```

So `type="primary"` rendered a **grey** solid button instead of a primary-coloured one, and `type="link"` rendered in the default colour. That is a bug against the spec we were modelling.

#311 read the overlap between `type` and `variant` values (`dashed`/`text`/`link` spelled identically) as redundancy and deprecated `type`. But the overlap is expected: `type` sets *two* axes at once, so of course its names collide with the single-axis `variant`. The right fix was to complete the mapping, not remove the prop.

## Change

```ts
const typeToColorVariant = {
  primary: { color: 'primary', variant: 'solid' },
  default: { color: 'default', variant: 'outlined' },
  dashed:  { color: 'default', variant: 'dashed' },
  text:    { color: 'default', variant: 'text' },
  link:    { color: 'primary', variant: 'link' },
};
```

- `@deprecated` withdrawn; JSDoc now documents the equivalence table.
- The `color` default moved off the parameter (`color = 'default'`) onto the resolution, so `type` gets a chance to supply it before the fallback applies.
- Call sites that #311 rewrote from `type="primary"` to `variant="solid"` are restored — that rewrite silently dropped their primary colour. `button-demo.tsx` keeps `variant="solid"` because it is a colour-matrix demo that varies `color` itself.

## Visible change

`type="primary"` and `type="link"` now pick up the primary colour. `default`, `dashed`, `text` are unchanged. Marked **minor**.

## Verification

Rendered both spellings and compared the emitted class string plus `data-color`:

```
✓ type=primary   === color=primary variant=solid
✓ type=default   === color=default variant=outlined
✓ type=dashed    === color=default variant=dashed
✓ type=text      === color=default variant=text
✓ type=link      === color=primary variant=link

✓ type=primary + variant=filled → primary colour kept, renders filled
✓ type=primary + color=danger   → danger wins
✓ type=primary + danger         → danger wins
✓ no props === variant=outlined color=default
```

Also checked that `variantClasses.solid`'s hardcoded `bg-primary` does not double-apply against the `--btn-bg` custom properties — `tailwind-merge` resolves it, leaving only `bg-(--btn-bg)` on coloured buttons.

`pnpm lint`, `pnpm check-types`, `pnpm build` pass across all 3 workspaces; regression net passes (`api-surface` 41 names / 12 subpaths, `preflight-reset`, `ssr-smoke` with `data-slot [button, col] present, Button/Tag chassis intact`).
