### PR TITLE
🔧 chore: modernize CI action versions and align pnpm to packageManager

### DIFF
--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,13 @@ jobs:
         node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,15 +23,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: 'pnpm'
@@ -57,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v6
 
       # v6+ is required for npm's OIDC "Trusted Publishing" used below.
       # No built-in `cache: 'pnpm'` here on purpose — this job skips
@@ -35,7 +33,7 @@ jobs:
       # step below is scoped to the same already_tagged condition as
       # Install dependencies instead.
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
@@ -62,7 +60,7 @@ jobs:
 
       - name: Setup pnpm cache
         if: steps.tag_check.outputs.already_tagged == 'false'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -150,7 +148,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.tag_check.outputs.already_tagged == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.tag_check.outputs.version }}
           body: ${{ steps.changelog.outputs.body || format('Release {0}', steps.tag_check.outputs.version) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag }}
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.tag }}
           body: ${{ steps.changelog.outputs.body || format('Release {0}', github.event.inputs.tag) }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,17 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: 'pnpm'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "engines": {
     "node": ">=20",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   },
   "packageManager": "pnpm@10.28.0",
   "workspaces": [


### PR DESCRIPTION
## Summary

Fixes the two latent CI defects in #331 in one pass:

- **Node 16/20 runtimes** — every action still declaring a deprecated Node runtime is bumped to its newest major that ships on Node 24:
  - `actions/checkout` v4 → v7
  - `actions/setup-node` v4/v6 → v7 (was inconsistent: publish.yml already on v6, others on v4)
  - `actions/cache` v4 → v6
  - `actions/deploy-pages` v4 → v5
  - `pnpm/action-setup` v2 → v6
  - `softprops/action-gh-release` v1 → v3
- **pnpm version mismatch** — dropped the hardcoded `version: 9` pin so `pnpm/action-setup` v6 reads `pnpm@10.28.0` from `packageManager`, ending the CI-runs-9 / local-runs-10 drift at its source.
- Narrowed `engines.pnpm` from `>=9` to `>=10` so future drift is an error, not silent.

## Intentionally left as-is (per #331 "Not a problem")

- `actions/upload-pages-artifact@v3` — composite action, no Node runtime to deprecate.
- `changesets/action@v1` — already runs on Node 24; bumping is optional/unrelated.
- `publish.yml`'s omission of `cache: 'pnpm'` on `setup-node` — preserved (the job skips `pnpm install` on most runs, so the cache-save step would error).

## Test plan

- All 6 workflows parse as valid YAML.
- `grep -rn "uses: " .github/workflows/` shows no action older than its Node 24 major.
- No `version: 9` pins remain.
- On the next runs: no `Node 20 is being deprecated` annotation; *Setup pnpm* reports a 10.x version; `ci`/`version`/`publish`/`changeset-draft`/`docs-deploy` still pass. `docs-deploy` and `release` are the least-exercised — worth an explicit check.

Closes #331