### PR TITLE
💥 feat(ui): finish Tag's vocabulary alignment — remove the default alias and unify its colour path (#320)

### DIFF
--- a/.changeset/tag-color-path-unification.md
+++ b/.changeset/tag-color-path-unification.md
@@ -1,0 +1,60 @@
+---
+'@repo/ui': major
+---
+
+**Breaking:** `Tag`'s `variant="default"` is removed, and every `Tag` colour now
+resolves through the same `data-color` + `--tag-*` system. Completes #320, which
+6.2.0 shipped only halfway.
+
+### `variant="default"` → `variant="filled"`
+
+6.2.0 renamed the value but kept `'default'` as a deprecated alias. That left the
+exact asymmetry the issue was filed about — `variant="default"` was valid on
+`Tag` but not on `Button`. The alias is now gone.
+
+```diff
+- <Tag variant="default">…</Tag>
++ <Tag variant="filled">…</Tag>
+```
+
+`filled` is also the default, so `variant="default"` can usually just be dropped.
+This is the only source change consumers need to make.
+
+### One colour path instead of two
+
+Before, only the 13 preset colours emitted `data-color` and read `--tag-*`; the
+semantic states (`default`/`primary`/`success`/`warning`/`danger`) carried fixed
+Tailwind classes instead. So `[data-color]` selectors and `--tag-*` overrides
+worked on some colours and silently did nothing on others.
+
+Now every colour goes through the same three custom properties:
+
+| Property     | Role                                          |
+| ------------ | --------------------------------------------- |
+| `--tag-bg`   | the hue; the border when `variant="outlined"` |
+| `--tag-fg`   | text colour (defaults to `--tag-bg`)          |
+| `--tag-tint` | the fill behind `variant="filled"`            |
+
+```css
+/* now works for every colour, not just the presets */
+[data-slot='badge'][data-color='success'] {
+  --tag-bg: oklch(70% 0.2 160);
+}
+```
+
+`Tag` also emits `data-variant` so stylesheets can target a variant without
+re-deriving it from class names.
+
+**Rendered output is unchanged.** All 36 colour × variant combinations were
+screenshot-compared before and after in both light and dark mode; the images are
+byte-identical (MD5 match). The semantic states keep the exact Tailwind ramp
+values they had — `success` still reads green-500/600 with green-400 in dark
+mode, `warning` yellow-500/600 with yellow-400.
+
+### What deliberately did not change
+
+`success` and `warning` stay on `Tag` even though `Button`'s `color` has no such
+values. A `Tag` marks state, and antd's `Tag` carries status colours its `Button`
+does not — dropping them would have made the component worse, not more aligned.
+`variant` likewise stays `filled | outlined` rather than adopting `Button`'s full
+`solid`/`dashed`/`text`/`link` set, which #320 never asked for.

--- a/apps/web/docs/components/atoms/tag.mdx
+++ b/apps/web/docs/components/atoms/tag.mdx
@@ -37,8 +37,32 @@ import { Tag } from '@jbpark/ui-kit';
 `geekblue`, `lime`, `gold` — on top of the named states
 (`primary`/`success`/`warning`/`danger`).
 
-> **Deprecation:** `variant="default"` is still accepted as an alias for
-> `"filled"` and renders identically, but it will be removed in a future major.
-> Prefer `variant="filled"`.
+`success` and `warning` have no `Button` counterpart by design: a `Tag` marks
+state, which is why antd's `Tag` also carries status colours its `Button` does
+not.
+
+### Theming a colour
+
+Every colour — states and presets alike — resolves from the same custom
+properties, set per `data-color`, so any of them can be re-themed the same way:
+
+| Property     | Role                                            |
+| ------------ | ----------------------------------------------- |
+| `--tag-bg`   | the hue; the border when `variant="outlined"`   |
+| `--tag-fg`   | text colour (defaults to `--tag-bg`)            |
+| `--tag-tint` | the fill behind `variant="filled"`              |
+
+```css
+/* re-theme one colour, wherever it is used */
+[data-slot='badge'][data-color='success'] {
+  --tag-bg: oklch(70% 0.2 160);
+}
+```
+
+> **Breaking in 7.0:** `variant="default"` was removed — use `variant="filled"`,
+> which renders identically. Before 7.0 only preset colours emitted `data-color`
+> and read `--tag-*`; the named states used fixed classes, so the hooks above
+> silently did nothing for them. Now every colour takes the same path, and the
+> rendered output for existing tags is pixel-identical.
 
 `Tag` also accepts the rest of `React.ComponentProps<'span'>` (e.g. `onClick`, `style`).

--- a/packages/ui/src/components/atoms/tag.tsx
+++ b/packages/ui/src/components/atoms/tag.tsx
@@ -8,7 +8,7 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
-import { type PresetColor, isPresetColor } from '../../lib/colors';
+import { type PresetColor } from '../../lib/colors';
 
 type NativeSpanProps = React.ComponentProps<'span'> & {
   asChild?: boolean;
@@ -16,18 +16,19 @@ type NativeSpanProps = React.ComponentProps<'span'> & {
 
 export interface Props extends Omit<NativeSpanProps, 'variant' | 'color'> {
   /**
-   * Fill style, aligned with `Button`'s vocabulary. `'default'` is a
-   * **deprecated alias** for `'filled'` — it still renders identically, but
-   * prefer `'filled'` going forward (#320).
-   *
-   * @remarks `'default'` will be removed in a future major.
+   * Fill style, aligned with `Button`'s vocabulary (#320). The pre-7.0
+   * `'default'` spelling was removed — use `'filled'`, which renders
+   * identically.
    */
-  variant?: 'filled' | 'outlined' | 'default';
+  variant?: 'filled' | 'outlined';
   /**
-   * Colour, sharing `Button`'s preset palette. The named states
-   * (`primary`/`success`/`warning`/`danger`) keep their semantic look; the
-   * shared presets (`blue`, `red`, `gold`, …) are backed by the same
-   * `data-color` system as `Button` (#320).
+   * Colour. Every value — the semantic states (`primary`/`success`/`warning`/
+   * `danger`) as well as the palette shared with `Button` (`blue`, `red`,
+   * `gold`, …) — resolves through the same `data-color` + `--tag-*` system
+   * (#320), so any of them can be re-themed the same way.
+   *
+   * `success`/`warning` have no `Button` counterpart on purpose: a Tag marks
+   * state, which is why antd's Tag also carries them while its Button does not.
    */
   color?:
     'default' | 'primary' | 'success' | 'warning' | 'danger' | PresetColor;
@@ -48,35 +49,18 @@ const TAG_BASE = cn(
   'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
 );
 
-const fillColorClasses: Record<string, string> = {
-  default: 'border-transparent bg-muted text-muted-foreground',
-  primary: 'border-transparent bg-primary/10 text-primary',
-  success:
-    'border-transparent bg-green-500/10 text-green-600 dark:text-green-400',
-  warning:
-    'border-transparent bg-yellow-500/10 text-yellow-600 dark:text-yellow-400',
-  danger: 'border-transparent bg-destructive/10 text-destructive',
-};
+// Every colour — semantic states and shared presets alike — resolves from the
+// `--tag-*` custom properties that `globals.css` sets per `data-color` (#320).
+// Before 7.0 only the presets took this path while the states carried bespoke
+// Tailwind classes, which meant `[data-color]` hooks and `--tag-*` overrides
+// worked on some colours but silently not on others.
+//
+//   --tag-bg    the hue; the border in `outlined`
+//   --tag-fg    text colour (defaults to --tag-bg)
+//   --tag-tint  the fill behind `filled` (defaults to a 10% --tag-bg wash)
+const fillClasses = cn('border-transparent bg-(--tag-tint) text-(--tag-fg)');
 
-const outlinedColorClasses: Record<string, string> = {
-  default: 'border-border text-foreground',
-  primary: 'border-primary text-primary',
-  success: 'border-green-500 text-green-600 dark:text-green-400',
-  warning: 'border-yellow-500 text-yellow-600 dark:text-yellow-400',
-  danger: 'border-destructive text-destructive',
-};
-
-// Preset colours resolve their hue from the shared `--tag-bg` custom property
-// (globals.css, keyed on `data-color`) rather than a per-colour Tailwind class,
-// so `Tag` and `Button` stay in lock-step. Fill uses a 10% tint behind the
-// full-strength hue; outlined borders and texts it directly.
-const presetFillClasses = cn(
-  'border-transparent',
-  'bg-[color-mix(in_oklch,var(--tag-bg),transparent_90%)]',
-  'text-(--tag-bg)',
-);
-
-const presetOutlinedClasses = cn('border-(--tag-bg) text-(--tag-bg)');
+const outlinedClasses = cn('border-(--tag-bg) text-(--tag-fg)');
 
 const Tag = ({
   className,
@@ -93,29 +77,23 @@ const Tag = ({
   // — the same resolution order `Button` uses.
   const resolvedVariant = variant ?? tagDefaults?.variant ?? 'filled';
   const resolvedColor = color ?? tagDefaults?.color ?? 'default';
-  // `'default'` is the pre-#320 spelling of `'filled'`; fold it in so the alias
-  // renders identically.
   const isOutlined = resolvedVariant === 'outlined';
-  const preset = isPresetColor(resolvedColor);
   const Comp = asChild ? Slot : 'span';
 
   return (
     <Comp
       data-slot="badge"
-      // Only preset colours drive the `--tag-*` system; the named states keep
-      // their bespoke classes, so existing usage renders byte-identical.
-      data-color={preset ? resolvedColor : undefined}
+      // Emitted for every colour, not just the presets, so consumers can hook
+      // `[data-color]` / `[data-variant]` uniformly. `data-variant` is what
+      // lets `globals.css` give `default` a different text colour when
+      // outlined without reintroducing a second class path here.
+      data-color={resolvedColor}
+      data-variant={resolvedVariant}
       className={cn(
         TAG_BASE,
         'rounded-full px-2.5 py-1',
         'text-xs font-medium',
-        preset
-          ? isOutlined
-            ? presetOutlinedClasses
-            : presetFillClasses
-          : isOutlined
-            ? outlinedColorClasses[resolvedColor]
-            : fillColorClasses[resolvedColor],
+        isOutlined ? outlinedClasses : fillClasses,
         className,
         //
       )}

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -255,11 +255,57 @@
     --btn-bg: #f59e0b;
   }
 
-  /* Tag's shared preset palette (#320). Mirrors the `--btn-*` hues above so a
-   * given colour word renders the same on `Tag` and `Button`; `Tag` reads
-   * `--tag-bg` for both its 10% fill tint and its outlined border/text (see
-   * tag.tsx). Named states (primary/success/warning/danger) keep their own
-   * classes and never set `data-color`, so only these presets match here. */
+  /* Tag's colour system (#320). Every colour — the semantic states as well as
+   * the palette shared with `Button` — resolves here, so `[data-color]` hooks
+   * and `--tag-*` overrides behave the same whichever one is in use. Preset
+   * hues mirror the `--btn-*` values above so a colour word renders the same
+   * on `Tag` and `Button`.
+   *
+   *   --tag-bg    the hue; also the border in `outlined`
+   *   --tag-fg    text colour; defaults to the hue
+   *   --tag-tint  the fill behind `filled`; defaults to a 10% wash */
+  [data-slot='badge'][data-color] {
+    --tag-fg: var(--tag-bg);
+    --tag-tint: color-mix(in oklab, var(--tag-bg), transparent 90%);
+  }
+
+  /* Semantic states. `default` is the one colour whose fill is a solid surface
+   * rather than a wash of its own hue, and whose text differs between the two
+   * variants — hence the explicit tint/fg. */
+  [data-slot='badge'][data-color='default'] {
+    --tag-bg: var(--border);
+    --tag-tint: var(--muted);
+    --tag-fg: var(--muted-foreground);
+  }
+  [data-slot='badge'][data-color='default'][data-variant='outlined'] {
+    --tag-fg: var(--foreground);
+  }
+
+  [data-slot='badge'][data-color='primary'] {
+    --tag-bg: var(--primary);
+  }
+  [data-slot='badge'][data-color='danger'] {
+    --tag-bg: var(--destructive);
+  }
+  /* success/warning read one step darker than their hue for legible text on a
+   * light surface, and one step lighter in dark mode — the exact Tailwind
+   * green/yellow ramp values these two rendered before they joined this
+   * system, so the move is visually lossless. */
+  [data-slot='badge'][data-color='success'] {
+    --tag-bg: oklch(72.3% 0.219 149.579);
+    --tag-fg: oklch(62.7% 0.194 149.214);
+  }
+  [data-slot='badge'][data-color='warning'] {
+    --tag-bg: oklch(79.5% 0.184 86.047);
+    --tag-fg: oklch(68.1% 0.162 75.834);
+  }
+  :is(.dark, [data-theme='dark']) [data-slot='badge'][data-color='success'] {
+    --tag-fg: oklch(79.2% 0.209 151.711);
+  }
+  :is(.dark, [data-theme='dark']) [data-slot='badge'][data-color='warning'] {
+    --tag-fg: oklch(85.2% 0.199 91.936);
+  }
+
   [data-slot='badge'][data-color='blue'] {
     --tag-bg: #3b82f6;
   }


### PR DESCRIPTION
Closes #320. Follows up #327, which shipped this issue only halfway.

## Why reopen a closed issue

#320 asked to align `Tag`'s vocabulary with `Button` and filed it as
**breaking / major**, while inviting a deprecation window "if feasible". #327
took that option and shipped as an additive minor in 6.2.0 — which was a
reasonable call, but it left the issue's actual complaint unresolved:

- `variant="default"` stayed valid on `Tag` and still isn't on `Button`. That
  asymmetry *is* the thing the issue opened with.
- Only preset colours were moved onto the shared system. The semantic states kept
  bespoke Tailwind classes, so `Tag` ended up with **two** colour paths where it
  previously had one — `[data-color]` selectors and `--tag-*` overrides worked on
  13 colours and silently did nothing on the other 5.

This PR finishes the job as a major.

## Checked against antd first

Before removing anything I compared with [antd's Tag](https://ant.design/components/tag)
(v6.6), since this library follows its vocabulary:

| | antd `Tag` | antd `Button` |
| --- | --- | --- |
| `variant` | `filled \| solid \| outlined` (`bordered` boolean deprecated) | `outlined \| dashed \| solid \| filled \| text \| link` |
| `color` | `string` — presets **and** status words | `default \| primary \| danger \| PresetColors` |

Two things follow:

1. **Removing `variant="default"` matches antd**, which did the same thing in v6
   by folding `bordered` into `variant` and deprecating it.
2. **`success`/`warning` must stay.** antd deliberately does *not* align the two
   `color` domains — its documented "Status Tag" example passes
   `success`/`processing`/`warning`/`error`/`default` as `color`, none of which
   its `Button` accepts. Dropping them to match `Button` would have made `Tag`
   worse, not more aligned. An earlier plan for this PR did intend to drop them;
   the antd check is what corrected it.

## What changed

- **`variant="default"` removed.** Use `variant="filled"` — identical rendering,
  and it's the default value, so the prop can usually just be dropped.
- **One colour path.** Every colour emits `data-color` and resolves from three
  custom properties:

  | Property | Role |
  | --- | --- |
  | `--tag-bg` | the hue; the border when `variant="outlined"` |
  | `--tag-fg` | text colour (defaults to `--tag-bg`) |
  | `--tag-tint` | the fill behind `variant="filled"` |

  Three properties rather than one is what lets `default` keep its solid `muted`
  surface — and its different text colour per variant — without reintroducing a
  second class path in the component.
- **`data-variant` is emitted**, so stylesheets can target a variant directly. It
  also backs the `default`-when-outlined text rule.
- `tag.tsx` drops four class maps and the `isPresetColor` branch for a single
  fill/outlined pair.

## Verification: rendered output is unchanged

The risk in this refactor is silent visual drift, so it was checked by pixels
rather than by eye. Both revisions were built and SSR-rendered across the full
**36-case matrix** (18 colours × 2 variants), then screenshotted in light and
dark mode:

```
light: IDENTICAL   md5 be6f5f138200c25b240c0b077f777408
dark : IDENTICAL   md5 4ab0ae8f8da81aae46338873a50bf995
```

Byte-identical PNGs both ways. Getting there required two corrections found by
computed-style diffing:

- the semantic states use the exact Tailwind ramp values in `oklch`
  (`success` = green-500/600, green-400 in dark; `warning` = yellow-500/600,
  yellow-400 in dark) rather than their sRGB hex equivalents, which are a hair
  less saturated on wide-gamut displays;
- `--tag-tint` mixes `in oklab` to match what Tailwind's `/10` opacity modifier
  did before.

Local: `check-types` · `lint` · `check-dynamic-classes` · `check-regression-net`
(api-surface / preflight-reset / ssr-smoke — 37 components, `badge` slot and Tag
chassis intact) all green.

## Migration

```diff
- <Tag variant="default">…</Tag>
+ <Tag variant="filled">…</Tag>
```

That is the only required source change. Nothing inside this repo used the alias
(only the docs note announcing it), so no call sites needed updating.

## Type of Change

- [x] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

Ships as **major** (7.0.0) per the changeset.

## Checklist

- [x] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [x] Storybook stories are added for new components / features — the existing
      Tag story already exposed only `filled`/`outlined`, so it needed no change
- [x] No type or lint errors
- [x] Build completes successfully, regression net green
