### PR TITLE
⏪️ revert: remove .mailmap added in #339

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,0 @@
-pjb0811 <pjb0811@gmail.com> jax <jax@dev.local>


### PR DESCRIPTION
## Summary
- Reverts the `.mailmap` file added in #339 per request — tracking the `jax@dev.local` commit identity mentally/by note instead of remapping it in the repo.