### PR TITLE
feat(marquees): add gap between the repeated copies of a row

### DIFF
--- a/.changeset/marquees-repeat-gap.md
+++ b/.changeset/marquees-repeat-gap.md
@@ -1,0 +1,26 @@
+---
+'@repo/ui': minor
+---
+
+Add `gap` to `Marquees`, the space between the repeated copies of a row.
+
+`autoFill` duplicates each row until it covers the container, and those copies
+were laid out flush against one another. Any row that spaces its own children —
+the common case, a flex row of pills — therefore rendered a visibly tighter seam
+than the rest of the track: 12px between pills inside a copy, 0px between the
+last pill of one copy and the first pill of the next, repeating at every
+boundary.
+
+```tsx
+<Marquees speed={40} gap={12} items={[{ key: 0, children: row }]} />
+```
+
+`gap` is a px number, defaults to `0` (the previous layout), and is available
+per-row through `ItemProps` like `speed` and `autoFill`. It is applied as
+trailing padding on every copy rather than a flex `gap` on the track, so the
+spacing is uniform at both the copy seam and the boundary between the two loop
+halves, with no special case at either end. Because `offsetWidth` is the
+border-box width, the measured copy width already includes that padding and the
+loop distance stays exact — the scroll remains seamless. Changing `gap` rewinds
+the measurement to the container width so the repeat count is recomputed instead
+of reusing a count derived from the old copy width.

--- a/apps/docs/stories/molecules/marquees/index.stories.tsx
+++ b/apps/docs/stories/molecules/marquees/index.stories.tsx
@@ -22,6 +22,14 @@ const meta: Meta<typeof Marquees> = {
     autoFill: {
       control: { type: 'boolean' },
     },
+    gap: {
+      control: { type: 'range', min: 0, max: 100, step: 4 },
+    },
+  },
+  // The rows below space their own children by `gap-2`; `gap` applies the same
+  // 8px between the repeated copies so the seam is not tighter than the rest.
+  args: {
+    gap: 8,
   },
   render: props => {
     return (

--- a/apps/web/docs/components/molecules/marquees.mdx
+++ b/apps/web/docs/components/molecules/marquees.mdx
@@ -15,6 +15,7 @@ import { Marquees } from '@jbpark/ui-kit';
 
 <Marquees
   speed={40}
+  gap={12}
   items={[{ key: 0, children: <div>Scrolling content</div> }]}
 />;
 ```
@@ -33,6 +34,7 @@ import { Marquees } from '@jbpark/ui-kit';
 | `speed`        | `number` (px/second)  | `100`   |
 | `pauseOnHover` | `boolean`             | `true`  |
 | `autoFill`     | `boolean \| number`   | `true`  |
+| `gap`          | `number` (px)         | `0`     |
 | `className`    | `string`              | -       |
 
-Each `ItemProps` is `{ key?; children; speed?; autoFill?; pauseOnHover? }` — per-row overrides fall back to the values set on `Marquees`. `autoFill` repeats each row enough to cover the container (pass a number to force a specific repeat count). `Marquees.Item` is also exported for rendering a single track directly. `Marquees` forwards the rest of `React.ComponentProps<'div'>`.
+Each `ItemProps` is `{ key?; children; speed?; autoFill?; pauseOnHover?; gap? }` — per-row overrides fall back to the values set on `Marquees`. `autoFill` repeats each row enough to cover the container (pass a number to force a specific repeat count). `gap` is the space between those repeats — set it to match the spacing inside your row, otherwise the last element of one copy sits flush against the first element of the next. `Marquees.Item` is also exported for rendering a single track directly. `Marquees` forwards the rest of `React.ComponentProps<'div'>`.

--- a/apps/web/src/demo/marquees-demo.tsx
+++ b/apps/web/src/demo/marquees-demo.tsx
@@ -17,5 +17,5 @@ const row = (
 const items = [{ key: 0, children: row }];
 
 export default function MarqueesDemo() {
-  return <Marquees speed={40} items={items} />;
+  return <Marquees speed={40} gap={12} items={items} />;
 }

--- a/packages/ui/src/components/molecules/marquees/item.tsx
+++ b/packages/ui/src/components/molecules/marquees/item.tsx
@@ -13,6 +13,7 @@ export interface ItemProps {
   autoFill?: boolean | number;
   pause?: boolean;
   pauseOnHover?: boolean;
+  gap?: number;
   children?: React.ReactNode;
 }
 
@@ -30,12 +31,21 @@ export interface Props
 // render by ~90%.
 const INITIAL_AUTO_FILL_GUESS = 10;
 
+const resolveInitialRepeatCount = (autoFill: boolean | number) => {
+  if (!autoFill) {
+    return 0;
+  }
+
+  return typeof autoFill === 'boolean' ? INITIAL_AUTO_FILL_GUESS : autoFill;
+};
+
 const Item = ({
   width: _width,
   speed = 100,
   autoFill = false,
   pause: _pause = false,
   pauseOnHover = false,
+  gap = 0,
   children,
 }: Props) => {
   const itemRefs = useRef<HTMLDivElement[]>([]);
@@ -45,14 +55,11 @@ const Item = ({
   const [width, setWidth] = useState<string | number>(_width);
   const { pause, hoverEvents } = usePauseOnHover(pauseOnHover);
   const [repeatCount, setRepeatCount] = useState(
-    autoFill
-      ? typeof autoFill === 'boolean'
-        ? INITIAL_AUTO_FILL_GUESS
-        : autoFill
-      : 0,
+    resolveInitialRepeatCount(autoFill),
   );
   const [prevWidthProp, setPrevWidthProp] = useState(_width);
   const [prevAutoFill, setPrevAutoFill] = useState(autoFill);
+  const [prevGap, setPrevGap] = useState(gap);
 
   // Adjusted directly in render (React's "adjust state during render"
   // pattern) instead of an effect, so `width`/`repeatCount` re-sync with
@@ -64,13 +71,16 @@ const Item = ({
 
   if (autoFill !== prevAutoFill) {
     setPrevAutoFill(autoFill);
-    setRepeatCount(
-      autoFill
-        ? typeof autoFill === 'boolean'
-          ? INITIAL_AUTO_FILL_GUESS
-          : autoFill
-        : 0,
-    );
+    setRepeatCount(resolveInitialRepeatCount(autoFill));
+  }
+
+  // `gap` widens every copy, so both the measured item width and the repeat
+  // count derived from it are stale. Rewind `width` to the container width
+  // so the measuring effect below recomputes the loop distance from scratch.
+  if (gap !== prevGap) {
+    setPrevGap(gap);
+    setWidth(_width);
+    setRepeatCount(resolveInitialRepeatCount(autoFill));
   }
 
   const isPaused = _pause || pause;
@@ -85,6 +95,9 @@ const Item = ({
       return;
     }
 
+    // `offsetWidth` is the border-box width, so it already includes the
+    // `gap` padding each copy carries — the loop distance stays exact
+    // without adding `gap` back in here.
     const itemWidth = itemRefs.current[0].offsetWidth;
 
     if (itemWidth >= width) {
@@ -103,7 +116,7 @@ const Item = ({
 
     setWidth(totalWidth);
     setRepeatCount(repeatCount - 1);
-  }, [autoFill, width, children]);
+  }, [autoFill, width, children, gap]);
 
   useGSAP(
     () => {
@@ -161,19 +174,25 @@ const Item = ({
             style={{ minWidth: width }}
             className="flex flex-nowrap"
           >
+            {/* Every copy carries the same trailing `gap`, so the spacing is
+                uniform at the seam between copies and between the two loop
+                halves — no special-casing at either boundary. */}
             <div
               ref={el => {
                 if (el) {
                   itemRefs.current[index] = el;
                 }
               }}
+              style={{ paddingRight: gap }}
             >
               {children}
             </div>
             {[
               ...Array(typeof autoFill === 'number' ? autoFill : repeatCount),
             ].map((_, i) => (
-              <div key={i}>{children}</div>
+              <div key={i} style={{ paddingRight: gap }}>
+                {children}
+              </div>
             ))}
           </div>
         ))}

--- a/packages/ui/src/components/molecules/marquees/marquees.tsx
+++ b/packages/ui/src/components/molecules/marquees/marquees.tsx
@@ -17,6 +17,7 @@ export interface Props extends React.ComponentPropsWithoutRef<'div'> {
   speed?: number;
   autoFill?: boolean | number;
   pauseOnHover?: boolean;
+  gap?: number;
   items?: ItemProps[];
 }
 
@@ -26,6 +27,7 @@ const Marquees = ({
   speed,
   pauseOnHover = true,
   autoFill = true,
+  gap,
   ...props
 }: Props) => {
   const [width, setWidth] = useState<string | number>(
@@ -87,6 +89,7 @@ const Marquees = ({
             pause={pause}
             speed={speed}
             autoFill={autoFill}
+            gap={gap}
             {...item}
           >
             {children}


### PR DESCRIPTION
## Summary

`Marquees` laid the copies that `autoFill` generates flush against one another, so any row that spaces its own children rendered a visibly tighter seam than the rest of the track. This adds a `gap` prop for the space between those repeats.

The docs demo (`apps/web/src/demo/marquees-demo.tsx`) is a flex row of pills with `gap-3`, which made it obvious there: 12px between pills inside a copy, 0px at every copy boundary. Measured in the browser against the docs dev server:

| Boundary | Before | After |
| --- | --- | --- |
| Between pills inside a copy | `12.00px` | `12.00px` |
| **Between copies (the seam)** | **`0.00px`** | **`12.00px`** |

It is not limited to the first wrap — the seam recurs at every repeat boundary.

## Changes

- Add `gap` (px, default `0`) to `Marquees`, forwarded to each track and available per-row through `ItemProps` alongside `speed` / `autoFill` / `pauseOnHover`.
- Apply it as trailing padding on **every** copy rather than a flex `gap` on the track. Every copy is then `itemWidth + gap` wide, so the spacing is uniform at the copy seam *and* at the boundary between the two loop halves, with no special case at either end. A flex `gap` would have needed one, since the track-level gap and the group's `minWidth` slack stack up at the wrap.
- Leave the loop-distance arithmetic untouched: `offsetWidth` is the border-box width, so the measured copy width already includes that padding. Verified the loop stays seamless — sum of copy widths (1056) == group `minWidth` (1056) == `scrollWidth` (1056), no leftover slack, and the per-frame translation is uniform (median `-0.68px`, range `-0.60`…`-0.72`) with no anomalous step.
- Rewind `width` to the container width when `gap` changes, via the existing "adjust state during render" block, so the repeat count is recomputed instead of reusing one derived from the old copy width. Add `gap` to the measuring effect's dependencies for the case where `width` is already the container width and the reset is a no-op.
- Extract `resolveInitialRepeatCount` — seeding `repeatCount` is now needed in three places, and the nested ternary did not read well duplicated.
- Docs: pass `gap={12}` in the demo, add the prop to the props table, and explain why you would set it.
- Storybook: add a `gap` range control and a meta-level `gap: 8` default matching the stories' own `gap-2` rows.
- Add a minor changeset for `@repo/ui`.

Default is `0`, so existing consumers keep the current layout and opt in.

## Type of Change

- [x] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [x] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

No image attached; the change is a spacing delta that reads better as the measured numbers in the table above, captured from the rendered docs page with Playwright. To see it, run `pnpm --filter web dev` and open `/docs/components/molecules/marquees` — the seam between `Docusaurus` and the following `React` now matches every other gap.

## Checklist

- [x] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [x] Storybook stories are added for new components / features — the existing `Marquees` stories gained a `gap` control and default rather than a new story, since `gap` is a prop on an existing component
- [x] No type or lint errors (`pnpm lint`, `pnpm run check-types`) — 0 errors; remaining warnings are pre-existing, from `docs` linting built output
- [x] Build completes successfully (`pnpm exec turbo run build`) — 3/3 tasks
- [x] Regression net passes (`check-regression-net`, `check-dynamic-classes`, `check-orphaned-docs`)