### PR TITLE
🐛 fix(ui): mark Space as a client component

### DIFF
--- a/.changeset/space-use-client-directive.md
+++ b/.changeset/space-use-client-directive.md
@@ -1,0 +1,9 @@
+---
+'@repo/ui': patch
+---
+
+Add the `'use client'` directive to `Space`. `Space` reads `componentSize` via
+`useConfig` (a React context hook), so it must be a client component like every
+other `Config` consumer (`Button`, `Switch`, `Modal`, `Tag`, …). Without the
+directive, importing `<Space>` into a React Server Component tree could throw at
+runtime. Non-behavioural fix — output is unchanged in existing client trees.

--- a/packages/ui/src/components/molecules/space.tsx
+++ b/packages/ui/src/components/molecules/space.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Children } from 'react';
 
 import { useConfig } from '@repo/ui/providers';


### PR DESCRIPTION
## What

Add the `'use client'` directive to `Space`.

## Why

`Space` reads `componentSize` via `useConfig` (a React context hook) since #317, but — unlike every other `Config` consumer (`Button`, `Switch`, `Modal`, `Tag`, `Drawer`, `Toast`, …) — it was missing the `'use client'` directive. Without it, importing `<Space>` into a React Server Component tree can throw at runtime. The build and SSR paths didn't catch it because the stories/apps render it in client trees, but the repo convention is that any component calling `useConfig` is a client component.

## Scope

One-line, non-behavioural. Output is unchanged in existing client trees; this only prevents an RSC-import crash and aligns `Space` with the established convention.

Follow-up to #317 / #321.