### PR TITLE
fix(docs): render the CodeEditor subpath admonition

### DIFF
--- a/apps/web/docs/components/atoms/code-editor.mdx
+++ b/apps/web/docs/components/atoms/code-editor.mdx
@@ -17,7 +17,7 @@ import CodeEditor from '@jbpark/ui-kit/CodeEditor';
 <CodeEditor value={code} onChange={setCode} height="200px" />;
 ```
 
-:::info Subpath-only, with optional peers
+:::info[Subpath-only, with optional peers]
 
 `CodeEditor` is **not** exported from the package root — `import { CodeEditor }
 from '@jbpark/ui-kit'` will not work, and that is deliberate. CodeMirror is a


### PR DESCRIPTION
The `:::info` block on the CodeEditor docs page never rendered as an admonition — it shipped as literal text.

## Symptom

`/docs/components/atoms/code-editor` rendered three artefacts instead of one info box:

- a paragraph reading `:::info Subpath-only, with optional peers`
- the intended box contents as ordinary prose
- a stray `:::` paragraph just above the live demo

## Cause

Docusaurus 3 (MDX v3 + `remark-directive`) recognises admonition titles only in the bracket form. `apps/web/docs/components/atoms/code-editor.mdx:20`, added in #347, used the pre-v3 space form:

```diff
-:::info Subpath-only, with optional peers
+:::info[Subpath-only, with optional peers]
```

An unparsed directive degrades silently — no build warning, which is why it survived CI and the Vercel preview.

## Scope

This was the only occurrence. The two pre-existing admonitions already use the bracket form:

```
docs/components/atoms/tag.mdx:43    :::note[Deprecated spellings]
docs/components/atoms/button.mdx:64 :::note[Deprecated spellings]
```

## Verification

Rendered against `pnpm dev` in a real browser (headless Chrome, DOM dump + screenshot):

| Check | Before | After |
| --- | --- | --- |
| `theme-admonition` elements on the page | 1 | 2 |
| literal `:::` in rendered DOM | 2 | 0 |

Both admonitions on the page now render, and the untitled `:::note` in the Theme section was unaffected either way.

No changeset: `packages/ui` is untouched, this is `apps/web` content only.