### PR TITLE
✨ feat(ui): unify Modal/Toast semantic axis under status (#318)

### DIFF
--- a/.changeset/modal-toast-status-alias.md
+++ b/.changeset/modal-toast-status-alias.md
@@ -1,0 +1,13 @@
+---
+'@repo/ui': minor
+---
+
+Unify the semantic-state axis under `status`. `Modal` and `Toast` now take a
+`status` prop (`info | success | error | warning`), matching `Result`'s
+vocabulary, instead of spelling the same axis `type`. The old `type` prop stays
+as a deprecated alias, so this is **non-breaking** — existing
+`type="error"` usage and every `Modal.*` / `Toast.*` call keep working.
+
+`Modal.confirm` is unchanged: `confirm` is an interaction mode (the two-button
+footer), not a status, so it stays on its own axis rather than being folded into
+`status` (ui-kit#318).

--- a/apps/web/docs/components/organisms/modal.mdx
+++ b/apps/web/docs/components/organisms/modal.mdx
@@ -32,7 +32,7 @@ const [open, setOpen] = useState(false);
 
 ## Imperative
 
-The static methods render a centered, type-styled modal and manage their own open state. `Modal.confirm` shows both OK/Cancel; the others show a single acknowledge button.
+The static methods render a centered, status-styled modal and manage their own open state. `Modal.confirm` shows both OK/Cancel; the others show a single acknowledge button.
 
 ```tsx
 Modal.confirm({
@@ -73,4 +73,4 @@ Modal.success({ title: 'Saved.' });
 | `Modal.confirm`                                   | OK + Cancel                        |
 | `Modal.destroy(id)` / `Modal.destroyAll()`        | programmatic close                 |
 
-Each imperative type renders a matching icon next to the title.
+Each imperative status renders a matching icon next to the title. `Modal.info` / `success` / `error` / `warning` set the `status` axis; `Modal.confirm` is a separate interaction mode (two-button footer), not a status.

--- a/apps/web/docs/components/organisms/toast.mdx
+++ b/apps/web/docs/components/organisms/toast.mdx
@@ -50,11 +50,11 @@ Toast.destroy(id);
 | ------------- | ----------------------- | ----------- |
 | `description` | `ReactNode`             | -           |
 | `duration`    | `number` (ms, `0` = sticky) | `4000`  |
-| `icon`        | `ReactNode` (overrides the type icon) | -   |
+| `icon`        | `ReactNode` (overrides the status icon) | - |
 | `closable`    | `boolean`               | `true`      |
 | `action`      | `ReactNode`             | -           |
 | `container`   | `HTMLElement` (custom mount target) | -     |
 | `className`   | `string`                | -           |
 | `onClose`     | `() => void`            | -           |
 
-Each type sets an accessible role automatically (`alert` for `error`, `status` otherwise) and a matching icon.
+Each status sets an accessible role automatically (`alert` for `error`, `status` otherwise) and a matching icon. The `Toast.*` methods set `status` for you; on the `<Toast>` component the `status` prop drives this (the old `type` prop still works as a deprecated alias).

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -60,8 +60,17 @@ export interface Props {
   onCancel?: () => void;
 }
 
+type ModalStatus = 'info' | 'success' | 'error' | 'warning';
+
 interface StaticProps extends Props {
-  type?: 'info' | 'success' | 'error' | 'warning' | 'confirm';
+  status?: ModalStatus;
+  /**
+   * @deprecated Use `status` for the semantic state. Kept as an alias so
+   * existing `type="info|success|error|warning"` calls keep working. `confirm`
+   * is an interaction mode, not a status — call `Modal.confirm()` instead
+   * (still accepted here as `type="confirm"` for back-compat).
+   */
+  type?: ModalStatus | 'confirm';
   id?: string;
   icon?: React.ReactNode;
   container?: HTMLElement;
@@ -170,6 +179,7 @@ const STATIC_ICONS = {
 
 const StaticModal = ({
   id,
+  status,
   type,
   title,
   content,
@@ -186,6 +196,10 @@ const StaticModal = ({
   const resolvedOkText = okText ?? locale.ok ?? DEFAULT_LOCALE.ok;
   const resolvedCancelText =
     cancelText ?? locale.cancel ?? DEFAULT_LOCALE.cancel;
+  // `confirm` is an interaction mode (two-button footer), not a status. The
+  // semantic state comes from `status`, with `type` as its deprecated alias.
+  const isConfirm = type === 'confirm';
+  const resolvedStatus = status ?? (isConfirm ? undefined : type);
 
   const closeModal = (callback?: () => void) => {
     callback?.();
@@ -195,31 +209,30 @@ const StaticModal = ({
     }, 200);
   };
 
-  const footer =
-    type === 'confirm' ? (
-      <div className="grid w-full grid-cols-5 gap-x-2">
-        <Button
-          variant="outlined"
-          className="col-span-2"
-          onClick={() => closeModal(onCancel)}
-        >
-          {resolvedCancelText}
-        </Button>
-        <Button className="col-span-3" onClick={() => closeModal(onOk)}>
-          {resolvedOkText}
-        </Button>
-      </div>
-    ) : (
+  const footer = isConfirm ? (
+    <div className="grid w-full grid-cols-5 gap-x-2">
       <Button
-        className={cn(
-          'grow',
-          //
-        )}
-        onClick={() => closeModal(onOk)}
+        variant="outlined"
+        className="col-span-2"
+        onClick={() => closeModal(onCancel)}
       >
+        {resolvedCancelText}
+      </Button>
+      <Button className="col-span-3" onClick={() => closeModal(onOk)}>
         {resolvedOkText}
       </Button>
-    );
+    </div>
+  ) : (
+    <Button
+      className={cn(
+        'grow',
+        //
+      )}
+      onClick={() => closeModal(onOk)}
+    >
+      {resolvedOkText}
+    </Button>
+  );
 
   if (!isBrowser) {
     return null;
@@ -251,7 +264,10 @@ const StaticModal = ({
             //
           )}
         >
-          {icon || (type && STATIC_ICONS[type])}
+          {icon ||
+            (isConfirm
+              ? STATIC_ICONS.confirm
+              : resolvedStatus && STATIC_ICONS[resolvedStatus])}
           {title}
         </p>
       }
@@ -290,13 +306,15 @@ Modal.destroyAll = () => {
 };
 
 Modal.info = (props: StaticProps) =>
-  modalStack.render({ type: 'info', ...props });
+  modalStack.render({ status: 'info', ...props });
 Modal.success = (props: StaticProps) =>
-  modalStack.render({ type: 'success', ...props });
+  modalStack.render({ status: 'success', ...props });
 Modal.error = (props: StaticProps) =>
-  modalStack.render({ type: 'error', ...props });
+  modalStack.render({ status: 'error', ...props });
 Modal.warning = (props: StaticProps) =>
-  modalStack.render({ type: 'warning', ...props });
+  modalStack.render({ status: 'warning', ...props });
+// `confirm` is a mode, not a status, so it rides the `type` axis (the only
+// place it lives) rather than `status`.
 Modal.confirm = (props: StaticProps) =>
   modalStack.render({ type: 'confirm', ...props });
 

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -16,10 +16,16 @@ import {
   isBrowser,
 } from './imperative-stack';
 
-type ToastType = 'info' | 'success' | 'error' | 'warning';
+type ToastStatus = 'info' | 'success' | 'error' | 'warning';
 
 export interface Props {
-  type?: ToastType;
+  status?: ToastStatus;
+  /**
+   * @deprecated Use `status`. Kept as an alias so existing
+   * `type="info|success|error|warning"` usage keeps working; `status` matches
+   * the shared semantic-state vocabulary used by `Result`.
+   */
+  type?: ToastStatus;
   title: React.ReactNode;
   description?: React.ReactNode;
   icon?: React.ReactNode;
@@ -35,7 +41,7 @@ interface StaticProps extends Props {
   container?: HTMLElement;
 }
 
-const TYPE_ICONS: Record<ToastType, React.ReactNode> = {
+const STATUS_ICONS: Record<ToastStatus, React.ReactNode> = {
   info: <Info className="text-blue-400" />,
   success: <Check className="text-green-400" />,
   error: <OctagonX className="text-red-400" />,
@@ -43,6 +49,7 @@ const TYPE_ICONS: Record<ToastType, React.ReactNode> = {
 };
 
 const Toast = ({
+  status,
   type,
   title,
   description,
@@ -53,10 +60,12 @@ const Toast = ({
   onClose,
 }: Props) => {
   const { locale } = useConfig();
+  // `type` is the deprecated alias for `status`; prefer `status` when both set.
+  const resolvedStatus = status ?? type;
 
   return (
     <div
-      role={type === 'error' ? 'alert' : 'status'}
+      role={resolvedStatus === 'error' ? 'alert' : 'status'}
       className={cn(
         'pointer-events-auto flex w-80 items-start gap-3 rounded-lg',
         'bg-background text-foreground border p-4 shadow-lg',
@@ -64,9 +73,9 @@ const Toast = ({
         //
       )}
     >
-      {(icon || type) && (
+      {(icon || resolvedStatus) && (
         <div className="mt-0.5 shrink-0 [&_svg]:size-5">
-          {icon || (type && TYPE_ICONS[type])}
+          {icon || (resolvedStatus && STATUS_ICONS[resolvedStatus])}
         </div>
       )}
       <div className="flex-1 space-y-1">
@@ -165,16 +174,16 @@ Toast.destroyAll = () => {
   toastStack.destroy();
 };
 
-type TriggerOptions = Omit<StaticProps, 'type' | 'title'>;
+type TriggerOptions = Omit<StaticProps, 'status' | 'type' | 'title'>;
 
 Toast.info = (title: React.ReactNode, props?: TriggerOptions) =>
-  toastStack.render({ type: 'info', title, ...props });
+  toastStack.render({ status: 'info', title, ...props });
 Toast.success = (title: React.ReactNode, props?: TriggerOptions) =>
-  toastStack.render({ type: 'success', title, ...props });
+  toastStack.render({ status: 'success', title, ...props });
 Toast.error = (title: React.ReactNode, props?: TriggerOptions) =>
-  toastStack.render({ type: 'error', title, ...props });
+  toastStack.render({ status: 'error', title, ...props });
 Toast.warning = (title: React.ReactNode, props?: TriggerOptions) =>
-  toastStack.render({ type: 'warning', title, ...props });
+  toastStack.render({ status: 'warning', title, ...props });
 
 export default Toast;
 export type { StaticProps as ToastOptions };


### PR DESCRIPTION
## What

Unifies the semantic-state axis under `status`. `Modal` and `Toast` now expose a `status` prop (`info | success | error | warning`), matching `Result`'s vocabulary, instead of spelling the same axis `type`. `Button.type` is left as the only `type` in the library and unambiguously means "style shorthand".

Closes #318 (split out of #314, Idea 1).

## Changes

- **`Toast`** — adds `status`; `type` kept as a deprecated alias. `role` and the status icon now resolve `status ?? type`. `Toast.info/success/error/warning` set `status`.
- **`Modal`** — adds `status` to the imperative `StaticProps`; `type` kept as a deprecated alias. `Modal.info/success/error/warning` set `status`.
- **`Modal.confirm` is untouched.** `confirm` is an interaction mode (the two-button footer), not a semantic state, so it stays on its own axis (`type="confirm"` / `Modal.confirm()`) rather than being folded into `status` — resolving the open question raised in #314.
- Docs prose (`toast.mdx`, `modal.mdx`) updated to describe the axis as `status`.

## Risk

**Non-breaking.** The old `type` prop still works everywhere (deprecated alias), and every `Modal.*` / `Toast.*` call keeps working — the imperative API is unchanged for callers. Only the internal wiring and the recommended prop name change. Removing the `type` alias would be a separate, later breaking change.

## Verify

- `check-types`, `lint`, full monorepo `build` (ui + docs + web), and the regression net (API surface / preflight / SSR smoke) all pass locally.
- Public API-surface snapshot unchanged (it tracks exported names + subpaths, not type members).
- `Modal.confirm()` still renders the two-button footer + question icon; `Toast.error()` still gets `role="alert"` and the error icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
