### PR TITLE
chore(ci): drop gitmoji from bot-generated commit messages

### DIFF
--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -84,7 +84,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add .changeset/*.md
-            git commit -m "📝 docs: draft changeset for PR #${{ github.event.pull_request.number }}"
+            git commit -m "docs: draft changeset for PR #${{ github.event.pull_request.number }}"
             git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
           else
             echo "No changeset produced (no tracked package changed, or model found no notable change) — skipping commit."

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -42,7 +42,11 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm exec changeset version
-          commit: '🔖 chore: version packages'
-          title: '🔖 chore: version packages'
+          # No emoji prefix — see .github/COMMIT_CONVENTION.md. These strings
+          # become a real commit on the release branch and the PR title that
+          # lands on main, so they follow the same `type: summary` shape as a
+          # hand-written commit.
+          commit: 'chore: version packages'
+          title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two workflows still hardcoded emoji prefixes in the commits and PR titles they
generate, so every bot-authored commit landed against the convention this
repository documents. #341 dropped gitmoji from
[`COMMIT_CONVENTION.md`](.github/COMMIT_CONVENTION.md) ("Do not prefix the title
with an emoji/gitmoji") but the automation was never updated to match.

## Changes

- `version.yml` passed `🔖 chore: version packages` as both `commit:` and
  `title:` to `changesets/action`. The `title:` is what becomes the squash
  commit on `main` when the Version Packages PR merges — 8.0.0 landed as
  `chore: version packages (#345)` only because the subject was overridden by
  hand at merge time. Now the workflow emits the convention-compliant string,
  so the default is correct without intervention.
- `changeset-draft.yml` committed `📝 docs: draft changeset for PR #N` onto the
  head branch of every PR it drafts a changeset for.

Both now emit a plain `type: summary`, with a comment on the `version.yml` pair
pointing at the convention so the next edit doesn't reintroduce the prefix.

Verified no other emoji survive anywhere under `.github/` in a string that
reaches a commit message or PR title. The emoji in the PR template's "Type of
Change" checklist are deliberately left alone — they label choices in a form and
never end up in a commit.

## Type of Change

- [ ] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [x] 🔧 chore — build or config changes

## Verification

Workflow-only change, so there is nothing to build or type-check beyond CI's own
run. The effect is only observable the next time each workflow fires:

- `version.yml` — the next Version Packages PR should open titled
  `chore: version packages`.
- `changeset-draft.yml` — this PR is itself a live check that the drafting job
  still runs; it touches no tracked package, so it should skip committing a
  changeset rather than push one.

No changeset is included: nothing in `packages/ui` changed, so there is nothing
to release.
