### PR TITLE
docs(web): add the CodeEditor page to the sidebar

### DIFF
--- a/.changeset/docs-sidebar-code-editor-web.md
+++ b/.changeset/docs-sidebar-code-editor-web.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Add code editor component to sidebar navigation.

--- a/.changeset/docs-sidebar-code-editor-web.md
+++ b/.changeset/docs-sidebar-code-editor-web.md
@@ -2,4 +2,6 @@
 'web': minor
 ---
 
-Add code editor component to sidebar navigation.
+List the CodeEditor docs page in the sidebar under Data Entry. The page has
+existed since the component landed, but no sidebar referenced it, so it was
+reachable only by typing its URL.

--- a/apps/web/sidebars.ts
+++ b/apps/web/sidebars.ts
@@ -33,6 +33,7 @@ const sidebars: SidebarsConfig = {
         'components/atoms/switch',
         'components/atoms/slider',
         'components/atoms/rich-text-editor',
+        'components/atoms/code-editor',
         'components/atoms/input',
         'components/atoms/checkbox',
         'components/atoms/radio',


### PR DESCRIPTION
## Symptom

`/docs/components/atoms/code-editor` renders fine but appears nowhere in the docs navigation — the only way to reach it is to type the URL.

## Cause

`apps/web/docs/components/atoms/code-editor.mdx` was added in #347, but that PR never touched `apps/web/sidebars.ts`:

```
$ git show --stat 6d069d8 -- apps/web
 apps/web/docs/components/atoms/code-editor.mdx | 153 ++++++++++++
 apps/web/package.json                          |   5 +
 apps/web/src/demo/code-editor-demo.tsx         |  50 ++++
```

The sidebar is a fully manual item list (no `type: 'autogenerated'`), and Docusaurus emits **no warning** for docs that no sidebar references — `docusaurus start` and `docusaurus build` both succeed silently. So neither CI nor the manual browser pass on #347 could have caught it. `sidebar_position: 18` in the page's frontmatter is inert for the same reason.

It is the only orphaned page:

```
$ comm -23 \
    <(find docs -name '*.mdx' -o -name '*.md' | sed -E 's|^docs/||; s|\.mdx?$||' | sort) \
    <(grep -oE "'[a-z0-9/-]+'" sidebars.ts | tr -d "'" | sort)
components/atoms/code-editor
```

## Change

One line: `'components/atoms/code-editor'` under **Data Entry**, right after `rich-text-editor`. That category matches the story's `title: 'Data Entry/CodeEditor'`, which is the grouping rule `sidebars.ts` documents at the top of the file.

## Verification

`docusaurus start` + a headless DOM dump of the page:

- the sidebar renders the link at position 14, between RichTextEditor and Input;
- the page's own entry carries `menu__link--active`;
- prev/next pagination is wired into the chain (prev → RichTextEditor, next → Input).

`pnpm build` in `apps/web` exits 0. `pnpm lint` and `pnpm check-types` pass (pre-commit hook).

## Out of scope

- The landing page's `CATEGORIES` list (`src/pages/index.tsx:47`) is a curated sample, not an index — it already omits ColorPicker, Slider and RichTextEditor, so `CodeEditor` is not missing from it in any meaningful sense.
- A guard against this recurring (a `check-orphaned-docs` script wrapping the `comm` above, in the spirit of the existing `check-*` scripts) would be worth having, but is a separate change.