### PR TITLE
feat(ui): add CodeEditor as an opt-in CodeMirror subpath

### DIFF
--- a/.changeset/pink-comics-listen.md
+++ b/.changeset/pink-comics-listen.md
@@ -1,0 +1,52 @@
+---
+'@repo/ui': minor
+---
+
+Add `CodeEditor`, a CodeMirror 6 editing surface published at its own subpath
+(ui-kit#346).
+
+Extracted from live-editor's editor, which already split into a reusable
+CodeMirror surface and app-specific glue. Only the surface moved: JS/TS
+highlighting (`javascript({ jsx: true, typescript: true })`), line wrapping, the
+VSCode theme pair, the Cmd/Ctrl+S write-back, and CodeMirror's unified diff
+view.
+
+```tsx
+import CodeEditor from '@jbpark/ui-kit/CodeEditor';
+
+<CodeEditor value={code} onChange={setCode} height="200px" />;
+```
+
+**CodeMirror is an optional peer, and `CodeEditor` is reachable only through
+`@jbpark/ui-kit/CodeEditor`** — it is deliberately absent from the root barrel.
+An ESM re-export is eager, so exposing it there would make
+`import { Button } from '@jbpark/ui-kit'` fail to resolve for every consumer
+that never asked for an editor. Nothing changes for existing imports; using the
+new subpath means installing the peer set:
+
+```bash
+pnpm add @uiw/react-codemirror @uiw/codemirror-theme-vscode \
+  @codemirror/lang-javascript @codemirror/merge codemirror
+```
+
+**No formatter ships with it.** Format-on-save is injected as
+`formatCode?: (code: string) => Promise<string>`, so the package carries none of
+prettier's ~9.6 MB; pass the formatter your app already owns. Cmd+S runs it,
+writes the result back with the cursor preserved, then fires `onChange`/`onSave`
+— and without `formatCode` the shortcut still fires `onSave`, unformatted. The
+write-back discards its result if the document moved while an async format was
+in flight, and skips the transaction entirely when the text is unchanged so no
+no-op undo entry is pushed. Errors surface through `onFormatError` (named around
+the DOM `onError` handler the underlying props already carry).
+
+`diff={{ original }}` renders `unifiedMergeView` against `original` instead of a
+plain document, for a read-only review step before persisting; `mergeControls`
+defaults to `false`.
+
+`theme` is `'light' | 'dark' | 'auto' | 'none' | Extension`, defaulting to
+`'auto'`, which follows the nearest `Config`'s `theme.dark` (`'system'` resolved
+against `prefers-color-scheme`) and stays light when no `Config` sets it. The
+two named options select the VSCode pair — narrowing CodeMirror's own meaning
+for `'light'`/`'dark'`, which upstream are its built-in themes — while `'none'`
+and a theme extension pass straight through. Apps that toggle the `.dark` class
+themselves instead of going through `Config` should pass `theme` explicitly.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,8 +13,13 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/merge": "^6.12.2",
     "@repo/ui": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
+    "@uiw/codemirror-theme-vscode": "^4.25.11",
+    "@uiw/react-codemirror": "^4.25.11",
+    "codemirror": "^6.0.0",
     "gsap": "^3.15.0",
     "lucide-react": "^1.31.0",
     "next": "^16.3.1",

--- a/apps/docs/stories/atoms/code-editor/index.stories.tsx
+++ b/apps/docs/stories/atoms/code-editor/index.stories.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Config } from '@repo/ui';
+import CodeEditor from '@repo/ui/CodeEditor';
+import { cn } from '@repo/ui/utils';
+
+const SAMPLE = `const greet = (name: string) => {
+  return <p>Hello, {name}!</p>;
+};
+`;
+
+const UNFORMATTED = `const sum = (a: number, b: number) => {
+  return    a + b;
+};
+`;
+
+const meta: Meta<typeof CodeEditor> = {
+  title: 'Data Entry/CodeEditor',
+  component: CodeEditor,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    value: {
+      control: { type: 'text' },
+      description: 'CodeMirror 문서 내용 (제어 컴포넌트)',
+    },
+    height: {
+      control: { type: 'text' },
+      description: "CodeMirror에 그대로 전달. 기본값은 '100%'",
+    },
+    theme: {
+      control: { type: 'inline-radio' },
+      options: ['auto', 'light', 'dark', 'none'],
+      description:
+        "'light'/'dark'는 VSCode 테마 쌍, 'auto'(기본값)는 Config의 theme.dark를 따른다. CodeMirror 테마 Extension을 직접 넘겨도 된다",
+    },
+    editable: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: SAMPLE,
+    height: '200px',
+  },
+  render: props => (
+    <div className={cn('w-[36rem]')}>
+      <CodeEditor {...props} />
+    </div>
+  ),
+};
+
+export const Dark: Story = {
+  args: {
+    value: SAMPLE,
+    height: '200px',
+  },
+  render: props => (
+    <div className={cn('w-[36rem]')}>
+      <CodeEditor {...props} theme="dark" />
+    </div>
+  ),
+};
+
+// `theme` defaults to `'auto'`, which reads Config's `theme.dark` — so an app
+// that already toggles dark mode through Config gets a matching editor without
+// passing anything. `dark: 'system'` follows the OS instead.
+export const AutoFollowsConfig: Story = {
+  args: {
+    value: SAMPLE,
+    height: '200px',
+  },
+  render: props => (
+    <Config theme={{ dark: 'dark' }}>
+      <div className={cn('bg-background w-[36rem] p-4')}>
+        <CodeEditor {...props} />
+      </div>
+    </Config>
+  ),
+};
+
+export const Controlled: Story = {
+  args: {
+    value: SAMPLE,
+    height: '200px',
+  },
+  render: function Render({ value: initialValue, ...props }) {
+    const [value, setValue] = useState(initialValue);
+
+    return (
+      <div className={cn('w-[36rem] space-y-2')}>
+        <CodeEditor {...props} value={value} onChange={setValue} />
+        <p className={cn('text-muted-foreground text-sm')}>
+          {value.split('\n').length} lines / {value.length} chars
+        </p>
+      </div>
+    );
+  },
+};
+
+// `formatCode` is injected, not bundled — the library owns no formatter. A real
+// app passes prettier here; this stand-in only collapses runs of spaces so the
+// Cmd+S round-trip is visible without a 9.6 MB dependency.
+export const FormatOnSave: Story = {
+  args: {
+    value: UNFORMATTED,
+    height: '200px',
+  },
+  render: function Render({ value: initialValue, ...props }) {
+    const [value, setValue] = useState(initialValue);
+    const [saved, setSaved] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    return (
+      <div className={cn('w-[36rem] space-y-2')}>
+        <CodeEditor
+          {...props}
+          value={value}
+          formatCode={async code => code.replace(/ {2,}(?=\S)/g, ' ')}
+          onChange={setValue}
+          onSave={() => setSaved(new Date().toLocaleTimeString())}
+          onFormatError={setError}
+        />
+        <p className={cn('text-muted-foreground text-sm')}>
+          Press ⌘S / Ctrl+S to format and save.
+          {saved && ` Last saved ${saved}.`}
+          {error && ` Error: ${error}`}
+        </p>
+      </div>
+    );
+  },
+};
+
+export const Diff: Story = {
+  args: {
+    value: UNFORMATTED.replace('a + b', 'a + b + 1'),
+    height: '200px',
+    editable: false,
+  },
+  render: props => (
+    <div className={cn('w-[36rem]')}>
+      <CodeEditor {...props} diff={{ original: UNFORMATTED }} />
+    </div>
+  ),
+};

--- a/apps/web/docs/components/atoms/code-editor.mdx
+++ b/apps/web/docs/components/atoms/code-editor.mdx
@@ -1,0 +1,153 @@
+---
+sidebar_position: 18
+title: CodeEditor
+---
+
+import DemoTheme from '@site/src/components/DemoTheme';
+import CodeEditorDemo from '../../../src/demo/code-editor-demo';
+
+# CodeEditor
+
+A CodeMirror 6 code editing surface with JS/TS highlighting, line wrapping, a
+Cmd+S hook, and an optional unified diff view.
+
+```tsx
+import CodeEditor from '@jbpark/ui-kit/CodeEditor';
+
+<CodeEditor value={code} onChange={setCode} height="200px" />;
+```
+
+:::info Subpath-only, with optional peers
+
+`CodeEditor` is **not** exported from the package root — `import { CodeEditor }
+from '@jbpark/ui-kit'` will not work, and that is deliberate. CodeMirror is a
+set of _optional_ peer dependencies, so pulling the editor through the root
+barrel would make every consumer resolve CodeMirror just to import a `Button`.
+
+Install the peer set alongside the library to use this subpath:
+
+```bash
+pnpm add @uiw/react-codemirror @uiw/codemirror-theme-vscode \
+  @codemirror/lang-javascript @codemirror/merge codemirror
+```
+
+All five are needed even if you never render a diff — `@codemirror/merge` is
+imported statically by the component.
+
+:::
+
+<DemoTheme>
+
+<CodeEditorDemo />
+
+</DemoTheme>
+
+## Props
+
+Every [`@uiw/react-codemirror`](https://uiwjs.github.io/react-codemirror/) prop
+is accepted (`editable`, `readOnly`, `basicSetup`, …). The additions and
+overrides:
+
+| Prop            | Type                                                   | Default      |
+| --------------- | ------------------------------------------------------ | ------------ |
+| `value`         | `string`                                               | — (required) |
+| `height`        | `string`                                               | `'100%'`     |
+| `theme`         | `'light' \| 'dark' \| 'auto' \| 'none' \| Extension`   | `'auto'`     |
+| `extensions`    | `Extension[]`                                          | -            |
+| `diff`          | `{ original: string; mergeControls?: boolean }`         | -            |
+| `formatCode`    | `(code: string) => Promise<string>`                    | -            |
+| `onChange`      | `(value: string) => void`                              | -            |
+| `onSave`        | `(value: string) => void`                              | -            |
+| `onFormatError` | `(error: string \| null) => void`                       | -            |
+
+`CodeEditor` is always controlled via `value`/`onChange` — there is no
+`defaultValue`.
+
+### Theme
+
+`theme` takes the VSCode pair by name, follows the app's dark mode, or accepts
+any CodeMirror theme extension:
+
+```tsx
+<CodeEditor value={code} />                   // 'auto' — follows Config
+<CodeEditor value={code} theme="dark" />      // vscodeDark, regardless
+<CodeEditor value={code} theme={dracula} />   // your own theme extension
+<CodeEditor value={code} theme="none" />      // no theme at all; style it yourself
+```
+
+`'auto'` is the default and reads `theme.dark` from the nearest `Config`, with
+`'system'` resolved against `prefers-color-scheme`:
+
+```tsx
+<Config theme={{ dark: 'system' }}>
+  <CodeEditor value={code} onChange={setCode} />
+</Config>
+```
+
+With no `Config` — or one that doesn't set `dark` — `'auto'` is light, so
+nothing changes for an app that never opted into dark mode.
+
+:::note
+
+`'auto'` only sees dark mode that goes through `Config`. Toggling the `.dark`
+class yourself (which is what this documentation site does, so that `<body>`
+is covered too) leaves the editor on light, so pass `theme` explicitly there:
+
+```tsx
+const { colorMode } = useColorMode();
+
+<CodeEditor value={code} theme={colorMode} />;
+```
+
+Note also that `'light'`/`'dark'` mean the VSCode themes here, not CodeMirror's
+own same-named built-ins.
+
+:::
+
+### Format on save
+
+The component carries no formatter. Pass `formatCode` and Cmd/Ctrl+S runs it,
+writes the result back (keeping the cursor in place), then fires `onChange` and
+`onSave` with the formatted text. Without `formatCode` the shortcut still fires
+`onSave`, it just doesn't reformat.
+
+```tsx
+<CodeEditor
+  value={code}
+  formatCode={formatWithPrettier}
+  onChange={setCode}
+  onSave={persist}
+  onFormatError={setError}
+/>
+```
+
+Keeping the formatter out of the package is intentional: prettier is ~9.6 MB,
+and only apps that want format-on-save should pay for it. `onFormatError`
+receives `null` on a clean save, or the message a rejected `formatCode` threw —
+it is named that way because the underlying props already carry the DOM
+`onError` handler.
+
+Two safeguards apply to the write-back:
+
+- If the document changed while an async `formatCode` was in flight, the result
+  is discarded rather than clobbering newer keystrokes.
+- If the formatted text is identical to the input, no transaction is dispatched
+  (so Cmd+S doesn't push a no-op undo entry). The callbacks still fire.
+
+### Diff view
+
+`diff` swaps the plain document for CodeMirror's `unifiedMergeView`, diffing the
+current content against `diff.original` — useful as a read-only review step
+before persisting a change. `mergeControls` defaults to `false`; pass `true` for
+per-chunk accept/reject gutters.
+
+```tsx
+<CodeEditor value={current} diff={{ original: lastSaved }} editable={false} />
+```
+
+### Extensions and language support
+
+The built-in extension set is
+`javascript({ jsx: true, typescript: true })` plus `EditorView.lineWrapping`.
+Anything passed in `extensions` is appended after it, so another language mode,
+a keymap, or a linter can be layered on without forking the component.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,12 +11,17 @@
     "check-types": "tsc"
   },
   "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/merge": "^6.12.2",
     "@docusaurus/core": "3.10.2",
     "@docusaurus/faster": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
     "@docusaurus/theme-common": "3.10.2",
     "@repo/ui": "workspace:*",
+    "@uiw/codemirror-theme-vscode": "^4.25.11",
+    "@uiw/react-codemirror": "^4.25.11",
     "clsx": "^2.0.0",
+    "codemirror": "^6.0.0",
     "date-fns": "^4.4.0",
     "lucide-react": "^1.31.0",
     "react": "^19.2.8",

--- a/apps/web/src/demo/code-editor-demo.tsx
+++ b/apps/web/src/demo/code-editor-demo.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+import { useColorMode } from '@docusaurus/theme-common';
+
+import { Space, Typography } from '@repo/ui';
+import CodeEditor from '@repo/ui/CodeEditor';
+
+const SAMPLE = `const greet = (name: string) => {
+  return <p>Hello, {name}!</p>;
+};
+`;
+
+// `formatCode` is injected rather than bundled, so this page needs no
+// formatter dependency. The stand-in below collapses runs of spaces, which is
+// enough to show the Cmd+S round-trip; a real app passes prettier.
+const collapseSpaces = async (code: string) =>
+  code.replace(/ {2,}(?=\S)/g, ' ');
+
+export default function CodeEditorDemo() {
+  const [value, setValue] = useState(SAMPLE);
+  const [saved, setSaved] = useState<string | null>(null);
+  // `theme` defaults to `'auto'`, which follows <Config theme={{ dark }}>. This
+  // site doesn't use that — DemoTheme toggles `.dark` on <html> directly (see
+  // its comment for why) — so the color mode is handed over explicitly.
+  const { colorMode } = useColorMode();
+
+  return (
+    <Space
+      orientation="vertical"
+      align="start"
+      size="small"
+      className="w-full max-w-2xl"
+    >
+      <div className="border-border w-full rounded border">
+        <CodeEditor
+          value={value}
+          theme={colorMode}
+          height="200px"
+          formatCode={collapseSpaces}
+          onChange={setValue}
+          onSave={() => setSaved(new Date().toLocaleTimeString())}
+        />
+      </div>
+      <Typography.Text className="text-muted-foreground text-sm">
+        Press ⌘S / Ctrl+S to format and save.
+        {saved ? ` Last saved ${saved}.` : ''}
+      </Typography.Text>
+    </Space>
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,7 @@
     ".": "./src/index.ts",
     "./Typography": "./src/components/atoms/typography/index.ts",
     "./Button": "./src/components/atoms/button.tsx",
+    "./CodeEditor": "./src/components/atoms/code-editor.tsx",
     "./Tag": "./src/components/atoms/tag.tsx",
     "./Card": "./src/components/molecules/card.tsx",
     "./Space": "./src/components/molecules/space.tsx",
@@ -66,6 +67,8 @@
     "postpublish": "node scripts/restore-package.mjs"
   },
   "devDependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/merge": "^6.12.2",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
@@ -73,6 +76,9 @@
     "@types/node": "^26.2.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
+    "@uiw/codemirror-theme-vscode": "^4.25.11",
+    "@uiw/react-codemirror": "^4.25.11",
+    "codemirror": "^6.0.0",
     "eslint": "^9.39.5",
     "postcss": "^8.5.26",
     "rollup-plugin-postcss": "^4.0.2",
@@ -115,7 +121,29 @@
     "vaul": "^1.1.2"
   },
   "peerDependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/merge": "^6.12.2",
+    "@uiw/codemirror-theme-vscode": "^4.25.11",
+    "@uiw/react-codemirror": "^4.25.11",
+    "codemirror": "^6.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@codemirror/lang-javascript": {
+      "optional": true
+    },
+    "@codemirror/merge": {
+      "optional": true
+    },
+    "@uiw/codemirror-theme-vscode": {
+      "optional": true
+    },
+    "@uiw/react-codemirror": {
+      "optional": true
+    },
+    "codemirror": {
+      "optional": true
+    }
   }
 }

--- a/packages/ui/package.publish.json
+++ b/packages/ui/package.publish.json
@@ -16,6 +16,11 @@
       "import": "./dist/Button.mjs",
       "default": "./dist/Button.mjs"
     },
+    "./CodeEditor": {
+      "types": "./dist/CodeEditor.d.mts",
+      "import": "./dist/CodeEditor.mjs",
+      "default": "./dist/CodeEditor.mjs"
+    },
     "./Tag": {
       "types": "./dist/Tag.d.mts",
       "import": "./dist/Tag.mjs",

--- a/packages/ui/scripts/api-surface.snapshot.json
+++ b/packages/ui/scripts/api-surface.snapshot.json
@@ -3,6 +3,7 @@
     ".",
     "./Button",
     "./Card",
+    "./CodeEditor",
     "./Layout",
     "./Menu",
     "./Reveals",

--- a/packages/ui/scripts/check-ssr-smoke.mjs
+++ b/packages/ui/scripts/check-ssr-smoke.mjs
@@ -47,6 +47,12 @@ import { createElement as h } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import * as ui from '../dist/index.mjs';
+// Subpath-only entries (#346). CodeEditor is published at ./CodeEditor and is
+// deliberately NOT in the root barrel — CodeMirror is an optional peer, and an
+// eager re-export would break `import { Button }` for consumers without it. The
+// loop over `ui` below therefore can't see it, so it's rendered explicitly:
+// otherwise the newest component would be the one component with no SSR gate.
+import * as codeEditor from '../dist/CodeEditor.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const GLOBALS_CSS = path.join(__dirname, '..', 'src', 'globals.css');
@@ -116,6 +122,13 @@ const fixtures = {
   Toast: { title: 'hi' },
 };
 
+// Components reachable only through their own export subpath, with the module
+// they live in. Same contracts as the barrel exports — they just have to be
+// named here because nothing enumerates them for us.
+const SUBPATH_COMPONENTS = {
+  CodeEditor: { module: codeEditor, props: { value: 'const a = 1;\n' } },
+};
+
 // Exports that aren't renderable components (providers-as-values, hooks,
 // constants). Providers still render fine but carry no smoke value on their own.
 const NON_COMPONENTS = new Set([
@@ -145,6 +158,21 @@ for (const name of Object.keys(ui).sort()) {
       h(Config, null, h(Comp, props, children ?? undefined)),
     );
     markupByName[name] = markup;
+    results.push({ name, ok: true });
+  } catch (err) {
+    results.push({ name, ok: false, err });
+  }
+}
+
+for (const [name, { module: mod, props }] of Object.entries(
+  SUBPATH_COMPONENTS,
+)) {
+  const Comp = mod.default;
+  try {
+    if (!isComponent(Comp)) {
+      throw new Error('subpath module has no default-exported component');
+    }
+    markupByName[name] = renderToStaticMarkup(h(Config, null, h(Comp, props)));
     results.push({ name, ok: true });
   } catch (err) {
     results.push({ name, ok: false, err });

--- a/packages/ui/src/components/atoms/code-editor.tsx
+++ b/packages/ui/src/components/atoms/code-editor.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+// Subpath-only component (`@jbpark/ui-kit/CodeEditor`). Deliberately NOT
+// re-exported from `atoms/index.ts` — CodeMirror is an *optional* peer
+// dependency, and an ESM re-export from the root barrel is eager, so
+// `import { Button } from '@jbpark/ui-kit'` would fail to resolve for every
+// consumer that never asked for an editor. Keeping it behind its own subpath
+// is what makes the peer set genuinely opt-in (#346).
+import { useCallback, useMemo, useRef } from 'react';
+
+import { javascript } from '@codemirror/lang-javascript';
+import { unifiedMergeView } from '@codemirror/merge';
+import { vscodeDark, vscodeLight } from '@uiw/codemirror-theme-vscode';
+import CodeMirror, {
+  type Extension,
+  type ReactCodeMirrorRef,
+} from '@uiw/react-codemirror';
+import { EditorView } from 'codemirror';
+
+import { cn } from '@repo/ui/utils';
+
+// Relative rather than `@repo/ui/providers`, because this hook is deliberately
+// absent from that barrel — it is a published subpath, and the hook is internal.
+// Both specifiers resolve to the same files, so there is still one Config
+// context.
+import { useIsDarkActive } from '../../providers/config';
+
+export interface Props extends Omit<
+  React.ComponentProps<typeof CodeMirror>,
+  'value' | 'extensions' | 'onChange' | 'ref' | 'theme'
+> {
+  value: string;
+  /** Passed through to CodeMirror; `'100%'` fills the wrapper. */
+  height?: string;
+  /**
+   * `'light'`/`'dark'` pick the VSCode theme pair, `'auto'` (the default)
+   * follows the nearest `Config`'s `theme.dark`, and an `Extension` is any
+   * CodeMirror theme of your own.
+   *
+   * This narrows CodeMirror's own meaning for two of the strings — upstream,
+   * `'light'`/`'dark'` are *its* built-in themes — so that the two named
+   * options match what the component actually renders by default. `'none'`
+   * still means what it does upstream: no theme extension, style it yourself.
+   */
+  theme?: 'light' | 'dark' | 'auto' | 'none' | Extension;
+  /** Appended after the built-in JS/TS + line-wrapping extensions. */
+  extensions?: Extension[];
+  /**
+   * Renders a read-through unified diff against `original` instead of a plain
+   * document. `mergeControls` defaults to `false` (display-only review, no
+   * accept/reject gutters).
+   */
+  diff?: {
+    original: string;
+    mergeControls?: boolean;
+  };
+  /**
+   * Formatter run on the Cmd/Ctrl+S value before it is written back. Omitted,
+   * the shortcut still fires `onSave` — it just doesn't reformat. Kept as an
+   * injected function so this package carries no formatter dependency of its
+   * own (prettier is ~9.6 MB); pass the one your app already owns.
+   */
+  formatCode?: (code: string) => Promise<string>;
+  className?: string;
+  onChange?: (value: string) => void;
+  /** Fires on Cmd/Ctrl+S with the value that was written back. */
+  onSave?: (value: string) => void;
+  /**
+   * `null` on a clean save; a string carries the message a failed `formatCode`
+   * threw. Named `onFormatError` rather than `onError` because the base props
+   * already carry the DOM `onError` handler, and silently shadowing it would
+   * be worse than the extra word.
+   */
+  onFormatError?: (error: string | null) => void;
+}
+
+const CodeEditor = ({
+  value,
+  theme = 'auto',
+  height,
+  className,
+  extensions: extraExtensions,
+  diff,
+  formatCode,
+  onChange,
+  onSave,
+  onFormatError,
+  ...props
+}: Props) => {
+  const editorRef = useRef<ReactCodeMirrorRef>(null);
+  const isDarkActive = useIsDarkActive();
+
+  const resolvedTheme = useMemo(() => {
+    if (theme === 'auto') {
+      return isDarkActive ? vscodeDark : vscodeLight;
+    }
+    if (theme === 'light') {
+      return vscodeLight;
+    }
+    if (theme === 'dark') {
+      return vscodeDark;
+    }
+
+    // `'none'` and a caller-supplied Extension both mean what they mean
+    // upstream, so hand them straight to CodeMirror.
+    return theme;
+  }, [theme, isDarkActive]);
+
+  const extensions = useMemo(() => {
+    const base: Extension[] = [
+      javascript({ jsx: true, typescript: true }),
+      EditorView.lineWrapping,
+    ];
+
+    if (diff) {
+      base.push(
+        unifiedMergeView({
+          original: diff.original,
+          mergeControls: diff.mergeControls ?? false,
+        }),
+      );
+    }
+
+    return [...base, ...(extraExtensions ?? [])];
+  }, [diff, extraExtensions]);
+
+  const save = useCallback(
+    async (val: string) => {
+      const view = editorRef.current?.view;
+      if (!view) {
+        return;
+      }
+
+      try {
+        const currentLength = view.state.doc.length;
+        const cursorPos = view.state.selection.main.head;
+        const next = formatCode ? await formatCode(val) : val;
+
+        // Formatting is async, so the document may have moved on while it ran
+        // — writing back then would clobber keystrokes typed in the meantime.
+        if (currentLength !== view.state.doc.length) {
+          onFormatError?.(null);
+          return;
+        }
+
+        // Skip the transaction when the text is unchanged (the common case
+        // without a `formatCode`): replacing the doc with itself would push a
+        // pointless undo entry. The callbacks still fire, so a save handler
+        // sees every Cmd+S.
+        if (next !== val) {
+          view.dispatch(
+            view.state.update({
+              changes: { from: 0, to: currentLength, insert: next },
+              selection: { anchor: Math.min(cursorPos, next.length) },
+            }),
+          );
+        }
+
+        onChange?.(next);
+        onSave?.(next);
+        onFormatError?.(null);
+      } catch (e) {
+        onFormatError?.(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [formatCode, onChange, onSave, onFormatError],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault();
+        save(editorRef.current?.view?.state.doc.toString() ?? value);
+      }
+    },
+    [save, value],
+  );
+
+  return (
+    <div
+      data-slot="code-editor"
+      className={cn(
+        className,
+        // ...
+      )}
+      onKeyDown={onKeyDown}
+    >
+      <CodeMirror
+        ref={editorRef}
+        theme={resolvedTheme}
+        height={height || '100%'}
+        value={value}
+        extensions={extensions}
+        onChange={onChange}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default CodeEditor;

--- a/packages/ui/src/providers/config/config.tsx
+++ b/packages/ui/src/providers/config/config.tsx
@@ -1,18 +1,13 @@
 'use client';
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useSyncExternalStore,
-} from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DirectionProvider } from '@radix-ui/react-direction';
 
 import { cn } from '@repo/ui/utils';
 
 import { Context, DEFAULT_LOCALE, useConfig } from './context';
+import { resolveDark, useSystemPrefersDark } from './dark-mode';
 import { registerRootConfig } from './registry';
 import type {
   ComponentSize,
@@ -21,35 +16,6 @@ import type {
   ThemeConfig,
   ThemeToken,
 } from './types';
-
-const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
-
-const subscribeToSystemColorScheme = (callback: () => void) => {
-  if (typeof window === 'undefined') {
-    return () => {};
-  }
-
-  const mql = window.matchMedia(DARK_MEDIA_QUERY);
-  mql.addEventListener('change', callback);
-  return () => mql.removeEventListener('change', callback);
-};
-
-const getSystemPrefersDark = () =>
-  typeof window !== 'undefined' && window.matchMedia(DARK_MEDIA_QUERY).matches;
-
-// No `window` during SSR, so there's no way to know the visitor's actual
-// preference before hydration — assume light (the conservative default)
-// and let useSyncExternalStore correct it client-side once matchMedia is
-// available, same flash-of-incorrect-guess tradeoff already accepted for
-// Sider's breakpoint prop elsewhere in this library.
-const getServerSnapshot = () => false;
-
-const useSystemPrefersDark = () =>
-  useSyncExternalStore(
-    subscribeToSystemColorScheme,
-    getSystemPrefersDark,
-    getServerSnapshot,
-  );
 
 const tokenToCssVar: Record<keyof ThemeToken, string> = {
   colorPrimary: '--primary',
@@ -171,10 +137,7 @@ const Config = ({
   );
 
   const systemPrefersDark = useSystemPrefersDark();
-  const isDarkActive =
-    mergedTheme.dark === 'system'
-      ? systemPrefersDark
-      : mergedTheme.dark === 'dark';
+  const isDarkActive = resolveDark(mergedTheme.dark, systemPrefersDark);
 
   // `darkToken` overrides individual keys of `token` (not a full swap)
   // only while dark mode is actually active.

--- a/packages/ui/src/providers/config/dark-mode.ts
+++ b/packages/ui/src/providers/config/dark-mode.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+import { useConfig } from './context';
+import type { ThemeConfig } from './types';
+
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+const subscribeToSystemColorScheme = (callback: () => void) => {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const mql = window.matchMedia(DARK_MEDIA_QUERY);
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+};
+
+const getSystemPrefersDark = () =>
+  typeof window !== 'undefined' && window.matchMedia(DARK_MEDIA_QUERY).matches;
+
+// No `window` during SSR, so there's no way to know the visitor's actual
+// preference before hydration — assume light (the conservative default)
+// and let useSyncExternalStore correct it client-side once matchMedia is
+// available, same flash-of-incorrect-guess tradeoff already accepted for
+// Sider's breakpoint prop elsewhere in this library.
+const getServerSnapshot = () => false;
+
+export const useSystemPrefersDark = () =>
+  useSyncExternalStore(
+    subscribeToSystemColorScheme,
+    getSystemPrefersDark,
+    getServerSnapshot,
+  );
+
+/**
+ * Turns the three-valued `theme.dark` setting into the boolean that decides
+ * whether dark treatments actually apply. Kept as a pure function so `Config`
+ * can resolve the theme it is about to publish (its merged value isn't in
+ * context yet) while consumers resolve the one already in context, without the
+ * two drifting apart.
+ */
+export const resolveDark = (
+  dark: ThemeConfig['dark'],
+  systemPrefersDark: boolean,
+) => (dark === 'system' ? systemPrefersDark : dark === 'dark');
+
+/**
+ * Whether dark mode is active for the nearest `Config`, with `'system'`
+ * resolved against `prefers-color-scheme`.
+ *
+ * Internal to the package: components that render *CSS* can just use Tailwind's
+ * `dark:` variants against the `.dark` class `Config` puts on its wrapper. This
+ * exists for the ones that have to hand a light/dark choice to a third party in
+ * JS instead — `CodeEditor` picking a CodeMirror theme extension.
+ */
+export const useIsDarkActive = () => {
+  const { theme } = useConfig();
+
+  return resolveDark(theme.dark, useSystemPrefersDark());
+};

--- a/packages/ui/src/providers/config/index.ts
+++ b/packages/ui/src/providers/config/index.ts
@@ -1,5 +1,13 @@
 export { default, useConfig, DEFAULT_LOCALE } from './config';
 export { ConfigSnapshotProvider, getRootConfigValue } from './registry';
+// Internal on purpose — reachable from inside the package, but not re-exported
+// by `providers/index.ts`, so it stays out of the published `./providers`
+// surface until a consumer actually needs it.
+export {
+  resolveDark,
+  useIsDarkActive,
+  useSystemPrefersDark,
+} from './dark-mode';
 export type {
   Props,
   ComponentSize,

--- a/packages/ui/tsdown.config.ts
+++ b/packages/ui/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     index: 'src/index.ts',
     Typography: 'src/components/atoms/typography/index.ts',
     Button: 'src/components/atoms/button.tsx',
+    CodeEditor: 'src/components/atoms/code-editor.tsx',
     Tag: 'src/components/atoms/tag.tsx',
     Card: 'src/components/molecules/card.tsx',
     Space: 'src/components/molecules/space.tsx',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,12 +41,27 @@ importers:
 
   apps/docs:
     dependencies:
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
+      '@uiw/codemirror-theme-vscode':
+        specifier: ^4.25.11
+        version: 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)
+      '@uiw/react-codemirror':
+        specifier: ^4.25.11
+        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      codemirror:
+        specifier: ^6.0.0
+        version: 6.0.2
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
@@ -108,6 +123,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2
       '@docusaurus/core':
         specifier: 3.10.2
         version: 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@swc/helpers@0.5.23)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(@swc/core@1.16.1(@swc/helpers@0.5.23))(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
@@ -123,9 +144,18 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@uiw/codemirror-theme-vscode':
+        specifier: ^4.25.11
+        version: 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)
+      '@uiw/react-codemirror':
+        specifier: ^4.25.11
+        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
+      codemirror:
+        specifier: ^6.0.0
+        version: 6.0.2
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -316,6 +346,12 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -337,6 +373,15 @@ importers:
       '@types/react-dom':
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      '@uiw/codemirror-theme-vscode':
+        specifier: ^4.25.11
+        version: 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)
+      '@uiw/react-codemirror':
+        specifier: ^4.25.11
+        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      codemirror:
+        specifier: ^6.0.0
+        version: 6.0.2
       eslint:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.7.0)
@@ -1096,6 +1141,36 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.11.0':
+    resolution: {integrity: sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/merge@6.12.2':
+    resolution: {integrity: sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==}
+
+  '@codemirror/search@6.7.2':
+    resolution: {integrity: sha512-gUYkYhT2+n/+VGZ+8EzE5WFkYZUZYm1VOKDudIsNqh42uRVQJ0a6Yss9sdKT3MeOYfuL1N6AZA57oza0Oyr0LA==}
+
+  '@codemirror/state@6.7.4':
+    resolution: {integrity: sha512-QhQIVRY+xHZDxwOSFrJ1eUMapJBUID3IdeAjf7dHO7zBUzSkyooHiodnalz5MG3iHzwixKMlAAyn7244y537EA==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.43.11':
+    resolution: {integrity: sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -2201,6 +2276,18 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
   '@manypkg/find-root@3.1.0':
     resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
     engines: {node: '>=20.0.0'}
@@ -2212,6 +2299,9 @@ packages:
   '@manypkg/tools@2.1.2':
     resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
     engines: {node: '>=20.0.0'}
+
+  '@marijn/find-cluster-break@1.0.4':
+    resolution: {integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -4337,6 +4427,38 @@ packages:
     resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.11':
+    resolution: {integrity: sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/codemirror-theme-vscode@4.25.11':
+    resolution: {integrity: sha512-fTQ5676L9iV3Y6UyDBDd8Wt9Gewh55aC5rqnCtIpwyVFb6zJEHJScI4g43lzAD2IKhY7HlozB1ucrS3UqBFNEQ==}
+
+  '@uiw/codemirror-themes@4.25.11':
+    resolution: {integrity: sha512-SBNCOgRsCtewGNocRbmjbCkltGXlFcPJsvhxQ351VynQjnWUiPbUrFcEU/haQ3HanROdAAjWXZJPk5bMBxl2jw==}
+    peerDependencies:
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.11':
+    resolution: {integrity: sha512-DYVFAKLX+F/4JS9N/7xexh+TICrlncwkX9HKKInrP1bwO0tSfc3k0GB6oawTYhelVKh20cX3TuRx+NJSkVXuMw==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
@@ -4951,6 +5073,9 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -5075,6 +5200,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -8939,6 +9067,9 @@ packages:
   style-inject@0.3.0:
     resolution: {integrity: sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -10695,6 +10826,77 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.11.0':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      crelt: 1.0.7
+
+  '@codemirror/merge@6.12.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
+
+  '@codemirror/search@6.7.2':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      crelt: 1.0.7
+
+  '@codemirror/state@6.7.4':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.4
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.43.11':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@colors/colors@1.5.0':
     optional: true
@@ -12595,6 +12797,22 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
   '@manypkg/find-root@3.1.0':
     dependencies:
       '@manypkg/tools': 2.1.2
@@ -12609,6 +12827,8 @@ snapshots:
       jju: 1.4.0
       tinyglobby: 0.2.17
       yaml: 2.9.0
+
+  '@marijn/find-cluster-break@1.0.4': {}
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -14602,6 +14822,47 @@ snapshots:
       '@typescript-eslint/types': 8.67.0
       eslint-visitor-keys: 5.0.1
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.11.0
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.2
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+
+  '@uiw/codemirror-theme-vscode@4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)':
+    dependencies:
+      '@uiw/codemirror-themes': 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
+
+  '@uiw/codemirror-themes@4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+
+  '@uiw/react-codemirror@4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@codemirror/commands': 6.11.0
+      '@codemirror/state': 6.7.4
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.43.11
+      '@uiw/codemirror-extensions-basic-setup': 4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)
+      codemirror: 6.0.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
   '@ungap/structured-clone@1.3.3': {}
 
   '@vitest/expect@3.2.4':
@@ -15267,6 +15528,16 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.11.0
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.2
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -15376,6 +15647,8 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 6.0.3
+
+  crelt@1.0.7: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -20015,6 +20288,8 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   style-inject@0.3.0: {}
+
+  style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
     dependencies:


### PR DESCRIPTION
## Summary

Extracts live-editor's CodeMirror surface into `packages/ui` as `CodeEditor`,
published at its own export subpath with CodeMirror as an **optional** peer set.
Closes #346.

```tsx
import CodeEditor from '@jbpark/ui-kit/CodeEditor';

<CodeEditor value={code} onChange={setCode} height="200px" />;
```

Nothing changes for existing imports. The five CodeMirror packages are only
required by apps that reach for this subpath.

## Changes

- **Subpath-only, and deliberately not in the root barrel.** An ESM re-export is
  eager, so re-exporting `CodeEditor` from `atoms/index.ts` would make
  `import { Button } from '@jbpark/ui-kit'` fail to resolve for every consumer
  that never installed CodeMirror. Verified: `dist/index.mjs` contains zero
  `codemirror` references. The `exports` map, `package.publish.json` and the
  `tsdown` entry map all gained `./CodeEditor`, and
  `scripts/api-surface.snapshot.json` records the new subpath.
- **No formatter ships with it.** Format-on-save is injected as
  `formatCode?: (code: string) => Promise<string>` rather than moving
  live-editor's prettier hook across, so the library carries none of prettier's
  ~9.6 MB. Cmd/Ctrl+S runs it, writes the result back with the cursor preserved,
  then fires `onChange`/`onSave`; without `formatCode` the shortcut still fires
  `onSave`, unformatted. Two safeguards: the result is discarded if the document
  moved while an async format was in flight, and the transaction is skipped when
  the text is unchanged so Cmd+S pushes no no-op undo entry.
- `onFormatError` rather than `onError`, because the underlying CodeMirror props
  already carry the DOM `onError` handler and shadowing it silently would be
  worse than the extra word.
- `diff={{ original }}` swaps the plain document for `unifiedMergeView`;
  `mergeControls` defaults to `false` (display-only review).
- **`theme` is configurable:** `'light' | 'dark' | 'auto' | 'none' | Extension`,
  default `'auto'`. The two named options select the VSCode pair — narrowing
  CodeMirror's own meaning for those strings, which upstream are its built-in
  themes — while `'none'` and a caller-supplied extension pass straight through.
  `'auto'` follows the nearest `Config`'s `theme.dark` (`'system'` resolved
  against `prefers-color-scheme`) and stays light when no `Config` sets it, so
  the default is visually unchanged for apps that never opted into dark mode.
- To avoid a second definition of "is dark active", `Config`'s
  `prefers-color-scheme` store moved to `providers/config/dark-mode.ts`, with a
  pure `resolveDark()` shared by `Config` (resolving the theme it is about to
  publish) and `useIsDarkActive()` (resolving the one already in context). The
  hook is exported from the internal `providers/config` barrel only, **not**
  from `providers/index.ts` — the public surface is unchanged, and
  `check-api-surface` still reports 43 names / 13 subpaths.
- **`check-ssr-smoke` gained a `SUBPATH_COMPONENTS` pass.** Its loop enumerates
  the root barrel, so a subpath-only component would otherwise have been the one
  component in the library with no SSR gate.
- Docs: a Storybook page (`Data Entry/CodeEditor`, with `Dark` and
  `AutoFollowsConfig` stories) and a Docusaurus page. Both drive `formatCode`
  with a stand-in that collapses runs of spaces, so the docs pull no formatter
  either. The Docusaurus demo passes `theme` from `useColorMode()` because that
  site toggles the `.dark` class on `<html>` directly instead of going through
  `Config`, which `'auto'` cannot see — documented as a note on the page.

## Type of Change

- [x] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [x] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

Not attached. Storybook (`Data Entry/CodeEditor`) covers `Default`, `Dark`,
`AutoFollowsConfig`, `Controlled`, `FormatOnSave` and `Diff`.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm lint` | 3/3 packages, 0 errors |
| `turbo run check-types` | 3/3 |
| `turbo run build` | 3/3, including the Docusaurus static render of the demo |
| `check-regression-net` | 4/4 — api-surface (43 names / 13 subpaths), preflight-reset, SSR smoke (39 components) |
| `check-dynamic-classes` | 126 files, clean |
| `build-storybook` | success |

Also verified in the built output that `dist/CodeEditor.mjs` and
`dist/index.mjs` import the same `providers/config/context.mjs` chunk, so
`theme="auto"` reads the same Config context a consumer's `<Config>` provides —
the context isn't duplicated per entry.

**Not verified:** the editor has not been visually confirmed mounting in a
browser. It server-renders and Storybook builds, but no manual browser pass was
made.

## Follow-up

Switching live-editor over to consume this component is intentionally left to a
separate change in that repository.

## Checklist

- [x] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [x] Storybook stories are added for new components / features
- [x] No type or lint errors (`pnpm lint`, `pnpm typecheck`)
- [x] Build completes successfully (`pnpm build`)
