### PR TITLE
🐛 fix(ui): reset list-item margins so horizontal Radio.Group's first option stays aligned

### DIFF
--- a/.changeset/list-item-margin-reset.md
+++ b/.changeset/list-item-margin-reset.md
@@ -1,0 +1,25 @@
+---
+'@repo/ui': patch
+---
+
+`Radio.Group`'s first option no longer looks misaligned in horizontal
+orientation on hosts that style prose lists.
+
+The `<ul>` these groups render already reset `margin`/`padding`/`list-style`
+(#253), but their `<li>` children did not. Without preflight, a host's own
+list rules still reach the items — Docusaurus/Infima ships
+`.markdown li + li { margin-top: 0.25rem }`, which gives every option but the
+first a top margin. In a horizontal (flex-row) group that pushes options 2..n
+down 4px and stretches the first item's flex line, so the first radio sits
+higher than the rest; with `optionType="button"` the first segment ends up 4px
+taller than its neighbours. Measured on this repo's own docs site: item 1 at
+`y=288.3, h=23.3` vs items 2/3 at `y=292.3, h=19.3`.
+
+The list items in `Radio.Group`, `Checkbox.Group`, `Menu` and `Upload` now
+carry that `m-0` reset themselves. `classNames.wrapper`/`classNames.item`
+still win, so per-item margins remain overridable.
+
+`Checkbox.Group` also spaces its options with `flex` + `gap` in both
+orientations instead of `space-y-2` when vertical. `space-y` works by putting
+margins _on the children_, which is exactly what the new reset clears — the
+rendered spacing (8px) is unchanged.

--- a/packages/ui/src/components/atoms/checkbox/group.tsx
+++ b/packages/ui/src/components/atoms/checkbox/group.tsx
@@ -66,8 +66,11 @@ const Group = ({
     <ul
       {...props}
       className={cn(
-        'm-0 list-none p-0',
-        orientation === 'vertical' ? 'space-y-2' : 'flex gap-2',
+        // Spacing comes from `gap`, not `space-y`'s child margins, so the
+        // per-item `m-0` reset below can neutralise host list styles without
+        // also wiping out the group's own spacing.
+        'm-0 flex list-none gap-2 p-0',
+        orientation === 'vertical' && 'flex-col',
         className,
       )}
     >
@@ -77,7 +80,9 @@ const Group = ({
         return (
           <li
             key={`${index}-${String(item.value)}`}
-            className={cn('flex', classNames?.wrapper)}
+            // `m-0` completes the list reset the `ul` above starts (#253) —
+            // see Radio.Group for the host rule this guards against.
+            className={cn('m-0 flex', classNames?.wrapper)}
           >
             <Checkbox
               placement={placement}

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -110,7 +110,13 @@ const RadioGroup = ({
         return (
           <li
             key={`${index}-${String(item.value)}`}
-            className={cn('flex', classNames?.wrapper)}
+            // `m-0` completes the list reset the `ul` above starts (#253):
+            // without preflight, hosts that style prose lists still reach the
+            // items — Docusaurus/Infima's `.markdown li + li` gives every item
+            // but the first a `margin-top`, which in horizontal orientation
+            // drops options 2..n by that much and stretches the first one,
+            // making it look misaligned.
+            className={cn('m-0 flex', classNames?.wrapper)}
           >
             {isButton ? (
               // `asChild` gives the Button real radio semantics (role,

--- a/packages/ui/src/components/molecules/menu/item/item.tsx
+++ b/packages/ui/src/components/molecules/menu/item/item.tsx
@@ -200,6 +200,9 @@ const Item = ({
       className={cn(
         'group',
         'relative',
+        // `m-0` completes MENU_CLASSNAMES' list reset — see Radio.Group for
+        // the host rule (`.markdown li + li`) this guards against.
+        'm-0',
         root && isHorizontal ? 'inline-block' : 'block',
       )}
       onMouseEnter={() => {

--- a/packages/ui/src/components/molecules/upload.tsx
+++ b/packages/ui/src/components/molecules/upload.tsx
@@ -179,7 +179,9 @@ const Upload = ({
             <li
               key={file.uid}
               className={cn(
-                'flex items-center gap-2 rounded-md border p-2',
+                // `m-0` completes the list reset the `ul` above starts — see
+                // Radio.Group for the host rule this guards against.
+                'm-0 flex items-center gap-2 rounded-md border p-2',
                 classNames?.item,
                 //
               )}


### PR DESCRIPTION
## Summary

In horizontal orientation, `Radio.Group`'s first option looked misaligned — it
sat higher than the rest, and with `optionType="button"` its segment rendered
taller than its neighbours.

This is **not reproducible in Storybook**. It only shows up on hosts that style
prose lists, such as this repo's own Docusaurus site.

`Radio.Group` renders `<ul>` → `<li>`. The `<ul>` already resets
`margin`/`padding`/`list-style` (#253), but the `<li>` children did not. Since
the library deliberately drops Tailwind preflight (#252/#253), a host's own list
rules still reach the items. Docusaurus/Infima ships:

```css
.markdown li + li { margin-top: var(--ifm-list-item-margin); /* 0.25rem */ }
```

That gives every option **but the first** a `margin-top: 4px`. In a flex-row
group, options 2..n drop by 4px while the first item stretches to fill the flex
line — hence the first one looking off.

Measured on `/docs/components/atoms/radio` before the fix:

| | item 1 | items 2 & 3 |
| --- | --- | --- |
| `optionType="default"` | `y=288.3, h=23.3, mt=0` | `y=292.3, h=19.3, mt=4px` |
| `optionType="button"` | `y=343.5, h=36` | `y=347.5, h=32` |

## Changes

- `Radio.Group`: add the `m-0` list reset to the `<li>` items themselves.
  `classNames.wrapper` still comes last in `cn()`, so per-item margins stay
  overridable.
- `Checkbox.Group`, `Menu`, `Upload`: same leak, same fix — their list items
  carry the reset too. Horizontal `Menu` had the identical symptom.
- `Checkbox.Group` now spaces options with `flex` + `gap-2` in **both**
  orientations instead of `space-y-2` when vertical. `space-y` works by putting
  margins *on the children*, which is exactly what the new reset clears; `gap`
  is immune and matches how `Radio.Group` already does it. Rendered spacing is
  unchanged at 8px.
- Add a patch changeset.

## Type of Change

- [ ] ✨ feat — new feature
- [x] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

Verified by re-measuring the live Docusaurus docs site rather than by eye, since
the offset is 4px.

After the fix, on `/docs/components/atoms/radio`:

- default: all three items at `y=591.3, h=19.3, mt=0px`
- `optionType="button"`: all three at `y=642.5, h=32`

`Checkbox.Group` spacing after switching to `gap`:

- vertical: items at `y=588.6 / 612.6 / 636.6` → 8px apart, same as before
- horizontal: 8px apart, unchanged

## Checklist

- [x] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [x] Storybook stories are added for new components / features — n/a, no new
      component; existing Radio/Checkbox/Menu stories checked for regressions
      (vertical, horizontal, and button style all measured unchanged)
- [x] No type or lint errors (`pnpm --filter @repo/ui check-types`, `lint`)
- [x] Build completes successfully (`pnpm --filter @repo/ui build`), plus
      `pnpm check-dynamic-classes` and `pnpm check-regression-net`

## Note on specificity

`m-0` wins here because Infima's rule lives inside a cascade layer. A host that
sets `li + li` margins *outside* a layer with higher specificity could still
push the items. That's the same exposure the existing `<ul>` reset has, so this
follows the established policy rather than reaching for `!`.
