### PR TITLE
fix(scripts): extract nvidia-chat.mjs with model fallback and think-block strip

### DIFF
--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -8,14 +8,13 @@
 // something a human already wrote or edited. One file is written per
 // package that actually changed, since each needs its own bump + summary.
 //
-// Uses NVIDIA's OpenAI-compatible API Catalog endpoint (not Gemini/GitHub
-// Models — both have hit sustained outages/retirement before this).
+// Uses NVIDIA's OpenAI-compatible API Catalog endpoint. Model selection,
+// fallback logic, and <think>-block stripping live in nvidia-chat.mjs.
 
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import { nvidiaChat, requireEnv } from './nvidia-chat.mjs';
 
-const MODEL = process.env.NVIDIA_MODEL || 'meta/llama-3.1-8b-instruct';
-const API_URL = 'https://integrate.api.nvidia.com/v1/chat/completions';
 const MAX_DIFF_CHARS = 12000;
 
 // `fileSuffix: ''` for @repo/ui keeps its filename as just the branch
@@ -57,44 +56,6 @@ const PACKAGES = [
     kind: 'Storybook/docs site, deployed but not published to npm',
   },
 ];
-
-// The API occasionally returns 503/429 for a few minutes at a time — retry
-// those with backoff instead of failing the required "draft" check
-// outright. Non-retryable statuses (bad key, bad request, etc.) still fail
-// on the first attempt.
-const MAX_ATTEMPTS = 4;
-const RETRY_BASE_DELAY_MS = 2000;
-const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function fetchWithRetry(url, options) {
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const response = await fetch(url, options);
-
-    if (
-      response.ok ||
-      !RETRYABLE_STATUSES.has(response.status) ||
-      attempt === MAX_ATTEMPTS
-    ) {
-      return response;
-    }
-
-    const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
-    console.log(
-      `NVIDIA API returned ${response.status}, retrying in ${delayMs}ms (attempt ${attempt}/${MAX_ATTEMPTS})...`,
-    );
-    await sleep(delayMs);
-  }
-}
-
-function requireEnv(name) {
-  const value = process.env[name];
-  if (!value) throw new Error(`Missing required env var: ${name}`);
-  return value;
-}
 
 // The model isn't guaranteed to honor a strict JSON-only instruction, so
 // pull the object out of a ```json fenced block if present and fall back to
@@ -160,40 +121,17 @@ async function draftFor(pkg, { apiKey, baseSha, headSha, branchSlug }) {
   ].join(' ');
 
   // A drafted changeset is a nice-to-have, not something worth failing the
-  // required "draft" check over — if the API is unavailable even after
-  // retries, skip this package (other packages still get a chance) instead
-  // of blocking the PR. A human can always add a changeset by hand.
+  // required "draft" check over — if the API is unavailable even after all
+  // candidates are exhausted, skip this package instead of blocking the PR.
   let result;
   try {
-    const response = await fetchWithRetry(API_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        temperature: 0,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: `\`\`\`diff\n${truncatedDiff}\n\`\`\`` },
-        ],
-      }),
+    const content = await nvidiaChat(apiKey, {
+      temperature: 0,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: `\`\`\`diff\n${truncatedDiff}\n\`\`\`` },
+      ],
     });
-
-    if (!response.ok) {
-      throw new Error(
-        `NVIDIA API request failed for ${pkg.name}: ${response.status} ${response.statusText} — ${await response.text()}`,
-      );
-    }
-
-    const body = await response.json();
-    const content = body.choices?.[0]?.message?.content;
-    if (!content) {
-      throw new Error(
-        `NVIDIA API response missing choices[0].message.content for ${pkg.name}`,
-      );
-    }
 
     result = extractJson(content);
     if (!result || typeof result !== 'object') {

--- a/.github/scripts/nvidia-chat.mjs
+++ b/.github/scripts/nvidia-chat.mjs
@@ -1,0 +1,129 @@
+// Shared NVIDIA API Catalog chat helper.
+// Imported by polish-release-notes.mjs and draft-changeset.mjs.
+//
+// Key behaviours
+//   - Tries MODEL_CANDIDATES in order; moves to the next on 404/410 (gone).
+//   - Retries 429/5xx with exponential backoff (unchanged from before).
+//   - Strips a leading <think>…</think> block from content defensively
+//     (several NVIDIA-hosted reasoning models emit one into message.content).
+//   - On total exhaustion, throws a descriptive error — callers decide whether
+//     to surface it as ::warning:: or ::error::.
+
+export const API_URL = 'https://integrate.api.nvidia.com/v1/chat/completions';
+
+// Tried in order. First success wins; 404/410 advances to the next candidate.
+// Override the whole list by setting NVIDIA_MODEL (single model, no fallback).
+export const MODEL_CANDIDATES = process.env.NVIDIA_MODEL
+  ? [process.env.NVIDIA_MODEL]
+  : [
+      'openai/gpt-oss-20b',               // verified working 2026-09-03
+      'nvidia/nemotron-nano-3-30b-a3b',   // NVIDIA-own, likely longest-lived
+      'mistralai/mistral-7b-instruct-v0.3', // small, historically long-lived
+    ];
+
+const MAX_ATTEMPTS = 4;
+const RETRY_BASE_DELAY_MS = 2000;
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const GONE_STATUSES = new Set([404, 410]);
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Strip a leading <think>…</think> block that some reasoning-tuned models
+ * emit into message.content (as opposed to the separate reasoning_content
+ * field used by gpt-oss-20b). The block may span multiple lines.
+ */
+export function stripThinkBlock(text) {
+  return text.replace(/^\s*<think>[\s\S]*?<\/think>\s*/i, '').trim();
+}
+
+/**
+ * POST a single chat-completion request to one model with retry/backoff.
+ * Returns the raw fetch Response (ok or not).
+ * Throws only on network-level failures.
+ */
+async function fetchModel(model, apiKey, body) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const response = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ...body, model }),
+    });
+
+    if (response.ok) return response;
+    if (GONE_STATUSES.has(response.status)) return response; // caller advances candidate
+    if (!RETRYABLE_STATUSES.has(response.status)) return response; // fail fast
+    if (attempt === MAX_ATTEMPTS) return response;
+
+    const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    console.log(
+      `NVIDIA API [${model}] returned ${response.status}, retrying in ${delayMs}ms` +
+      ` (attempt ${attempt}/${MAX_ATTEMPTS})...`,
+    );
+    await sleep(delayMs);
+  }
+}
+
+/**
+ * Send a chat-completion request, falling through MODEL_CANDIDATES on 404/410.
+ *
+ * @param {string}   apiKey  NVIDIA_API_KEY value
+ * @param {object}   body    Request body fields (except `model`; that's injected here)
+ * @returns {Promise<string>} Polished content string (think-block stripped)
+ * @throws  {Error}          When all candidates are exhausted or the last one fails
+ */
+export async function nvidiaChat(apiKey, body) {
+  let lastError;
+
+  for (const model of MODEL_CANDIDATES) {
+    let response;
+    try {
+      response = await fetchModel(model, apiKey, body);
+    } catch (err) {
+      lastError = err;
+      console.log(`NVIDIA API [${model}] network error: ${err.message} — trying next candidate`);
+      continue;
+    }
+
+    if (GONE_STATUSES.has(response.status)) {
+      const detail = await response.text().catch(() => '');
+      console.log(
+        `NVIDIA API [${model}] returned ${response.status} (model gone) — trying next candidate.\n  ${detail}`,
+      );
+      lastError = new Error(`Model gone: ${response.status} — ${detail}`);
+      continue;
+    }
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(
+        `NVIDIA API [${model}] request failed: ${response.status} ${response.statusText} — ${detail}`,
+      );
+    }
+
+    const json = await response.json();
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) {
+      throw new Error(
+        `NVIDIA API [${model}] response missing choices[0].message.content`,
+      );
+    }
+
+    const content = stripThinkBlock(raw);
+    console.log(`NVIDIA API: used model ${model}`);
+    return content;
+  }
+
+  throw lastError ?? new Error('All NVIDIA model candidates exhausted with no response');
+}
+
+export function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}

--- a/.github/scripts/polish-release-notes.mjs
+++ b/.github/scripts/polish-release-notes.mjs
@@ -5,49 +5,12 @@
 // failure — the caller falls back to the raw changelog text in that case,
 // so a release is never blocked on this.
 //
-// Uses NVIDIA's OpenAI-compatible API Catalog endpoint (not GitHub Models —
-// retired 2026-07-30; see draft-changeset.mjs for the same move).
+// Uses NVIDIA's OpenAI-compatible API Catalog endpoint. Model selection and
+// fallback logic live in nvidia-chat.mjs.
 
-const MODEL = process.env.NVIDIA_MODEL || 'meta/llama-3.1-8b-instruct';
-const API_URL = 'https://integrate.api.nvidia.com/v1/chat/completions';
+import { nvidiaChat, requireEnv } from './nvidia-chat.mjs';
+
 const MAX_CHARS = 6000;
-
-// The API occasionally returns 503/429 for a few minutes at a time — retry
-// those with backoff instead of failing outright. Non-retryable statuses
-// (bad key, bad request, etc.) still fail on the first attempt.
-const MAX_ATTEMPTS = 4;
-const RETRY_BASE_DELAY_MS = 2000;
-const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function fetchWithRetry(url, options) {
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const response = await fetch(url, options);
-
-    if (
-      response.ok ||
-      !RETRYABLE_STATUSES.has(response.status) ||
-      attempt === MAX_ATTEMPTS
-    ) {
-      return response;
-    }
-
-    const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
-    console.log(
-      `NVIDIA API returned ${response.status}, retrying in ${delayMs}ms (attempt ${attempt}/${MAX_ATTEMPTS})...`,
-    );
-    await sleep(delayMs);
-  }
-}
-
-function requireEnv(name) {
-  const value = process.env[name];
-  if (!value) throw new Error(`Missing required env var: ${name}`);
-  return value;
-}
 
 async function readStdin() {
   const chunks = [];
@@ -80,33 +43,13 @@ async function main() {
     'no code fences.',
   ].join(' ');
 
-  const response = await fetchWithRetry(API_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      temperature: 0.3,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: truncated },
-      ],
-    }),
+  const content = await nvidiaChat(apiKey, {
+    temperature: 0.3,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: truncated },
+    ],
   });
-
-  if (!response.ok) {
-    throw new Error(
-      `NVIDIA API request failed: ${response.status} ${response.statusText} — ${await response.text()}`,
-    );
-  }
-
-  const body = await response.json();
-  const content = body.choices?.[0]?.message?.content?.trim();
-  if (!content) {
-    throw new Error('NVIDIA API response missing choices[0].message.content');
-  }
 
   process.stdout.write(content);
 }


### PR DESCRIPTION
## Summary

Fixes #330.

### Changes

**New: `.github/scripts/nvidia-chat.mjs`** (shared module)
- `MODEL_CANDIDATES` list — tries in order, falls through on 404/410 (model gone)
  1. `openai/gpt-oss-20b` — verified working 2026-09-03
  2. `nvidia/nemotron-nano-3-30b-a3b` — NVIDIA-own, likely longest-lived
  3. `mistralai/mistral-7b-instruct-v0.3` — small, historically long-lived
- 429/5xx retries with backoff unchanged from before
- `stripThinkBlock()` — strips leading `<think>…</think>` from `message.content` defensively (some reasoning-tuned models emit one inline)
- `requireEnv()` shared helper
- Override the whole list with `NVIDIA_MODEL` env var (single model, no fallback)

**Refactored: `polish-release-notes.mjs`**
- Imports `nvidiaChat` from `nvidia-chat.mjs` — all retry/fallback/strip logic removed from here

**Refactored: `draft-changeset.mjs`**
- Same — imports `nvidiaChat` from `nvidia-chat.mjs`

**Secret updated:** `NVIDIA_API_KEY` set to new token via `gh secret set`

### How to verify

```bash
printf '### Patch Changes\n\n- abc1234: Fix a thing.\n'   | PACKAGE_NAME="@repo/ui" VERSION="9.9.9"     NVIDIA_API_KEY="$NVIDIA_API_KEY"     node .github/scripts/polish-release-notes.mjs
# expect: prose release notes on stdout, exit 0, log line: "NVIDIA API: used model openai/gpt-oss-20b"
```

Then on the next real release: the *Get changelog entry* step should not emit `::warning::Release-note polishing failed`.