### PR TITLE
✨ feat(ui): align Tag's variant/color vocabulary with Button (#320)

### DIFF
--- a/.changeset/tag-button-vocab-alignment.md
+++ b/.changeset/tag-button-vocab-alignment.md
@@ -1,0 +1,22 @@
+---
+'@repo/ui': minor
+---
+
+Align `Tag`'s `variant`/`color` vocabulary with `Button` (ui-kit#320), **without
+breaking existing `Tag` usage**:
+
+- `variant="filled"` is the new canonical spelling of what used to be
+  `variant="default"`. `"default"` still works as a **deprecated alias** (renders
+  identically) and will be removed in a future major.
+- `color` now also accepts `Button`'s shared preset palette (`blue`, `purple`,
+  `cyan`, `green`, `magenta`, `pink`, `red`, `orange`, `yellow`, `volcano`,
+  `geekblue`, `lime`, `gold`) alongside the existing named states
+  (`primary`/`success`/`warning`/`danger`). Presets are backed by the same
+  `data-color` custom-property system as `Button` (`--tag-*` mirrors `--btn-*`),
+  so a colour word renders the same hue on either component.
+
+The preset list is now shared from `lib/colors` and consumed by both `Button`
+and `Tag`. Existing named-state tags render byte-identical (they keep their
+bespoke classes and never emit `data-color`), so this is additive and
+non-breaking — the vocabulary alignment ships as a minor with a deprecation
+window rather than waiting for a major.

--- a/apps/docs/stories/atoms/tag/index.stories.tsx
+++ b/apps/docs/stories/atoms/tag/index.stories.tsx
@@ -11,11 +11,30 @@ const meta: Meta<typeof Tag> = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: ['default', 'outlined'],
+      options: ['filled', 'outlined'],
     },
     color: {
       control: { type: 'select' },
-      options: ['default', 'primary', 'success', 'warning', 'danger'],
+      options: [
+        'default',
+        'primary',
+        'success',
+        'warning',
+        'danger',
+        'blue',
+        'purple',
+        'cyan',
+        'green',
+        'magenta',
+        'pink',
+        'red',
+        'orange',
+        'yellow',
+        'volcano',
+        'geekblue',
+        'lime',
+        'gold',
+      ],
     },
     className: {
       control: { type: 'text' },
@@ -36,5 +55,12 @@ export const Outlined: Story = {
   args: {
     children: 'Tag',
     variant: 'outlined',
+  },
+};
+
+export const Preset: Story = {
+  args: {
+    children: 'gold',
+    color: 'gold',
   },
 };

--- a/apps/web/docs/components/atoms/tag.mdx
+++ b/apps/web/docs/components/atoms/tag.mdx
@@ -24,11 +24,21 @@ import { Tag } from '@jbpark/ui-kit';
 
 ## Props
 
-| Prop        | Type                                                                | Default     |
-| ----------- | -------------------------------------------------------------------- | ----------- |
-| `variant`   | `'default' \| 'outlined'`                                          | `'default'` |
-| `color`     | `'default' \| 'primary' \| 'success' \| 'warning' \| 'danger'`     | `'default'` |
-| `className` | `string`                                                              | -           |
-| `children`  | `ReactNode`                                                           | -           |
+| Prop        | Type                                                              | Default    |
+| ----------- | ---------------------------------------------------------------- | ---------- |
+| `variant`   | `'filled' \| 'outlined'`                                         | `'filled'` |
+| `color`     | `'default' \| 'primary' \| 'success' \| 'warning' \| 'danger' \| PresetColor` | `'default'` |
+| `className` | `string`                                                         | -          |
+| `children`  | `ReactNode`                                                      | -          |
+
+`Tag` shares `Button`'s vocabulary (#320): `variant="filled"` matches `Button`'s
+`filled`, and `color` accepts the same preset palette — `blue`, `purple`,
+`cyan`, `green`, `magenta`, `pink`, `red`, `orange`, `yellow`, `volcano`,
+`geekblue`, `lime`, `gold` — on top of the named states
+(`primary`/`success`/`warning`/`danger`).
+
+> **Deprecation:** `variant="default"` is still accepted as an alias for
+> `"filled"` and renders identically, but it will be removed in a future major.
+> Prefer `variant="filled"`.
 
 `Tag` also accepts the rest of `React.ComponentProps<'span'>` (e.g. `onClick`, `style`).

--- a/apps/web/src/demo/tag-demo.tsx
+++ b/apps/web/src/demo/tag-demo.tsx
@@ -1,19 +1,49 @@
 import { Space, Tag } from '@repo/ui';
 
-const COLORS = ['default', 'primary', 'success', 'warning', 'danger'] as const;
+const STATES = ['default', 'primary', 'success', 'warning', 'danger'] as const;
+
+const PRESETS = [
+  'blue',
+  'purple',
+  'cyan',
+  'green',
+  'magenta',
+  'pink',
+  'red',
+  'orange',
+  'yellow',
+  'volcano',
+  'geekblue',
+  'lime',
+  'gold',
+] as const;
 
 export default function TagDemo() {
   return (
     <Space orientation="vertical" align="start" size="middle">
       <Space wrap>
-        {COLORS.map(color => (
+        {STATES.map(color => (
           <Tag key={color} color={color}>
             {color}
           </Tag>
         ))}
       </Space>
       <Space wrap>
-        {COLORS.map(color => (
+        {STATES.map(color => (
+          <Tag key={color} color={color} variant="outlined">
+            {color}
+          </Tag>
+        ))}
+      </Space>
+      <Space wrap>
+        {PRESETS.map(color => (
+          <Tag key={color} color={color}>
+            {color}
+          </Tag>
+        ))}
+      </Space>
+      <Space wrap>
+        {PRESETS.map(color => (
           <Tag key={color} color={color} variant="outlined">
             {color}
           </Tag>

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -9,25 +9,11 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
+import { type PresetColor } from '../../lib/colors';
 
 type NativeButtonProps = React.ComponentProps<'button'> & {
   asChild?: boolean;
 };
-
-type PresetColors =
-  | 'blue'
-  | 'purple'
-  | 'cyan'
-  | 'green'
-  | 'magenta'
-  | 'pink'
-  | 'red'
-  | 'orange'
-  | 'yellow'
-  | 'volcano'
-  | 'geekblue'
-  | 'lime'
-  | 'gold';
 
 export interface Props extends Omit<
   NativeButtonProps,
@@ -72,7 +58,7 @@ export interface Props extends Omit<
    * Color, independent of `variant`. Defaults to `'default'`, or to whatever
    * `type` maps to when `type` is set. `danger` overrides this.
    */
-  color?: PresetColors | 'default' | 'primary' | 'danger';
+  color?: PresetColor | 'default' | 'primary' | 'danger';
   loading?: boolean | { icon: React.ReactNode };
 }
 

--- a/packages/ui/src/components/atoms/tag.tsx
+++ b/packages/ui/src/components/atoms/tag.tsx
@@ -8,14 +8,29 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
+import { type PresetColor, isPresetColor } from '../../lib/colors';
 
 type NativeSpanProps = React.ComponentProps<'span'> & {
   asChild?: boolean;
 };
 
-export interface Props extends Omit<NativeSpanProps, 'variant'> {
-  variant?: 'default' | 'outlined';
-  color?: 'default' | 'primary' | 'success' | 'warning' | 'danger';
+export interface Props extends Omit<NativeSpanProps, 'variant' | 'color'> {
+  /**
+   * Fill style, aligned with `Button`'s vocabulary. `'default'` is a
+   * **deprecated alias** for `'filled'` — it still renders identically, but
+   * prefer `'filled'` going forward (#320).
+   *
+   * @remarks `'default'` will be removed in a future major.
+   */
+  variant?: 'filled' | 'outlined' | 'default';
+  /**
+   * Colour, sharing `Button`'s preset palette. The named states
+   * (`primary`/`success`/`warning`/`danger`) keep their semantic look; the
+   * shared presets (`blue`, `red`, `gold`, …) are backed by the same
+   * `data-color` system as `Button` (#320).
+   */
+  color?:
+    'default' | 'primary' | 'success' | 'warning' | 'danger' | PresetColor;
 }
 
 // Base absorbed from core/badge's cva base + its `outline` variant, which Tag
@@ -51,6 +66,18 @@ const outlinedColorClasses: Record<string, string> = {
   danger: 'border-destructive text-destructive',
 };
 
+// Preset colours resolve their hue from the shared `--tag-bg` custom property
+// (globals.css, keyed on `data-color`) rather than a per-colour Tailwind class,
+// so `Tag` and `Button` stay in lock-step. Fill uses a 10% tint behind the
+// full-strength hue; outlined borders and texts it directly.
+const presetFillClasses = cn(
+  'border-transparent',
+  'bg-[color-mix(in_oklch,var(--tag-bg),transparent_90%)]',
+  'text-(--tag-bg)',
+);
+
+const presetOutlinedClasses = cn('border-(--tag-bg) text-(--tag-bg)');
+
 const Tag = ({
   className,
   variant,
@@ -64,19 +91,31 @@ const Tag = ({
     Partial<Pick<Props, 'variant' | 'color'>> | undefined;
   // An explicit prop wins over a `Config` default, which wins over the built-in
   // — the same resolution order `Button` uses.
-  const resolvedVariant = variant ?? tagDefaults?.variant ?? 'default';
+  const resolvedVariant = variant ?? tagDefaults?.variant ?? 'filled';
   const resolvedColor = color ?? tagDefaults?.color ?? 'default';
+  // `'default'` is the pre-#320 spelling of `'filled'`; fold it in so the alias
+  // renders identically.
+  const isOutlined = resolvedVariant === 'outlined';
+  const preset = isPresetColor(resolvedColor);
   const Comp = asChild ? Slot : 'span';
 
   return (
     <Comp
       data-slot="badge"
+      // Only preset colours drive the `--tag-*` system; the named states keep
+      // their bespoke classes, so existing usage renders byte-identical.
+      data-color={preset ? resolvedColor : undefined}
       className={cn(
         TAG_BASE,
         'rounded-full px-2.5 py-1',
         'text-xs font-medium',
-        resolvedVariant === 'default' && fillColorClasses[resolvedColor],
-        resolvedVariant === 'outlined' && outlinedColorClasses[resolvedColor],
+        preset
+          ? isOutlined
+            ? presetOutlinedClasses
+            : presetFillClasses
+          : isOutlined
+            ? outlinedColorClasses[resolvedColor]
+            : fillColorClasses[resolvedColor],
         className,
         //
       )}

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -255,6 +255,51 @@
     --btn-bg: #f59e0b;
   }
 
+  /* Tag's shared preset palette (#320). Mirrors the `--btn-*` hues above so a
+   * given colour word renders the same on `Tag` and `Button`; `Tag` reads
+   * `--tag-bg` for both its 10% fill tint and its outlined border/text (see
+   * tag.tsx). Named states (primary/success/warning/danger) keep their own
+   * classes and never set `data-color`, so only these presets match here. */
+  [data-slot='badge'][data-color='blue'] {
+    --tag-bg: #3b82f6;
+  }
+  [data-slot='badge'][data-color='purple'] {
+    --tag-bg: #a855f7;
+  }
+  [data-slot='badge'][data-color='cyan'] {
+    --tag-bg: #06b6d4;
+  }
+  [data-slot='badge'][data-color='green'] {
+    --tag-bg: #22c55e;
+  }
+  [data-slot='badge'][data-color='magenta'] {
+    --tag-bg: #d946ef;
+  }
+  [data-slot='badge'][data-color='pink'] {
+    --tag-bg: #ec4899;
+  }
+  [data-slot='badge'][data-color='red'] {
+    --tag-bg: #ef4444;
+  }
+  [data-slot='badge'][data-color='orange'] {
+    --tag-bg: #f97316;
+  }
+  [data-slot='badge'][data-color='yellow'] {
+    --tag-bg: #eab308;
+  }
+  [data-slot='badge'][data-color='volcano'] {
+    --tag-bg: #ea580c;
+  }
+  [data-slot='badge'][data-color='geekblue'] {
+    --tag-bg: #6366f1;
+  }
+  [data-slot='badge'][data-color='lime'] {
+    --tag-bg: #84cc16;
+  }
+  [data-slot='badge'][data-color='gold'] {
+    --tag-bg: #f59e0b;
+  }
+
   /* Row/Col's 24-column responsive grid (templates/grid/col.tsx) — Col
    * hands over one CSS custom property per breakpoint tier, already
    * resolved via its own mobile-first cascade (pure prop math, no

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -1,0 +1,27 @@
+/**
+ * The shared preset colour palette. `Button` and `Tag` both express these via
+ * the `--btn-*` / `--tag-*` custom-property systems in `globals.css` (keyed off
+ * `data-color`), so the same word means the same hue on either component
+ * (#320). Keep this list in sync with the `[data-color='…']` rules there.
+ */
+export const PRESET_COLORS = [
+  'blue',
+  'purple',
+  'cyan',
+  'green',
+  'magenta',
+  'pink',
+  'red',
+  'orange',
+  'yellow',
+  'volcano',
+  'geekblue',
+  'lime',
+  'gold',
+] as const;
+
+export type PresetColor = (typeof PRESET_COLORS)[number];
+
+/** Runtime membership test — true when `color` is one of the shared presets. */
+export const isPresetColor = (color: string): color is PresetColor =>
+  (PRESET_COLORS as readonly string[]).includes(color);


### PR DESCRIPTION
Refs #320.

## The twist: non-breaking instead of major

The issue is filed as **breaking / major**, but it explicitly invites a deprecation window ("accept both spellings for one major, if feasible"). It's feasible — so this ships the alignment as an **additive minor**, the same playbook as #318's `type`→`status` alias. Existing `Tag` consumers keep working untouched; the breaking rename is deferred behind a deprecated alias.

## What

- **`variant`**: `filled` is now the canonical spelling of the former `default` (matching `Button`). `variant="default"` stays accepted as a **deprecated alias** and renders identically — to be removed in a future major.
- **`color`**: `Tag` now also accepts `Button`'s shared preset palette — `blue`, `purple`, `cyan`, `green`, `magenta`, `pink`, `red`, `orange`, `yellow`, `volcano`, `geekblue`, `lime`, `gold` — on top of the existing named states (`primary`/`success`/`warning`/`danger`). Presets are backed by the same `data-color` custom-property system as `Button`: `--tag-*` in `globals.css` mirrors `--btn-*`, so a colour word renders the same hue on either component.
- The preset list is hoisted to `packages/ui/src/lib/colors.ts` and consumed by **both** `Button` and `Tag` — literally "sharing Button's colour list" as the issue asks (Button's change is type-only).

## Why it's non-breaking

Named-state tags keep their bespoke Tailwind classes and never emit `data-color`, so their rendered HTML is **byte-identical** to before — only newly-requested preset colours take the `--tag-*` path. SSR smoke confirms `Tag` chassis + `badge` slot intact.

## Scope note

`Tag` keeps `success`/`warning` (which `Button`'s `color` doesn't have) rather than dropping them, since removing them would be breaking. Variants stay `filled`/`outlined` — the issue's concrete proposal is only the `default`→`filled` rename, not adopting Button's full solid/dashed/text/link set.

## Docs

Storybook story (adds `filled` + presets + a `Preset` story) and Docusaurus `tag.mdx` + `tag-demo` (preset rows) updated; deprecation note added to the mdx.

## Verification

`check-types` · `lint` (0 errors) · `check-dynamic-classes` · full `build` (ui + docs + web) · `check-regression-net` (api-surface / preflight-reset / ssr-smoke) — all local green. Verified the 13 `--tag-bg` preset rules land in `dist/style.css`.