### PR TITLE
✨ feat(ui): add Slider atom (radix-ui Slider primitive)

### DIFF
--- a/.changeset/slider-atom.md
+++ b/.changeset/slider-atom.md
@@ -1,0 +1,11 @@
+---
+'@repo/ui': minor
+---
+
+Add a `Slider` atom. A numeric-range control built on the Radix `Slider`
+primitive (draggable + keyboard-operable), following the existing
+`Checkbox`/`Switch` shape: controlled/uncontrolled via `useControllableState`,
+with `value`/`defaultValue`/`onChange`, `min`/`max`/`step`, `disabled`, and
+`orientation`. Pass a bare `number` for a single thumb or a `[min, max]` tuple
+for a two-thumb range — `onChange` returns the same shape. Consumers no longer
+need to hand-roll `<input type="range">` (ui-kit#315).

--- a/apps/docs/stories/atoms/slider/index.stories.tsx
+++ b/apps/docs/stories/atoms/slider/index.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Slider } from '@repo/ui';
+import { cn } from '@repo/ui/utils';
+
+const meta: Meta<typeof Slider> = {
+  title: 'Data Entry/Slider',
+  component: Slider,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    min: {
+      control: { type: 'number' },
+    },
+    max: {
+      control: { type: 'number' },
+    },
+    step: {
+      control: { type: 'number' },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+    },
+    orientation: {
+      control: { type: 'select' },
+      options: ['horizontal', 'vertical'],
+    },
+    className: {
+      control: { type: 'text' },
+    },
+  },
+  render: props => (
+    <div
+      className={cn(
+        'flex items-center justify-center',
+        'w-64 p-4',
+        'rounded-md border',
+        'bg-gray-50',
+      )}
+    >
+      <Slider {...props} />
+    </div>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    defaultValue: 40,
+    disabled: false,
+  },
+};
+
+export const Range: Story = {
+  args: {
+    defaultValue: [20, 60],
+  },
+};
+
+export const Stepped: Story = {
+  args: {
+    defaultValue: 50,
+    step: 10,
+  },
+};

--- a/apps/web/docs/components/atoms/slider.mdx
+++ b/apps/web/docs/components/atoms/slider.mdx
@@ -1,0 +1,49 @@
+---
+sidebar_position: 16
+title: Slider
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import SliderDemo from '../../../src/demo/slider-demo';
+
+# Slider
+
+A numeric-range control built on the Radix `Slider` primitive — draggable and
+fully keyboard-operable.
+
+```tsx
+import { Slider } from '@jbpark/ui-kit';
+
+// single thumb
+<Slider value={value} onChange={setValue} />;
+
+// two-thumb range
+<Slider value={[min, max]} onChange={setRange} />;
+```
+
+<DemoTheme>
+
+<SliderDemo />
+
+</DemoTheme>
+
+## Props
+
+| Prop           | Type                              | Default        |
+| -------------- | --------------------------------- | -------------- |
+| `value`        | `number \| number[]`              | -              |
+| `defaultValue` | `number \| number[]`              | `[min]`        |
+| `min`          | `number`                          | `0`            |
+| `max`          | `number`                          | `100`          |
+| `step`         | `number`                          | `1`            |
+| `disabled`     | `boolean`                         | -              |
+| `orientation`  | `'horizontal' \| 'vertical'`      | `'horizontal'` |
+| `onChange`     | `(value: number \| number[]) => void` | -          |
+| `className`    | `string`                          | -              |
+
+Works both controlled (pass `value` + `onChange`) and uncontrolled (pass
+`defaultValue`, or neither). Pass a single `number` for one thumb or a
+`[min, max]` tuple for a two-thumb range — `onChange` hands back the same shape
+you gave it. `Slider` also accepts the rest of
+`React.ComponentPropsWithoutRef<'span'>` except `onChange` and `defaultValue`
+(both renamed to the value-based forms above).

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/date-picker',
         'components/atoms/color-picker',
         'components/atoms/switch',
+        'components/atoms/slider',
         'components/atoms/input',
         'components/atoms/checkbox',
         'components/atoms/radio',

--- a/apps/web/src/demo/slider-demo.tsx
+++ b/apps/web/src/demo/slider-demo.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+import { Slider, Space, Typography } from '@repo/ui';
+
+export default function SliderDemo() {
+  const [value, setValue] = useState<number>(40);
+  const [range, setRange] = useState<number[]>([20, 60]);
+
+  return (
+    <Space orientation="vertical" align="start" size="large" className="w-72">
+      <Space
+        orientation="vertical"
+        align="start"
+        size="small"
+        className="w-full"
+      >
+        <Typography.Text className="text-muted-foreground text-sm">
+          value: {value}
+        </Typography.Text>
+        <Slider value={value} onChange={next => setValue(next as number)} />
+      </Space>
+      <Space
+        orientation="vertical"
+        align="start"
+        size="small"
+        className="w-full"
+      >
+        <Typography.Text className="text-muted-foreground text-sm">
+          range: {range.join(' – ')}
+        </Typography.Text>
+        <Slider value={range} onChange={next => setRange(next as number[])} />
+      </Space>
+      <Space
+        orientation="vertical"
+        align="start"
+        size="small"
+        className="w-full"
+      >
+        <Typography.Text className="text-muted-foreground text-sm">
+          stepped (10) &amp; disabled
+        </Typography.Text>
+        <Slider defaultValue={50} step={10} />
+        <Slider defaultValue={30} disabled />
+      </Space>
+    </Space>
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -93,6 +93,7 @@
     "@radix-ui/react-radio-group": "^1.4.7",
     "@radix-ui/react-select": "^2.3.7",
     "@radix-ui/react-separator": "^1.1.15",
+    "@radix-ui/react-slider": "^1.4.7",
     "@radix-ui/react-slot": "^1.3.3",
     "@radix-ui/react-switch": "^1.3.7",
     "class-variance-authority": "^0.7.1",

--- a/packages/ui/scripts/api-surface.snapshot.json
+++ b/packages/ui/scripts/api-surface.snapshot.json
@@ -44,6 +44,7 @@
     "Row",
     "Select",
     "Skeleton",
+    "Slider",
     "Space",
     "Spin",
     "Splitter",

--- a/packages/ui/src/components/atoms/index.ts
+++ b/packages/ui/src/components/atoms/index.ts
@@ -9,6 +9,7 @@ export { default as Progress } from './progress';
 export { default as Radio } from './radio';
 export { default as Select } from './select';
 export { default as Skeleton } from './skeleton';
+export { default as Slider } from './slider';
 export { default as Spin } from './spin';
 export { default as Switch } from './switch';
 export { default as Tag } from './tag';

--- a/packages/ui/src/components/atoms/slider/index.ts
+++ b/packages/ui/src/components/atoms/slider/index.ts
@@ -1,0 +1,4 @@
+import Slider, { type Props, type SliderValue } from './slider';
+
+export default Slider;
+export type { Props, SliderValue };

--- a/packages/ui/src/components/atoms/slider/slider.tsx
+++ b/packages/ui/src/components/atoms/slider/slider.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useControllableState } from '@jbpark/use-hooks';
+
+import { cn } from '@repo/ui/utils';
+
+import { slider } from '../../../core';
+
+const { Slider: Core } = slider;
+
+/** A single thumb (`number`) or a two-thumb range (`[min, max]`). */
+export type SliderValue = number | number[];
+
+export interface Props extends Omit<
+  React.ComponentPropsWithoutRef<'span'>,
+  'onChange' | 'defaultValue' | 'dir'
+> {
+  value?: SliderValue;
+  defaultValue?: SliderValue;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  orientation?: 'horizontal' | 'vertical';
+  onChange?: (value: SliderValue) => void;
+}
+
+const toArray = (value: SliderValue | undefined): number[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Array.isArray(value) ? value : [value];
+};
+
+const Slider = ({
+  value: _value,
+  defaultValue,
+  min = 0,
+  max = 100,
+  step = 1,
+  disabled,
+  orientation = 'horizontal',
+  onChange: _onChange = () => {},
+  className,
+  ...props
+}: Props) => {
+  // A `number[]` value/defaultValue means the consumer wants a range; a bare
+  // `number` means a single thumb. Radix works in `number[]` throughout, so we
+  // normalise on the way in and hand the original shape back through `onChange`.
+  const isRange = Array.isArray(_value ?? defaultValue);
+
+  const [value, onChange] = useControllableState<number[]>({
+    value: toArray(_value),
+    defaultValue: toArray(defaultValue) ?? [min],
+    onChange: next => {
+      _onChange(isRange ? next : (next[0] ?? min));
+    },
+  });
+
+  return (
+    <Core
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      orientation={orientation}
+      className={cn(className)}
+      onValueChange={onChange}
+      {...props}
+    />
+  );
+};
+
+export default Slider;

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -15,5 +15,6 @@ export * as resizable from './resizable';
 export * as select from './select';
 export * as separator from './separator';
 export * as skeleton from './skeleton';
+export * as slider from './slider';
 export * as switchComponent from './switch';
 export * as textarea from './textarea';

--- a/packages/ui/src/core/slider.tsx
+++ b/packages/ui/src/core/slider.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import * as React from 'react';
+
+import * as SliderPrimitive from '@radix-ui/react-slider';
+
+import { cn } from '@repo/ui/utils';
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const thumbs = React.useMemo(() => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (Array.isArray(defaultValue)) {
+      return defaultValue;
+    }
+    return [min, max];
+  }, [value, defaultValue, min, max]);
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        `relative flex w-full touch-none items-center select-none
+        data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50
+        data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44
+        data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col`,
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          `bg-input relative grow overflow-hidden rounded-full
+          data-[orientation=horizontal]:h-1.5
+          data-[orientation=horizontal]:w-full
+          data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5`,
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            `bg-primary absolute data-[orientation=horizontal]:h-full
+            data-[orientation=vertical]:w-full`,
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: thumbs.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className={cn(
+            `border-primary bg-background ring-ring/50 block size-4 shrink-0
+            rounded-full border shadow-sm transition-[color,box-shadow]
+            hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden
+            disabled:pointer-events-none disabled:opacity-50`,
+          )}
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@radix-ui/react-separator':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slider':
+        specifier: ^1.4.7
+        version: 1.4.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-slot':
         specifier: ^1.3.3
         version: 1.3.3(@types/react@19.2.18)(react@19.2.8)
@@ -2884,6 +2887,19 @@ packages:
 
   '@radix-ui/react-separator@1.1.15':
     resolution: {integrity: sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.4.7':
+    resolution: {integrity: sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -13053,6 +13069,25 @@ snapshots:
   '@radix-ui/react-separator@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
+  '@radix-ui/react-slider@1.4.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:


### PR DESCRIPTION
Closes #315.

## What

Adds a `Slider` atom — a numeric-range control built on the Radix `Slider` primitive (draggable + fully keyboard-operable), so consumers stop hand-rolling `<input type="range">`.

- `src/core/slider.tsx` — thin radix wrapper (Root/Track/Range/Thumb), `data-slot`-scoped styling like the other `core/*` primitives.
- `src/components/atoms/slider/` — controlled/uncontrolled via `useControllableState`, matching the `Checkbox`/`Switch` shape.

## API

| Prop | Type | Default |
|---|---|---|
| `value` | `number \| number[]` | - |
| `defaultValue` | `number \| number[]` | `[min]` |
| `min` / `max` / `step` | `number` | `0` / `100` / `1` |
| `disabled` | `boolean` | - |
| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` |
| `onChange` | `(value: number \| number[]) => void` | - |

Pass a bare `number` for a single thumb or a `[min, max]` tuple for a two-thumb range — `onChange` hands back the **same shape** it was given (single-value consumers get a `number`, range consumers get `number[]`). Both range support and single-value ship together since the range case was a trivial lift on top of radix.

## Dependency note

This adds `@radix-ui/react-slider`. The issue assumed a unified `radix-ui` package already in the tree, but this repo actually pulls each primitive as its own `@radix-ui/react-*` dependency (`react-checkbox`, `react-switch`, `react-select`, …). Adding `react-slider` follows that established convention rather than introducing a new dependency style.

## Docs

- Storybook story under `apps/docs/stories/atoms/slider` (Default / Range / Stepped), matching the `switch` story shape.
- Docusaurus `apps/web/docs/components/atoms/slider.mdx` + `slider-demo.tsx` + sidebar entry (Data Entry group).

## Verification

`check-types` · `lint` (0 errors) · `check-dynamic-classes` · full `build` (ui + docs + web) · `check-regression-net` — all local green. The api-surface snapshot was updated intentionally to include `Slider` (SSR smoke confirms it renders). Pre-commit hook passed.