### PR TITLE
refactor(ui): single-source the preset palette on Tailwind's colour names and drop inert Config tokens

### DIFF
--- a/.changeset/mean-jars-attack.md
+++ b/.changeset/mean-jars-attack.md
@@ -1,0 +1,46 @@
+---
+'@repo/ui': minor
+---
+
+Align the shared preset colour palette with Tailwind's own colour names, and
+define it in one place instead of two (ui-kit#342).
+
+**The palette is now a single source of truth.** `Button` and `Tag` each
+carried their own copy of the same thirteen hex literals — 26 declarations that
+nothing kept in sync, which is why `lib/colors.ts` had a "keep this list in
+sync" comment. Both now resolve from one shared `--preset-color` block, so a
+colour word renders the same hue on either component by construction.
+
+**Preset names now match Tailwind's.** The values were always Tailwind's — the
+presets were the v3 hex ramp, spelled with antd's vocabulary — so four names
+said one thing and rendered another:
+
+| before     | rendered           | now       |
+| ---------- | ------------------ | --------- |
+| `magenta`  | Tailwind `fuchsia` | `fuchsia` |
+| `geekblue` | Tailwind `indigo`  | `indigo`  |
+| `gold`     | Tailwind `amber`   | `amber`   |
+
+The other nine (`blue`, `purple`, `cyan`, `green`, `pink`, `red`, `orange`,
+`yellow`, `lime`) already matched and are unchanged.
+
+**The old spellings still work.** `magenta`, `geekblue`, `gold` and `volcano`
+are deprecated aliases that render exactly what they always did, and will be
+removed in the next major. `volcano` has no successor: every other preset is a
+distinct hue at Tailwind's `500` step, but `volcano` is `orange-600` — the same
+hue as `orange`, one step darker — so it is a lightness variant rather than a
+hue. It keeps rendering `orange-600` until removal.
+
+**Colours shift very slightly.** Each preset now references the matching
+`--color-*` Tailwind theme variable rather than a hand-copied literal, which
+picks up Tailwind v4's oklch/P3 recalibration of its palette (the old literals
+were the v3 sRGB hex values). The difference is small — ΔE 0.017–0.036 in
+oklab, at or just above the just-noticeable threshold — and nine of the
+thirteen now sit slightly outside sRGB, so they render a touch more saturated
+on P3 displays. `Tag`'s `success`/`warning` and their dark-mode variants were
+already exact Tailwind values inlined by hand; they now reference the same
+variables and are byte-identical.
+
+Referencing theme variables does not couple the published stylesheet to the
+consuming app's palette: Tailwind keeps a referenced theme variable in the
+build output, so `dist/style.css` ships its own copy of each colour it uses.

--- a/.changeset/olive-pumas-shave.md
+++ b/.changeset/olive-pumas-shave.md
@@ -1,0 +1,51 @@
+---
+'@repo/ui': major
+---
+
+Make every `Config` theme token actually do something (ui-kit#343).
+
+19 of `ThemeToken`'s 40 keys were inert — they type-checked, autocompleted, and
+silently did nothing. Verified by setting each one to a sentinel value against
+the built stylesheet and reading back the computed styles. The 21 survivors all
+demonstrably reach a component.
+
+**Removed: `btnBackground`, `btnBackgroundHover`, `btnBackgroundActive`,
+`btnBorder`, `btnForeground`.** `globals.css` declares `--btn-*` on the button
+element itself, keyed off `data-color`. An element's own declaration always
+beats an inherited one, so a value set on `Config`'s wrapper could never win —
+for any colour, including `default`. Re-theme buttons with
+`colorPrimary`/`colorDestructive` for the semantic colours, or by overriding
+`--preset-color` in CSS for the preset hues:
+
+```css
+[data-slot='button'][data-color='blue'] {
+  --preset-color: oklch(55% 0.2 250);
+}
+```
+
+**Removed: `sidebar`, `sidebarForeground`, `sidebarPrimary`,
+`sidebarPrimaryForeground`, `sidebarAccent`, `sidebarAccentForeground`,
+`sidebarBorder`, `sidebarRing`, `chart1`–`chart5`.** No component in the library
+reads them, and the matching utilities (`bg-sidebar`, `bg-chart-1`) are never
+generated into the published stylesheet, so nothing consumed them either. The
+underlying `--sidebar-*` / `--chart-*` custom properties are still declared and
+remain overridable in plain CSS — only the inert token API is gone. They should
+return alongside an actual Sidebar/Chart component.
+
+**Fixed: `fontSans` and `fontMono`.** These were inert for a different reason,
+so they were repaired rather than dropped. They previously wrote
+`--font-sans`/`--font-mono`, but those are `@theme inline` entries — Tailwind
+substitutes their _value_ into each utility (`.font-mono { font-family:
+var(--font-geist-mono) }`) instead of referencing them, so the override never
+applied. They now write `--ui-font-sans`/`--ui-font-mono`, which `globals.css`
+reads ahead of the app's own font variable.
+
+Dropping `inline` would have been the other fix, but it breaks the standard
+Next.js setup: `next/font` scopes its variable to `<body>` via a className, and
+a non-inline `@theme` resolves that variable at `:root`, where it does not
+exist. Apps that set no font token are unaffected — the app's own font variable
+is still the fallback.
+
+**Migration.** Code using a removed token had no effect, so deleting those keys
+changes nothing at runtime; it only clears the type error. Nothing else needs to
+move.

--- a/apps/docs/stories/atoms/button/index.stories.tsx
+++ b/apps/docs/stories/atoms/button/index.stories.tsx
@@ -25,15 +25,14 @@ const colorOptions: ColorType[] = [
   'purple',
   'cyan',
   'green',
-  'magenta',
+  'fuchsia',
   'pink',
   'red',
   'orange',
   'yellow',
-  'volcano',
-  'geekblue',
+  'indigo',
   'lime',
-  'gold',
+  'amber',
 ];
 
 const meta: Meta<typeof Button> = {

--- a/apps/docs/stories/atoms/config/index.stories.tsx
+++ b/apps/docs/stories/atoms/config/index.stories.tsx
@@ -104,3 +104,24 @@ export const Nested: Story = {
     </Config>
   ),
 };
+
+/**
+ * `fontSans`/`fontMono` override the app's own font variables for everything
+ * inside the `Config`. Leaving them unset keeps whatever font the host app
+ * already set, so this is purely additive.
+ */
+export const FontToken: Story = {
+  render: () => (
+    <div className={cn('flex flex-col gap-4')}>
+      <p className={cn('font-mono text-sm')}>Default mono (app font)</p>
+
+      <Config theme={{ token: { fontMono: 'ui-serif, Georgia, serif' } }}>
+        <p className={cn('font-mono text-sm')}>Overridden via token.fontMono</p>
+      </Config>
+
+      <p className={cn('font-mono text-sm')}>
+        Sibling outside Config is unaffected
+      </p>
+    </div>
+  ),
+};

--- a/apps/docs/stories/atoms/tag/index.stories.tsx
+++ b/apps/docs/stories/atoms/tag/index.stories.tsx
@@ -25,15 +25,14 @@ const meta: Meta<typeof Tag> = {
         'purple',
         'cyan',
         'green',
-        'magenta',
+        'fuchsia',
         'pink',
         'red',
         'orange',
         'yellow',
-        'volcano',
-        'geekblue',
+        'indigo',
         'lime',
-        'gold',
+        'amber',
       ],
     },
     className: {
@@ -60,7 +59,7 @@ export const Outlined: Story = {
 
 export const Preset: Story = {
   args: {
-    children: 'gold',
-    color: 'gold',
+    children: 'amber',
+    color: 'amber',
   },
 };

--- a/apps/web/docs/components/atoms/button.mdx
+++ b/apps/web/docs/components/atoms/button.mdx
@@ -55,8 +55,24 @@ So `<Button type="primary">` renders the same as
 `<Button type="primary" variant="filled">` keeps the primary color and renders
 filled instead. `danger` overrides the resolved color either way.
 
-Preset `color` names:
-`blue`, `purple`, `cyan`, `green`, `magenta`, `pink`, `red`, `orange`,
-`yellow`, `volcano`, `geekblue`, `lime`, `gold`, in addition to `default`,
-`primary`, `danger`. `Button` also accepts the rest of Radix UI's `Slot`
-props via `asChild`, and the native `<button>` attributes.
+Preset `color` names follow Tailwind's own palette names:
+`blue`, `purple`, `cyan`, `green`, `fuchsia`, `pink`, `red`, `orange`,
+`yellow`, `indigo`, `lime`, `amber`, in addition to `default`, `primary`,
+`danger`. Each resolves from the matching `--color-*` Tailwind theme variable,
+so a colour word renders the same hue on `Button` and `Tag`.
+
+:::note[Deprecated spellings]
+
+`magenta`, `geekblue`, `gold` and `volcano` still work and render exactly what
+they always did, but are deprecated and will be removed in the next major.
+They named antd's palette while rendering Tailwind's, so the name and the
+value disagreed — use `fuchsia`, `indigo` and `amber` instead.
+
+`volcano` has no successor: every other preset is a distinct hue at Tailwind's
+`500` step, but `volcano` is `orange-600` — the same hue as `orange`, one step
+darker. If you need that exact shade, set `--btn-bg` directly.
+
+:::
+
+`Button` also accepts the rest of Radix UI's `Slot` props via `asChild`, and
+the native `<button>` attributes.

--- a/apps/web/docs/components/atoms/tag.mdx
+++ b/apps/web/docs/components/atoms/tag.mdx
@@ -32,10 +32,23 @@ import { Tag } from '@jbpark/ui-kit';
 | `children`  | `ReactNode`                                                      | -          |
 
 `Tag` shares `Button`'s vocabulary (#320): `variant="filled"` matches `Button`'s
-`filled`, and `color` accepts the same preset palette — `blue`, `purple`,
-`cyan`, `green`, `magenta`, `pink`, `red`, `orange`, `yellow`, `volcano`,
-`geekblue`, `lime`, `gold` — on top of the named states
+`filled`, and `color` accepts the same preset palette, named after Tailwind's
+own colours — `blue`, `purple`, `cyan`, `green`, `fuchsia`, `pink`, `red`,
+`orange`, `yellow`, `indigo`, `lime`, `amber` — on top of the named states
 (`primary`/`success`/`warning`/`danger`).
+
+The presets are defined once and shared by both components, so a colour word is
+guaranteed to render the same hue on `Tag` and `Button`.
+
+:::note[Deprecated spellings]
+
+`magenta`, `geekblue`, `gold` and `volcano` still work and render exactly what
+they always did, but are deprecated and will be removed in the next major —
+use `fuchsia`, `indigo` and `amber` instead. `volcano` has no successor; it is
+`orange` one lightness step darker. See the `Button` page for the full
+rationale.
+
+:::
 
 `success` and `warning` have no `Button` counterpart by design: a `Tag` marks
 state, which is why antd's `Tag` also carries status colours its `Button` does

--- a/apps/web/src/demo/tag-demo.tsx
+++ b/apps/web/src/demo/tag-demo.tsx
@@ -7,15 +7,14 @@ const PRESETS = [
   'purple',
   'cyan',
   'green',
-  'magenta',
+  'fuchsia',
   'pink',
   'red',
   'orange',
   'yellow',
-  'volcano',
-  'geekblue',
+  'indigo',
   'lime',
-  'gold',
+  'amber',
 ] as const;
 
 export default function TagDemo() {

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -9,7 +9,7 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
-import { type PresetColor } from '../../lib/colors';
+import { type DeprecatedPresetColor, type PresetColor } from '../../lib/colors';
 
 type NativeButtonProps = React.ComponentProps<'button'> & {
   asChild?: boolean;
@@ -57,8 +57,14 @@ export interface Props extends Omit<
   /**
    * Color, independent of `variant`. Defaults to `'default'`, or to whatever
    * `type` maps to when `type` is set. `danger` overrides this.
+   *
+   * Preset hues use Tailwind's colour names (#342). The pre-8.0 spellings
+   * `magenta`/`geekblue`/`gold`/`volcano` still work and render unchanged, but
+   * are deprecated — use `fuchsia`/`indigo`/`amber` instead (`volcano` has no
+   * successor; it is `orange` one lightness step darker).
    */
-  color?: PresetColor | 'default' | 'primary' | 'danger';
+  color?:
+    PresetColor | DeprecatedPresetColor | 'default' | 'primary' | 'danger';
   loading?: boolean | { icon: React.ReactNode };
 }
 

--- a/packages/ui/src/components/atoms/tag.tsx
+++ b/packages/ui/src/components/atoms/tag.tsx
@@ -8,7 +8,7 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { INTERACTIVE_CHASSIS } from '../../lib/chassis';
-import { type PresetColor } from '../../lib/colors';
+import { type DeprecatedPresetColor, type PresetColor } from '../../lib/colors';
 
 type NativeSpanProps = React.ComponentProps<'span'> & {
   asChild?: boolean;
@@ -24,14 +24,25 @@ export interface Props extends Omit<NativeSpanProps, 'variant' | 'color'> {
   /**
    * Colour. Every value — the semantic states (`primary`/`success`/`warning`/
    * `danger`) as well as the palette shared with `Button` (`blue`, `red`,
-   * `gold`, …) — resolves through the same `data-color` + `--tag-*` system
+   * `amber`, …) — resolves through the same `data-color` + `--tag-*` system
    * (#320), so any of them can be re-themed the same way.
    *
    * `success`/`warning` have no `Button` counterpart on purpose: a Tag marks
    * state, which is why antd's Tag also carries them while its Button does not.
+   *
+   * Preset hues use Tailwind's colour names (#342). The pre-8.0 spellings
+   * `magenta`/`geekblue`/`gold`/`volcano` still work and render unchanged, but
+   * are deprecated — use `fuchsia`/`indigo`/`amber` instead (`volcano` has no
+   * successor; it is `orange` one lightness step darker).
    */
   color?:
-    'default' | 'primary' | 'success' | 'warning' | 'danger' | PresetColor;
+    | 'default'
+    | 'primary'
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | PresetColor
+    | DeprecatedPresetColor;
 }
 
 // Base absorbed from core/badge's cva base + its `outline` variant, which Tag

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -188,19 +188,105 @@
 }
 
 @layer components {
+  /* ------------------------------------------------------------------------
+   * Shared preset palette (#342).
+   *
+   * One block per colour, serving BOTH `Button` and `Tag` — before this the
+   * same thirteen hex literals were written out twice, once per component, and
+   * `lib/colors.ts` carried a "keep this in sync" note because nothing
+   * enforced it.
+   *
+   * Each entry resolves from Tailwind's own `--color-*` theme variable rather
+   * than a hand-copied literal. The values were always Tailwind's (they were
+   * the v3 hex ramp); referencing the variable makes that dependency explicit,
+   * picks up v4's oklch/P3 recalibration, and means the palette is defined in
+   * exactly one place — Tailwind's theme. Tailwind keeps a theme variable in
+   * the build output when it is referenced from CSS like this, so the compiled
+   * `dist/style.css` carries its own copy and does not depend on the consuming
+   * app also having that colour enabled.
+   *
+   * `--preset-color` is the single hand-off point: the rules further down map
+   * it onto each component's own `--btn-*` / `--tag-*` vocabulary. Overriding
+   * it on an element (or any ancestor of one) re-themes that preset for both
+   * components at once.
+   * --------------------------------------------------------------------- */
+  :is([data-slot='button'], [data-slot='badge'])[data-color='blue'] {
+    --preset-color: var(--color-blue-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='purple'] {
+    --preset-color: var(--color-purple-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='cyan'] {
+    --preset-color: var(--color-cyan-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='green'] {
+    --preset-color: var(--color-green-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='fuchsia'] {
+    --preset-color: var(--color-fuchsia-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='pink'] {
+    --preset-color: var(--color-pink-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='red'] {
+    --preset-color: var(--color-red-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='orange'] {
+    --preset-color: var(--color-orange-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='yellow'] {
+    --preset-color: var(--color-yellow-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='indigo'] {
+    --preset-color: var(--color-indigo-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='lime'] {
+    --preset-color: var(--color-lime-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='amber'] {
+    --preset-color: var(--color-amber-500);
+  }
+
+  /* Deprecated pre-8.0 spellings, resolving to the exact same hues they always
+   * rendered (see lib/colors.ts). Removed in the next major. `volcano` is the
+   * one with no canonical successor — it is `orange` one lightness step
+   * darker, not a hue of its own. */
+  :is([data-slot='button'], [data-slot='badge'])[data-color='magenta'] {
+    --preset-color: var(--color-fuchsia-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='geekblue'] {
+    --preset-color: var(--color-indigo-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='gold'] {
+    --preset-color: var(--color-amber-500);
+  }
+  :is([data-slot='button'], [data-slot='badge'])[data-color='volcano'] {
+    --preset-color: var(--color-orange-600);
+  }
+
   [data-slot='button'][data-color] {
+    --btn-bg: var(--preset-color);
     --btn-fg: white;
     --btn-border: var(--btn-bg);
     --btn-bg-hover: color-mix(in oklch, var(--btn-bg), black 12%);
     --btn-bg-active: color-mix(in oklch, var(--btn-bg), black 22%);
   }
 
+  /* Hues light enough that white text on them fails contrast. */
   [data-slot='button'][data-color='yellow'],
   [data-slot='button'][data-color='lime'],
+  [data-slot='button'][data-color='amber'],
   [data-slot='button'][data-color='gold'] {
     --btn-fg: black;
   }
 
+  /* Semantic colours resolve from the theme, not the preset palette, so they
+   * replace the `--btn-bg` set above.
+   *
+   * ⚠️ `[data-color='default']` and `[data-color]` have the SAME specificity
+   * (0,2,0) — an attribute selector counts the same with or without a value —
+   * so these win on source order alone. They must stay after the
+   * `[data-slot='button'][data-color]` block. */
   [data-slot='button'][data-color='default'] {
     --btn-bg: var(--muted);
     --btn-border: var(--muted-foreground);
@@ -215,63 +301,29 @@
     --btn-bg: var(--destructive);
   }
 
-  [data-slot='button'][data-color='blue'] {
-    --btn-bg: #3b82f6;
-  }
-  [data-slot='button'][data-color='purple'] {
-    --btn-bg: #a855f7;
-  }
-  [data-slot='button'][data-color='cyan'] {
-    --btn-bg: #06b6d4;
-  }
-  [data-slot='button'][data-color='green'] {
-    --btn-bg: #22c55e;
-  }
-  [data-slot='button'][data-color='magenta'] {
-    --btn-bg: #d946ef;
-  }
-  [data-slot='button'][data-color='pink'] {
-    --btn-bg: #ec4899;
-  }
-  [data-slot='button'][data-color='red'] {
-    --btn-bg: #ef4444;
-  }
-  [data-slot='button'][data-color='orange'] {
-    --btn-bg: #f97316;
-  }
-  [data-slot='button'][data-color='yellow'] {
-    --btn-bg: #eab308;
-  }
-  [data-slot='button'][data-color='volcano'] {
-    --btn-bg: #ea580c;
-  }
-  [data-slot='button'][data-color='geekblue'] {
-    --btn-bg: #6366f1;
-  }
-  [data-slot='button'][data-color='lime'] {
-    --btn-bg: #84cc16;
-  }
-  [data-slot='button'][data-color='gold'] {
-    --btn-bg: #f59e0b;
-  }
-
   /* Tag's colour system (#320). Every colour — the semantic states as well as
    * the palette shared with `Button` — resolves here, so `[data-color]` hooks
-   * and `--tag-*` overrides behave the same whichever one is in use. Preset
-   * hues mirror the `--btn-*` values above so a colour word renders the same
-   * on `Tag` and `Button`.
+   * and `--tag-*` overrides behave the same whichever one is in use. The preset
+   * hues come from the shared `--preset-color` block above, so a colour word
+   * renders the same on `Tag` and `Button` by construction rather than by
+   * keeping two hand-copied lists in sync (#342).
    *
    *   --tag-bg    the hue; also the border in `outlined`
    *   --tag-fg    text colour; defaults to the hue
    *   --tag-tint  the fill behind `filled`; defaults to a 10% wash */
   [data-slot='badge'][data-color] {
+    --tag-bg: var(--preset-color);
     --tag-fg: var(--tag-bg);
     --tag-tint: color-mix(in oklab, var(--tag-bg), transparent 90%);
   }
 
   /* Semantic states. `default` is the one colour whose fill is a solid surface
    * rather than a wash of its own hue, and whose text differs between the two
-   * variants — hence the explicit tint/fg. */
+   * variants — hence the explicit tint/fg.
+   *
+   * ⚠️ Same-specificity-as-`[data-color]` caveat as on the Button side: these
+   * replace `--tag-bg` by source order, so they must stay below the block
+   * above. */
   [data-slot='badge'][data-color='default'] {
     --tag-bg: var(--border);
     --tag-tint: var(--muted);
@@ -288,62 +340,23 @@
     --tag-bg: var(--destructive);
   }
   /* success/warning read one step darker than their hue for legible text on a
-   * light surface, and one step lighter in dark mode — the exact Tailwind
-   * green/yellow ramp values these two rendered before they joined this
-   * system, so the move is visually lossless. */
+   * light surface, and one step lighter in dark mode. These were already
+   * Tailwind's green/yellow ramp values, hand-copied as literals; referencing
+   * the theme variables instead is byte-identical and keeps them on the same
+   * footing as the shared presets (#342). */
   [data-slot='badge'][data-color='success'] {
-    --tag-bg: oklch(72.3% 0.219 149.579);
-    --tag-fg: oklch(62.7% 0.194 149.214);
+    --tag-bg: var(--color-green-500);
+    --tag-fg: var(--color-green-600);
   }
   [data-slot='badge'][data-color='warning'] {
-    --tag-bg: oklch(79.5% 0.184 86.047);
-    --tag-fg: oklch(68.1% 0.162 75.834);
+    --tag-bg: var(--color-yellow-500);
+    --tag-fg: var(--color-yellow-600);
   }
   :is(.dark, [data-theme='dark']) [data-slot='badge'][data-color='success'] {
-    --tag-fg: oklch(79.2% 0.209 151.711);
+    --tag-fg: var(--color-green-400);
   }
   :is(.dark, [data-theme='dark']) [data-slot='badge'][data-color='warning'] {
-    --tag-fg: oklch(85.2% 0.199 91.936);
-  }
-
-  [data-slot='badge'][data-color='blue'] {
-    --tag-bg: #3b82f6;
-  }
-  [data-slot='badge'][data-color='purple'] {
-    --tag-bg: #a855f7;
-  }
-  [data-slot='badge'][data-color='cyan'] {
-    --tag-bg: #06b6d4;
-  }
-  [data-slot='badge'][data-color='green'] {
-    --tag-bg: #22c55e;
-  }
-  [data-slot='badge'][data-color='magenta'] {
-    --tag-bg: #d946ef;
-  }
-  [data-slot='badge'][data-color='pink'] {
-    --tag-bg: #ec4899;
-  }
-  [data-slot='badge'][data-color='red'] {
-    --tag-bg: #ef4444;
-  }
-  [data-slot='badge'][data-color='orange'] {
-    --tag-bg: #f97316;
-  }
-  [data-slot='badge'][data-color='yellow'] {
-    --tag-bg: #eab308;
-  }
-  [data-slot='badge'][data-color='volcano'] {
-    --tag-bg: #ea580c;
-  }
-  [data-slot='badge'][data-color='geekblue'] {
-    --tag-bg: #6366f1;
-  }
-  [data-slot='badge'][data-color='lime'] {
-    --tag-bg: #84cc16;
-  }
-  [data-slot='badge'][data-color='gold'] {
-    --tag-bg: #f59e0b;
+    --tag-fg: var(--color-yellow-400);
   }
 
   /* Row/Col's 24-column responsive grid (templates/grid/col.tsx) — Col

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -23,8 +23,23 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  /*
+   * `Config`'s `fontSans`/`fontMono` tokens write `--ui-font-sans`/
+   * `--ui-font-mono`; the app's own font variable stays the fallback (#343).
+   *
+   * The indirection is needed because `@theme inline` substitutes the *value*
+   * into each utility (`.font-mono { font-family: var(--font-geist-mono) }`)
+   * rather than referencing `--font-mono`, so setting `--font-mono` on a
+   * wrapper — which is what `Config` used to do — never reached anything.
+   *
+   * Dropping `inline` would be the other way to fix that, but it would break
+   * the common Next.js setup: `next/font` scopes its variable to `<body>` via
+   * a className, and a non-inline `@theme` resolves `var(--font-geist-sans)`
+   * at `:root`, where that variable does not exist. Keeping `inline` and
+   * adding an override hook preserves element-scoped resolution.
+   */
+  --font-sans: var(--ui-font-sans, var(--font-geist-sans));
+  --font-mono: var(--ui-font-mono, var(--font-geist-mono));
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -2,26 +2,71 @@
  * The shared preset colour palette. `Button` and `Tag` both express these via
  * the `--btn-*` / `--tag-*` custom-property systems in `globals.css` (keyed off
  * `data-color`), so the same word means the same hue on either component
- * (#320). Keep this list in sync with the `[data-color='…']` rules there.
+ * (#320).
+ *
+ * The names track **Tailwind's own palette names** (#342). They always did
+ * track Tailwind's *values* — every preset was a Tailwind hue, just spelled
+ * with antd's vocabulary — so four of them said one thing and rendered
+ * another: `magenta` rendered Tailwind's `fuchsia`, `geekblue` rendered
+ * `indigo`, `gold` rendered `amber`. Aligning the spelling makes the name and
+ * the value agree, and lets `globals.css` resolve each entry straight from the
+ * matching `--color-*` theme variable instead of a hand-copied hex.
+ *
+ * Keep this list in sync with the `[data-color='…']` rules there.
  */
 export const PRESET_COLORS = [
   'blue',
   'purple',
   'cyan',
   'green',
-  'magenta',
+  'fuchsia',
   'pink',
   'red',
   'orange',
   'yellow',
-  'volcano',
-  'geekblue',
+  'indigo',
   'lime',
-  'gold',
+  'amber',
 ] as const;
 
 export type PresetColor = (typeof PRESET_COLORS)[number];
 
-/** Runtime membership test — true when `color` is one of the shared presets. */
-export const isPresetColor = (color: string): color is PresetColor =>
-  (PRESET_COLORS as readonly string[]).includes(color);
+/**
+ * Pre-8.0 spellings, still accepted and still rendering exactly what they
+ * rendered before — they are aliases, not a behaviour change:
+ *
+ * | deprecated | renders           | canonical spelling            |
+ * | ---------- | ----------------- | ----------------------------- |
+ * | `magenta`  | `--color-fuchsia-500` | `fuchsia`                 |
+ * | `geekblue` | `--color-indigo-500`  | `indigo`                  |
+ * | `gold`     | `--color-amber-500`   | `amber`                   |
+ * | `volcano`  | `--color-orange-600`  | *(none — see below)*      |
+ *
+ * `volcano` is the odd one out and has no canonical successor. Every other
+ * preset is a distinct hue at Tailwind's `500` step, but `volcano` is
+ * `orange-600` — the same hue as `orange`, one step darker. That makes it a
+ * lightness variant masquerading as a hue, so it doesn't belong in a list
+ * whose axis is "one entry per hue". It keeps rendering `orange-600` until the
+ * next major; callers who want that exact shade can set `--btn-bg`/`--tag-bg`
+ * directly.
+ *
+ * All four are removed in the next major.
+ */
+export const DEPRECATED_PRESET_COLORS = [
+  'magenta',
+  'geekblue',
+  'gold',
+  'volcano',
+] as const;
+
+export type DeprecatedPresetColor = (typeof DEPRECATED_PRESET_COLORS)[number];
+
+/**
+ * Runtime membership test — true when `color` is one of the shared presets,
+ * including the deprecated spellings (they still resolve to a preset hue).
+ */
+export const isPresetColor = (
+  color: string,
+): color is PresetColor | DeprecatedPresetColor =>
+  (PRESET_COLORS as readonly string[]).includes(color) ||
+  (DEPRECATED_PRESET_COLORS as readonly string[]).includes(color);

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -72,29 +72,12 @@ const tokenToCssVar: Record<keyof ThemeToken, string> = {
   colorRing: '--ring',
   borderRadius: '--radius',
 
-  btnBackground: '--btn-bg',
-  btnBackgroundHover: '--btn-bg-hover',
-  btnBackgroundActive: '--btn-bg-active',
-  btnBorder: '--btn-border',
-  btnForeground: '--btn-fg',
-
-  sidebar: '--sidebar',
-  sidebarForeground: '--sidebar-foreground',
-  sidebarPrimary: '--sidebar-primary',
-  sidebarPrimaryForeground: '--sidebar-primary-foreground',
-  sidebarAccent: '--sidebar-accent',
-  sidebarAccentForeground: '--sidebar-accent-foreground',
-  sidebarBorder: '--sidebar-border',
-  sidebarRing: '--sidebar-ring',
-
-  chart1: '--chart-1',
-  chart2: '--chart-2',
-  chart3: '--chart-3',
-  chart4: '--chart-4',
-  chart5: '--chart-5',
-
-  fontSans: '--font-sans',
-  fontMono: '--font-mono',
+  // Not `--font-sans`/`--font-mono`: those are `@theme inline` entries, so
+  // Tailwind substitutes their value into each utility rather than referencing
+  // them, and a wrapper-level override never applied. `globals.css` reads these
+  // hooks ahead of the app's own font variable instead (#343).
+  fontSans: '--ui-font-sans',
+  fontMono: '--ui-font-mono',
 };
 
 const buildCssVars = (token?: ThemeToken): React.CSSProperties => {

--- a/packages/ui/src/providers/config/types.ts
+++ b/packages/ui/src/providers/config/types.ts
@@ -1,3 +1,28 @@
+/**
+ * Theme overrides applied as CSS custom properties on `Config`'s wrapper
+ * element, inherited by everything inside it.
+ *
+ * Every token here is verified to actually reach a component. That is worth
+ * stating because it did not use to be true: 19 of the previous 40 tokens were
+ * inert (#343). Three groups were dropped in 8.0 —
+ *
+ * - `btnBackground`/`btnBackgroundHover`/`btnBackgroundActive`/`btnBorder`/
+ *   `btnForeground` — `globals.css` declares `--btn-*` on the button element
+ *   itself (keyed off `data-color`), and an element's own declaration always
+ *   beats an inherited one, so a wrapper value could never win. Re-theming a
+ *   button is done through `colorPrimary`/`colorDestructive` for the semantic
+ *   colours, or by overriding `--preset-color` in CSS for the preset hues.
+ * - `sidebar*` and `chart*` — no component in the library reads them, and the
+ *   matching utilities (`bg-sidebar`, `bg-chart-1`) are never generated into
+ *   the published stylesheet, so nothing consumed them. The underlying
+ *   `--sidebar-*`/`--chart-*` custom properties are still declared in
+ *   `globals.css` and remain overridable in plain CSS; only the inert token
+ *   API is gone. They should come back alongside an actual Sidebar/Chart
+ *   component.
+ *
+ * `fontSans`/`fontMono` were inert for a different reason and were fixed
+ * rather than removed — see below.
+ */
 export interface ThemeToken {
   // Colors
   colorPrimary?: string;
@@ -28,32 +53,10 @@ export interface ThemeToken {
   // propagates to the entire derived scale with nothing more needed.
   borderRadius?: string;
 
-  // Button color presets (Button's color prop reads these — see
-  // button.tsx's `bg-(--btn-bg)` etc)
-  btnBackground?: string;
-  btnBackgroundHover?: string;
-  btnBackgroundActive?: string;
-  btnBorder?: string;
-  btnForeground?: string;
-
-  // Sidebar
-  sidebar?: string;
-  sidebarForeground?: string;
-  sidebarPrimary?: string;
-  sidebarPrimaryForeground?: string;
-  sidebarAccent?: string;
-  sidebarAccentForeground?: string;
-  sidebarBorder?: string;
-  sidebarRing?: string;
-
-  // Charts
-  chart1?: string;
-  chart2?: string;
-  chart3?: string;
-  chart4?: string;
-  chart5?: string;
-
-  // Fonts
+  // Fonts. These write `--ui-font-sans`/`--ui-font-mono`, the override hooks
+  // `globals.css` reads ahead of the app's own font variable — see the comment
+  // on the `@theme inline` block there for why the indirection is required
+  // (#343).
   fontSans?: string;
   fontMono?: string;
 }


### PR DESCRIPTION
## Summary

Makes the shared preset colour palette a single source of truth named after the hues it actually renders, then removes the `Config` theme tokens that never reached a component and repairs the two that were mis-wired.

Closes #342, closes #343.

Both changes touch the same theming surface and the second depends on the seam the first introduces, so they ship together as two reviewable commits.

## Changes

**`refactor(ui): align preset palette with tailwind colour names`** (minor)

- Collapse the two per-component copies of the 13-colour palette into one shared `--preset-color` block. `Button` and `Tag` each map it onto their own `--btn-*` / `--tag-*` vocabulary, so a colour word is guaranteed to render the same hue on both — previously enforced only by a "keep this list in sync" comment.
- Resolve each preset from the matching Tailwind `--color-*` theme variable instead of a hand-copied hex. The values already *were* Tailwind's (the v3 hex ramp), so this makes an existing dependency explicit.
- Rename `magenta` → `fuchsia`, `geekblue` → `indigo`, `gold` → `amber` so the name matches the hue. The old spellings, plus `volcano`, stay as **deprecated aliases rendering exactly what they render today**, following the existing `Tag` `variant="default"` → `"filled"` precedent.
- `Tag`'s `success`/`warning` (and their dark-mode variants) now reference the green/yellow theme variables they were already inlining by hand — byte-identical.

**`refactor(ui)!: drop inert Config theme tokens and fix the font ones`** (major)

19 of `ThemeToken`'s 40 keys were inert. Verified by driving each with a sentinel value against the built stylesheet and reading back computed styles — not by reading code.

- Remove `btn*` (5): `globals.css` declares `--btn-*` on the button element itself, and an element's own declaration always beats an inherited one, so a wrapper value could never win.
- Remove `sidebar*` and `chart*` (13): no component reads them and the matching utilities are never generated into the published stylesheet. The underlying custom properties stay declared and overridable in CSS; only the inert token API goes.
- Fix `fontSans`/`fontMono` (2), which were inert for a different reason — `@theme inline` substitutes the *value* into each utility rather than referencing the variable. They now write `--ui-font-sans`/`--ui-font-mono`, read ahead of the app's own font variable.

Result: 40 → 21 tokens, all demonstrably working.

## Type of Change

- [x] ♻️ refactor — code refactoring
- [x] 💄 style — UI / style changes
- [x] 📝 docs — documentation update

## Notes for review

**Expected visual change.** Referencing v4's variables picks up its oklch/P3 recalibration (the old literals were v3 sRGB hex). Measured drift is ΔE 0.017–0.036 in oklab, at or just above the just-noticeable threshold; nine of thirteen then sit slightly outside sRGB and render a touch more saturated on P3 displays. Documented in the changeset.

**Two cascade landmines**, both commented in `globals.css`:

- `[data-color='default']` and `[data-color]` have **the same specificity** (0,2,0) — an attribute selector counts the same with or without a value — so the semantic colours win on source order alone and must stay below the preset block.
- The font fix deliberately **keeps `@theme inline`**. Dropping it would resolve the variable at `:root`, but `next/font` scopes its variable to `<body>` via a className, so app fonts would break.

**Tailwind tree-shaking.** v4 drops unused theme variables, so `--color-blue-500` was absent from `dist/style.css` before this change. Referencing it from CSS keeps it: all 17 referenced variables are present in the built output, verified for both the prebuilt `dist/style.css` and the source-compiled Docusaurus build. Cost is +970 bytes raw / +176 bytes gzipped.

**Prior art for the naming direction.** Libraries built on Tailwind align with Tailwind's names (Tailwind Labs' own Catalyst uses `amber`/`lime`/`fuchsia` verbatim) or drop hue names for semantic roles (daisyUI, shadcn/ui). Libraries with their own colour science keep idiosyncratic names (antd, Radix). Our values are Tailwind's, so we belong in the first camp — measured against antd's real seed colours, 7 of our 13 differed perceptibly (ΔE > 0.05), e.g. `purple` 0.137 and `magenta` 0.138.

## Screenshots

Verified in the built Docusaurus site — all 12 canonical presets render correctly in both `filled` and `outlined`, and each deprecated alias resolves to the same computed colour as its canonical name.

## Checklist

- [x] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [x] Storybook stories are added for new components / features (`FontToken` story covers the repaired font tokens; existing Button/Tag stories updated to the new names)
- [x] No type or lint errors (`pnpm lint`, `pnpm check-types`)
- [x] Build completes successfully (`pnpm build`)
- [x] Regression net passes (`pnpm check-regression-net`, `pnpm check-dynamic-classes`)
