### PR TITLE
✨ feat(ui): widen Config.defaultProps beyond button.shape (#319)

### DIFF
--- a/.changeset/widen-config-defaultprops.md
+++ b/.changeset/widen-config-defaultprops.md
@@ -1,0 +1,15 @@
+---
+'@repo/ui': minor
+---
+
+Widen `Config`'s `defaultProps` beyond `button.shape`. Apps can now set
+library-wide defaults for more of the settled prop surface in one place:
+
+- `defaultProps.button.variant` / `defaultProps.button.color`
+- `defaultProps.tag.variant` / `defaultProps.tag.color`
+- `defaultProps.modal.maskClosable`
+
+Each resolves `explicit prop ?? Config default ?? built-in`, the same order
+`Button` already used for `shape` (for `Button`, a call-site `type` shorthand
+still wins over the `Config` default). Additive and non-breaking — components
+behave exactly as before when no default is set (ui-kit#319).

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -178,19 +178,22 @@ const Button = ({
 }: Props) => {
   const { componentSize, defaultProps } = useConfig();
   const buttonDefaults = defaultProps?.button as
-    Partial<Pick<Props, 'shape'>> | undefined;
+    Partial<Pick<Props, 'shape' | 'variant' | 'color'>> | undefined;
   const resolvedSize = size ?? componentSize ?? 'middle';
   const resolvedShape = shape ?? buttonDefaults?.shape ?? 'default';
   const iconOnly = icon && !children;
   // `type` is syntactic sugar that expands to a (color, variant) pair; explicit
   // `color`/`variant` win over it, so `type` only fills the axes left unset.
-  // `danger` still trumps everything, matching antd. Defaults live here rather
-  // than on the parameters so `type` gets a chance to supply them first.
+  // A `Config` default sits below the call-site `type` (which is more specific)
+  // but above the library built-in. `danger` still trumps everything, matching
+  // antd. Defaults live here rather than on the parameters so `type` gets a
+  // chance to supply them first.
   const typeDefaults = type ? typeToColorVariant[type] : undefined;
-  const resolvedVariant = variant ?? typeDefaults?.variant ?? 'outlined';
+  const resolvedVariant =
+    variant ?? typeDefaults?.variant ?? buttonDefaults?.variant ?? 'outlined';
   const computedColor = danger
     ? 'danger'
-    : (color ?? typeDefaults?.color ?? 'default');
+    : (color ?? typeDefaults?.color ?? buttonDefaults?.color ?? 'default');
   const colored = computedColor !== 'default';
   const isLoading = !!loading;
 

--- a/packages/ui/src/components/atoms/tag.tsx
+++ b/packages/ui/src/components/atoms/tag.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import * as React from 'react';
 
 import { Slot } from '@radix-ui/react-slot';
 
+import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
@@ -50,12 +53,19 @@ const outlinedColorClasses: Record<string, string> = {
 
 const Tag = ({
   className,
-  variant = 'default',
-  color = 'default',
+  variant,
+  color,
   asChild = false,
   children,
   ...props
 }: Props) => {
+  const { defaultProps } = useConfig();
+  const tagDefaults = defaultProps?.tag as
+    Partial<Pick<Props, 'variant' | 'color'>> | undefined;
+  // An explicit prop wins over a `Config` default, which wins over the built-in
+  // — the same resolution order `Button` uses.
+  const resolvedVariant = variant ?? tagDefaults?.variant ?? 'default';
+  const resolvedColor = color ?? tagDefaults?.color ?? 'default';
   const Comp = asChild ? Slot : 'span';
 
   return (
@@ -65,8 +75,8 @@ const Tag = ({
         TAG_BASE,
         'rounded-full px-2.5 py-1',
         'text-xs font-medium',
-        variant === 'default' && fillColorClasses[color],
-        variant === 'outlined' && outlinedColorClasses[color],
+        resolvedVariant === 'default' && fillColorClasses[resolvedColor],
+        resolvedVariant === 'outlined' && outlinedColorClasses[resolvedColor],
         className,
         //
       )}

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -78,7 +78,7 @@ interface StaticProps extends Props {
 
 const Modal = ({
   open = false,
-  maskClosable = false,
+  maskClosable,
   closable = false,
   closeIcon,
   className,
@@ -95,7 +95,12 @@ const Modal = ({
   onCancel,
   ...props
 }: Props) => {
-  const { locale } = useConfig();
+  const { locale, defaultProps } = useConfig();
+  const modalDefaults = defaultProps?.modal as
+    Partial<Pick<Props, 'maskClosable'>> | undefined;
+  // Explicit prop > `Config` default > built-in, matching Button/Tag.
+  const resolvedMaskClosable =
+    maskClosable ?? modalDefaults?.maskClosable ?? false;
 
   if (typeof window === 'undefined') {
     return null;
@@ -126,7 +131,7 @@ const Modal = ({
         closeIcon={closeIcon}
         container={container}
         onPointerDownOutside={event => {
-          if (!maskClosable) {
+          if (!resolvedMaskClosable) {
             event.preventDefault();
           }
         }}


### PR DESCRIPTION
## What

Widens `Config`'s `defaultProps` beyond the single `button.shape` it honoured before, so an app can set library-wide defaults ("every button is `solid`", "every tag is `filled`", "modals close on mask click") in one place.

Closes #319 (split out of #314, Idea 3).

## Changes

Newly-honoured defaults, each resolving `explicit prop ?? Config default ?? built-in` — the same order `Button` already used for `shape`:

- **`Button`** — `defaultProps.button.variant`, `defaultProps.button.color` (a call-site `type` shorthand still wins over the config default, since it's more specific).
- **`Tag`** — `defaultProps.tag.variant`, `defaultProps.tag.color`. Tag now reads `Config`, so it gains a `'use client'` directive to match the other Config-reading components.
- **`Modal`** — `defaultProps.modal.maskClosable` (applies to both controlled `<Modal>` and the imperative `Modal.*` methods).

```tsx
<Config
  defaultProps={{
    button: { variant: 'solid', color: 'primary' },
    tag: { variant: 'outlined' },
    modal: { maskClosable: true },
  }}
>
  <App />
</Config>
```

## Scope

The issue's own examples ("every button is solid") are style-axis defaults, so this covers the settled `variant`/`color` axes on `Button`/`Tag` plus one representative behavioural default on `Modal` (`maskClosable`). The `defaultProps` plumbing and shallow-merge semantics are unchanged — this only threads more keys through each component's existing resolution.

## Risk

Additive and non-breaking. With no `defaultProps` set, every component behaves exactly as before (same built-in fallbacks).

## Verify

- `check-types`, `lint`, full monorepo `build` (ui + docs + web), and the regression net all pass locally.
- API-surface snapshot unchanged (41 names, 12 subpaths); Tag chassis + badge reset-slot contracts still green despite the new `'use client'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
