### PR TITLE
✨ feat(ui): let Space honour the global componentSize contract (#317)

### DIFF
--- a/.changeset/space-honors-componentsize.md
+++ b/.changeset/space-honors-componentsize.md
@@ -1,0 +1,9 @@
+---
+'@repo/ui': minor
+---
+
+`Space` now honours the global `componentSize` from `Config`. When `size` is
+left unset it falls back to `<Config componentSize>` before the built-in
+`middle`, matching `Button`'s resolution order — so a single
+`<Config componentSize="large">` sizes both. An explicit `size` (including
+numeric/array gaps) still wins, so this is non-breaking (ui-kit#317).

--- a/packages/ui/src/components/molecules/space.tsx
+++ b/packages/ui/src/components/molecules/space.tsx
@@ -1,5 +1,6 @@
 import { Children } from 'react';
 
+import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import Skeleton from '../atoms/skeleton';
@@ -35,7 +36,7 @@ const Space = ({
   loading,
   loader,
   children,
-  size = 'middle',
+  size,
   orientation = 'horizontal',
   align = 'center',
   wrap = false,
@@ -46,12 +47,17 @@ const Space = ({
   style,
   ...props
 }: Props) => {
+  const { componentSize } = useConfig();
+  // `size` overrides the global `componentSize` from `Config`, which in turn
+  // falls back to `middle` — the same resolution order `Button` uses so a single
+  // `<Config componentSize>` sizes both. Numeric/array gaps bypass the token.
+  const resolvedSize = size ?? componentSize ?? 'middle';
   const [x, y] =
-    typeof size === 'string'
-      ? sizes[size] || [0, 0]
-      : Array.isArray(size)
-        ? size
-        : [size, size];
+    typeof resolvedSize === 'string'
+      ? sizes[resolvedSize] || [0, 0]
+      : Array.isArray(resolvedSize)
+        ? resolvedSize
+        : [resolvedSize, resolvedSize];
   const count = Children.count(children);
 
   if (loading) {


### PR DESCRIPTION
## What

`Space` now honours the global `componentSize` from `Config`. When `size` is left unset it resolves `size ?? componentSize ?? 'middle'` — the same order `Button` already uses — so a single `<Config componentSize="large">` sizes both instead of leaving `Space` on its own default.

Closes #317 (split out of #314, Idea 4).

## Scope decision

#317 originally listed four components. Reading the actual code, only `Space` cleanly shares the `ComponentSize` (`'small' | 'middle' | 'large'`) contract, so this PR narrows to it:

- **`Space`** — ✅ same vocabulary; wired here.
- **`Radio.Group`** — already honours it: in `optionType="button"` mode it forwards `size` to `Button`, which resolves `componentSize` when `size` is unset; in default mode `size` isn't applied. No change needed.
- **`Switch`** — out of scope. Its `size` is `'small' | 'medium'` (note `medium`, no `middle`/`large`), a different 2-step vocabulary that can't take a `ComponentSize` value without a mapping decision.
- **`Drawer`** — out of scope. Its `size` (`'small' | 'medium' | 'large' | 'full' | string`) is a spatial panel dimension, not a control-density token; inheriting `componentSize` would be semantically wrong.

Reconciling `Switch`'s vocabulary with `ComponentSize` can be filed separately if wanted; `Drawer` is intentionally excluded.

## Risk

Non-breaking. An explicit `size` (including numeric / array gaps) still wins over `componentSize`, so existing usage is unaffected; only the previously-hardcoded `middle` default now defers to `Config` first.

## Verify

- `check-types`, `lint`, full monorepo `build` (ui + docs + web), and the regression net all pass locally.
- `<Config componentSize="large">` now visibly widens `Space` gaps; explicit `size` overrides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
