### PR TITLE
🔧 chore: add .mailmap to correct a stray commit identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+pjb0811 <pjb0811@gmail.com> jax <jax@dev.local>


### PR DESCRIPTION
## Summary
- Commit dab6d7e ("fix(scripts): extract nvidia-chat.mjs with model fallback and think-block strip") was made from a session using a generic `jax <jax@dev.local>` git identity.
- Rewriting that commit isn't practical: it's 16 commits behind HEAD on an already-pushed `main`, and everything after it (including the just-published `v7.1.0` tag) would need new hashes plus a force-push — worse than the problem it fixes.
- Added `.mailmap` remapping it to `pjb0811 <pjb0811@gmail.com>` for `git log`/`git shortlog`/`--use-mailmap`, without touching any commit hash.

## Test plan
- [x] `git log --use-mailmap --format='%aN <%aE>' dab6d7e` now shows `pjb0811 <pjb0811@gmail.com>`