### PR TITLE
docs: drop gitmoji from commit convention

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: commit
-description: "Analyze the currently staged git changes and draft a commit message in gitmoji + conventional-commit style (one gitmoji + `type(scope): summary` title, then Korean or English `-` bullets), get user approval, then run the actual git commit. Defaults to English; pass 'ko' to write in Korean. If the repo has `.github/COMMIT_CONVENTION.ko.md` / `.github/COMMIT_CONVENTION.en.md`, follow those as the source of truth instead of the built-in tables below. Use when the user says '커밋해줘', '/commit', 'commit this', 'write a commit message and commit'."
+description: "Analyze the currently staged git changes and draft a commit message in conventional-commit style (`type(scope): summary` title, no emoji, then Korean or English `-` bullets), get user approval, then run the actual git commit. Defaults to English; pass 'ko' to write in Korean. If the repo has `.github/COMMIT_CONVENTION.ko.md` / `.github/COMMIT_CONVENTION.en.md`, follow those as the source of truth instead of the built-in tables below. Use when the user says '커밋해줘', '/commit', 'commit this', 'write a commit message and commit'."
 ---
 
 # Commit
 
-스테이징된 변경사항을 분석해 gitmoji + conventional-commit 스타일 커밋 메시지를 작성하고, 승인받은 뒤 실제로 커밋한다.
+스테이징된 변경사항을 분석해 conventional-commit 스타일 커밋 메시지를 작성하고, 승인받은 뒤 실제로 커밋한다.
 
 인자: 언어 지정 (`ko` 또는 `en`). 미지정 시 기본값은 `en`.
 
@@ -56,7 +56,7 @@ git diff --cached
 **형식**:
 
 ```
-<emoji> <type>(<scope>): <요약>
+<type>(<scope>): <요약>
 
 - 세부 변경사항 1
 - 세부 변경사항 2
@@ -79,52 +79,7 @@ git diff --cached
 | `ci`       | CI/CD 설정                           |
 | `build`    | 빌드 시스템 변경                     |
 
-**Gitmoji 선택 기준** (변경 성격에 가장 적절한 것 하나만, https://gitmoji.dev/ 기준):
-
-| Emoji | 설명                                       |
-| ----- | ------------------------------------------ |
-| ✨    | 새로운 기능/컴포넌트 도입                  |
-| 🐛    | 버그 수정                                  |
-| 🚑️    | 긴급 핫픽스                                |
-| ♻️    | 코드 리팩토링                              |
-| 🎨    | 코드 구조/포맷 개선                        |
-| 📝    | 문서 추가/수정                             |
-| 🔧    | 설정 파일 추가/수정                        |
-| 🔨    | 개발 스크립트 추가/수정                    |
-| ⬆️    | 의존성 업그레이드                          |
-| ⬇️    | 의존성 다운그레이드                        |
-| 📌    | 특정 버전으로 의존성 고정                  |
-| ➕    | 의존성 추가                                |
-| ➖    | 의존성 제거                                |
-| 🔥    | 코드/파일 삭제                             |
-| 🚚    | 리소스 이동/이름 변경 (파일, 경로, 라우트) |
-| 💄    | UI/스타일 변경                             |
-| ♿️    | 접근성 개선                                |
-| 🏷️    | 타입 추가/수정                             |
-| 🩹    | 간단한 수정                                |
-| ⚡️    | 성능 향상                                  |
-| 💚    | CI 빌드 수정                               |
-| 👷    | CI 빌드 시스템 추가/수정                   |
-| 🚧    | 작업 진행 중                               |
-| ✅    | 테스트 추가/수정/통과                      |
-| 🧪    | 실패하는 테스트 추가                       |
-| 🔒️    | 보안/개인정보 보호 문제 해결               |
-| 🔐    | 비밀 키 추가/수정                          |
-| 🔖    | 릴리스/버전 태그                           |
-| 🚨    | 컴파일러/린터 경고 수정                    |
-| 💥    | 호환성을 깨뜨리는 변경 도입                |
-| 🌐    | 국제화/현지화                              |
-| ✏️    | 오타 수정                                  |
-| 🔀    | 브랜치 병합                                |
-| ⏪️    | 변경 사항 되돌리기                         |
-| 🗃️    | 데이터베이스 관련 변경                     |
-| 🏗️    | 아키텍처 변경                              |
-| 📱    | 반응형 디자인 작업                         |
-| 🚸    | 사용자 경험/사용성 개선                    |
-| 🥅    | 에러 처리                                  |
-| 🧑‍💻    | 개발자 경험 개선                           |
-
-(이 외 gitmoji가 더 적절하면 https://gitmoji.dev/ 목록에서 하나 선택해도 된다. 저장소에 `.github/COMMIT_CONVENTION.*.md`가 있으면 그쪽의 전체 목록을 우선한다.)
+**이모지/gitmoji 없음** — 제목 앞에 이모지를 붙이지 않는다. (2026-09-07 전역 컨벤션 변경. 저장소에 `.github/COMMIT_CONVENTION.*.md`가 있으면 그쪽을 우선한다.)
 
 **작성 원칙**:
 

--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -6,16 +6,16 @@ Please write it accurately as it will be used for actual commits.
 ### Basic Format
 
 ```
-<emoji> <type>(<scope>): <short summary>
-│       │        │            │
-│       │        │            └─⫸ Imperative, present tense. No capitalization. No period at the end.
-│       │        │
-│       │        └─⫸ Optional. Only when the change is clearly scoped to one specific area
-│       │
-│       └─⫸ feat|fix|docs|style|refactor|test|chore|perf|ci|build
+<type>(<scope>): <short summary>
+│        │            │
+│        │            └─⫸ Imperative, present tense. No capitalization. No period at the end.
+│        │
+│        └─⫸ Optional. Only when the change is clearly scoped to one specific area
 │
-└─⫸ Select only one gitmoji most appropriate for the change
+└─⫸ feat|fix|docs|style|refactor|test|chore|perf|ci|build
 ```
+
+**Do not prefix the title with an emoji/gitmoji.** (Per the global convention change on 2026-09-07, commit titles are plain `type(scope): summary`.)
 
 **Language**: English
 
@@ -45,94 +45,6 @@ Scope is optional. Add it only when the change is clearly limited to one specifi
 **Don't use the branch name as scope** — branch names (especially ones with slashes, like `feat/main`) aren't valid conventional-commit scopes.
 
 For changes spanning multiple areas (e.g. a CI/release pipeline overhaul, a broad documentation cleanup), omit the scope entirely rather than forcing it into one.
-
-### Gitmoji Selection
-
-**Rules**:
-
-- Select **only one** gitmoji from https://gitmoji.dev/
-- Add **one space** after gitmoji
-- Place before type
-
-**Complete Gitmoji List**:
-
-| Emoji | Description                                      |
-| ----- | ------------------------------------------------ |
-| 🎨    | Improve structure/format of code                 |
-| ⚡️    | Improve performance                              |
-| 🔥    | Remove code or files                             |
-| 🐛    | Fix a bug                                        |
-| 🚑️    | Critical hotfix                                  |
-| ✨    | Introduce new features                           |
-| 📝    | Add or update documentation                      |
-| 🚀    | Deploy stuff                                     |
-| 💄    | Add or update UI and style files                 |
-| 🎉    | Begin a project                                  |
-| ✅    | Add, update, or pass tests                       |
-| 🔒️    | Fix security or privacy issues                   |
-| 🔐    | Add or update secrets                            |
-| 🔖    | Release / Version tags                           |
-| 🚨    | Fix compiler / linter warnings                   |
-| 🚧    | Work in progress                                 |
-| 💚    | Fix CI Build                                     |
-| ⬇️    | Downgrade dependencies                           |
-| ⬆️    | Upgrade dependencies                             |
-| 📌    | Pin dependencies to specific versions            |
-| 👷    | Add or update CI build system                    |
-| 📈    | Add or update analytics or track code            |
-| ♻️    | Refactor code                                    |
-| ➕    | Add a dependency                                 |
-| ➖    | Remove a dependency                              |
-| 🔧    | Add or update configuration files                |
-| 🔨    | Add or update development scripts                |
-| 🌐    | Internationalization and localization            |
-| ✏️    | Fix typos                                        |
-| 💩    | Write bad code that needs to be improved         |
-| ⏪️    | Revert changes                                   |
-| 🔀    | Merge branches                                   |
-| 📦️    | Add or update compiled files or packages         |
-| 👽️    | Update code due to external API changes          |
-| 🚚    | Move or rename resources (files, paths, routes)  |
-| 📄    | Add or update license                            |
-| 💥    | Introduce breaking changes                       |
-| 🍱    | Add or update assets                             |
-| ♿️    | Improve accessibility                            |
-| 💡    | Add or update comments in source code            |
-| 🍻    | Write code drunkenly                             |
-| 💬    | Add or update text and literals                  |
-| 🗃️    | Perform database related changes                 |
-| 🔊    | Add or update logs                               |
-| 🔇    | Remove logs                                      |
-| 👥    | Add or update contributor(s)                     |
-| 🚸    | Improve user experience / usability              |
-| 🏗️    | Make architectural changes                       |
-| 📱    | Work on responsive design                        |
-| 🤡    | Mock things                                      |
-| 🥚    | Add or update an easter egg                      |
-| 🙈    | Add or update a .gitignore file                  |
-| 📸    | Add or update snapshots                          |
-| ⚗️    | Perform experiments                              |
-| 🔍️    | Improve SEO                                      |
-| 🏷️    | Add or update types                              |
-| 🌱    | Add or update seed files                         |
-| 🚩    | Add, update, or remove feature flags             |
-| 🥅    | Catch errors                                     |
-| 💫    | Add or update animations and transitions         |
-| 🗑️    | Deprecate code that needs to be cleaned up       |
-| 🛂    | Work on code related to authorization, roles     |
-| 🩹    | Simple fix for a non-critical issue              |
-| 🧐    | Data exploration/inspection                      |
-| ⚰️    | Remove dead code                                 |
-| 🧪    | Add a failing test                               |
-| 👔    | Add or update business logic                     |
-| 🩺    | Add or update healthcheck                        |
-| 🧱    | Infrastructure related changes                   |
-| 🧑‍💻    | Improve developer experience                     |
-| 💸    | Add sponsorships or money related infrastructure |
-| 🧵    | Add or update code related to multithreading     |
-| 🦺    | Add or update code related to validation         |
-| ✈️    | Improve offline support                          |
-| 🦖    | Add backward compatibility                       |
 
 ### Message Body Writing
 
@@ -170,12 +82,12 @@ Human co-authors are legitimate. `github-actions[bot]` trailers on `chore: versi
 
 This document is the source of truth for this repository and **takes precedence** over the global commit rules (`~/.claude/commands/commit.md`, `~/.copilot/instructions/commit-message.instructions.md`), which default to Korean summaries and no scope.
 
-The two deliberate differences are **English** and the **optional scope**, both because this repository's commit history is a public artifact — it is published to npm as `@jbpark/ui-kit` and read by outside contributors and release notes, the same reasoning the global rules apply to issues and PRs. Everything else (gitmoji selection, commit types, no trailers, `CHANGELOG.md` exclusion, lock-file exclusion) matches the global rules.
+The two deliberate differences are **English** and the **optional scope**, both because this repository's commit history is a public artifact — it is published to npm as `@jbpark/ui-kit` and read by outside contributors and release notes, the same reasoning the global rules apply to issues and PRs. Everything else (no emoji/gitmoji, commit types, no trailers, `CHANGELOG.md` exclusion, lock-file exclusion) matches the global rules.
 
 ### Examples
 
 ```
-✨ feat(auth): add user authentication feature
+feat(auth): add user authentication feature
 
 - Implement JWT-based login/logout
 - Add automatic token refresh logic
@@ -183,7 +95,7 @@ The two deliberate differences are **English** and the **optional scope**, both 
 ```
 
 ```
-🐛 fix(use-query): fix metaform type error
+fix(use-query): fix metaform type error
 
 - Change any type to specific type in useMutation
 - Improve error handling logic in useQuery
@@ -191,7 +103,7 @@ The two deliberate differences are **English** and the **optional scope**, both 
 ```
 
 ```
-♻️ refactor(events): improve event directory structure
+refactor(events): improve event directory structure
 
 - Reorganize component folders
 - Improve naming consistency

--- a/.github/skills/commit/SKILL.md
+++ b/.github/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: "Generate a commit message from staged changes using this repository's commit convention. Use when the user asks for /commit, commit message generation, gitmoji selection, commit type or scope selection, or creating an actual git commit from staged files."
+description: "Generate a commit message from staged changes using this repository's commit convention. Use when the user asks for /commit, commit message generation, commit type or scope selection, or creating an actual git commit from staged files."
 argument-hint: 'Optional: special emphasis, for example "docs only" or "no scope". Messages are English by default.'
 user-invocable: true
 disable-model-invocation: false
@@ -14,7 +14,7 @@ disable-model-invocation: false
 
 - 사용자가 `/commit` 을 호출할 때
 - 스테이징된 변경을 바탕으로 커밋 메시지를 만들어 달라고 할 때
-- gitmoji, type, scope 선택까지 포함한 커밋 메시지 초안이 필요할 때
+- type, scope 선택까지 포함한 커밋 메시지 초안이 필요할 때
 - 사용자가 명시적으로 요청한 경우 실제 `git commit` 까지 진행해야 할 때
 
 ## Source Convention
@@ -25,7 +25,7 @@ disable-model-invocation: false
 - 형식은 반드시 아래 형태를 따른다.
 
 ```text
-<emoji> <type>(<scope>): <short summary>
+<type>(<scope>): <short summary>
 
 - detail 1
 - detail 2
@@ -33,7 +33,7 @@ disable-model-invocation: false
 
 ## Required Rules
 
-- 변경 내용에 가장 적절한 gitmoji 하나만 고른다.
+- **제목 앞에 이모지/gitmoji를 붙이지 않는다.** (2026-09-07 전역 컨벤션 변경)
 - `type` 은 `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`, `build` 중 하나만 사용한다.
 - `scope` 는 **선택 사항**이다. 변경이 한 영역에 명확히 국한될 때만 붙인다. 예: `ui`, `web`, `docs`, `components`, `config`, `build`
 - **브랜치명을 scope 로 쓰지 않는다.** 슬래시가 든 브랜치명(`refactor/ui-phase5-...`)은 유효한 conventional-commit scope 가 아니다.
@@ -61,7 +61,7 @@ disable-model-invocation: false
 3. 스테이징된 변경이 없으면 메시지를 지어내지 말고, 스테이징이 필요하다고 안내한다.
 4. 변경이 한 영역에 국한되는지 판단해 `scope` 를 붙일지 정한다. 브랜치명은 쓰지 않는다.
 5. 스테이징된 diff 와 파일 목록만 보고 가장 대표적인 변경 목적 하나를 고른다.
-6. 그 목적에 맞는 `gitmoji` 와 `type` 을 하나씩만 선택한다.
+6. 그 목적에 맞는 `type` 을 하나만 선택한다.
 7. 한 줄 제목을 먼저 만들고, 이어서 본문 bullet 을 1개 이상 작성한다.
 8. 결과는 바로 사용할 수 있는 최종 커밋 메시지 형태로 제시한다.
 9. 사용자가 실제 커밋 실행을 명시적으로 요청한 경우에만 `git commit` 을 수행한다.
@@ -76,15 +76,15 @@ disable-model-invocation: false
 ## Output Format
 
 - 응답 첫 부분에 완성된 커밋 메시지를 코드 블록으로 제공한다.
-- 필요하면 바로 아래에 `type`, `scope`, `gitmoji` 선택 이유를 한두 문장으로 짧게 덧붙인다.
+- 필요하면 바로 아래에 `type`, `scope` 선택 이유를 한두 문장으로 짧게 덧붙인다.
 - 사용자가 커밋 실행까지 요청하지 않았다면 실제 `git commit` 명령은 실행하지 않는다.
 
 ## Quick Checks
 
-- 제목이 `<emoji> <type>(<scope>): <short summary>` 형식을 만족하는가 (scope 는 선택)
+- 제목이 `<type>(<scope>): <short summary>` 형식을 만족하는가 (scope 는 선택, 이모지 없음)
 - 제목과 본문이 영어인가
 - 제목이 소문자로 시작하는가
-- gitmoji 가 정확히 하나인가
+- 제목 앞에 이모지가 없는가
 - 제목 끝에 마침표가 없는가
 - 본문이 `-` bullet 형식이고 최소 1개 이상인가
 - scope 에 브랜치명을 쓰지 않았는가


### PR DESCRIPTION
Sync this repo's commit-message docs with the global convention change made on 2026-09-07: commit/PR titles are now plain `type(scope): summary` with **no leading gitmoji/emoji**.

## Changes

- **`.github/COMMIT_CONVENTION.md`**: drop the emoji from the format diagram, remove the whole "Gitmoji Selection" section and its emoji table, strip the emoji from the three examples, and update the "Relationship to the Global Convention" note (the only remaining deliberate differences are English + optional scope).
- **`.github/skills/commit/SKILL.md`** and **`.claude/skills/commit/SKILL.md`**: remove gitmoji from the format, rules, procedure, checks, and (for the `.claude` one) the emoji table; both now state titles carry no emoji.

Scope, English default, no-trailers, and `CHANGELOG.md`/lock-file exclusion rules are unchanged — this only removes the emoji requirement. Docs/tooling only; nothing shipped in the package changes.