### PR TITLE
fix(marquees): seed the track width from the container, not the viewport

### DIFF
--- a/.changeset/marquees-initial-width.md
+++ b/.changeset/marquees-initial-width.md
@@ -1,0 +1,32 @@
+---
+'@repo/ui': patch
+---
+
+Fix `Marquees` briefly painting its track at the viewport width before the
+measurement lands.
+
+`width` was seeded with `'100vw'`. `useResponsiveSize` measures in a layout
+effect, so the real container width is known before the first paint, but
+`Marquees` copies it into state in a passive effect and then passes it through
+`useThrottledValue(width, 200)` — whose leading edge is spent on mount by the
+seed itself, pushing the first real value onto the trailing timer. So the seed
+is what paints for roughly the first 200ms.
+
+On the docs page that drew the track 1280px wide inside a 703px column: the
+whole track was visible for ~190ms, the page grew a transient horizontal
+scrollbar (`scrollWidth` 1596 vs `clientWidth` 1280), and then it snapped to the
+column width and clipped. Measured from first paint:
+
+|                           | Before                       | After   |
+| ------------------------- | ---------------------------- | ------- |
+| Track width, first ~190ms | `1280px` (column is `703px`) | `703px` |
+| Page horizontal overflow  | `+316px`                     | `0px`   |
+
+The seed is now `'100%'`, which resolves against the container to the same value
+the measurement produces (`size.width` minus the container's horizontal
+padding), so there is nothing left to snap. Verified at 420 / 768 / 1280 /
+1920px viewports: no page overflow on any frame, and the track renders at its
+final width from the first paint.
+
+This does not change the throttle, which is still wanted for resize; it only
+stops the pre-measurement frames from being wrong.

--- a/packages/ui/src/components/molecules/marquees/marquees.tsx
+++ b/packages/ui/src/components/molecules/marquees/marquees.tsx
@@ -28,8 +28,16 @@ const Marquees = ({
   autoFill = true,
   ...props
 }: Props) => {
+  // The container's own width, not the viewport's. `useResponsiveSize`
+  // measures in a layout effect, but this component copies the result into
+  // state in a passive effect and then throttles it, so the seed is what
+  // paints for the first ~200ms. `100vw` overflowed every padded or columned
+  // layout for that window — on the docs page it drew the track 1280px wide
+  // inside a 703px column, briefly showing the whole track and giving the
+  // page a horizontal scrollbar. `100%` resolves to the same value the
+  // measurement lands on, so there is nothing left to snap.
   const [width, setWidth] = useState<string | number>(
-    '100vw',
+    '100%',
     //
   );
   const [padding, setPadding] = useState(0);


### PR DESCRIPTION
## Summary

On first paint, `Marquees` rendered its track at the **viewport** width instead of the container width for roughly 200ms. On the docs page that drew a 1280px track inside a 703px column: every item was briefly visible, the page grew a transient horizontal scrollbar, and then the track snapped to the column width and clipped.

The seed is now `'100%'` instead of `'100vw'`, so the pre-measurement frames already resolve to the container width.

Separate from #356 — that one fixes the 0px seam between `autoFill` copies, this one fixes the initial width.

## Changes

- Change the initial `width` state in `packages/ui/src/components/molecules/marquees/marquees.tsx` from `'100vw'` to `'100%'`, with a comment explaining why the seed is what paints.
- Add a `patch` changeset for `@repo/ui`.

### Why the seed paints at all

`useResponsiveSize` measures in a layout effect, so the real container width *is* known before the first paint. But `Marquees` copies `size.width` into state in a **passive** `useEffect` and then passes it through `useThrottledValue(width, 200)`. The throttle's leading edge is spent on mount by the seed itself (a no-op `setThrottledValue('100vw')`), which pushes the first real width onto the trailing timer. Net effect: the seed is what the user sees for ~200ms.

`'100vw'` overflowed any padded or columned layout for that window. `'100%'` resolves against the container to the same value the measurement lands on (`size.width` minus the container's horizontal padding), so there is nothing left to snap.

The throttle is untouched — it is still wanted for resize. This only stops the pre-measurement frames from being wrong.

### Measured, from first paint (docs page, 1280px viewport)

| | Before | After |
| --- | --- | --- |
| Track width, first ~190ms | `1280px` (column is `703px`) | `703px` |
| Page horizontal overflow | `+316px` (`scrollWidth` 1596 vs `clientWidth` 1280) | `0px` |

Viewport sweep on the built docs site — track width `388` / `736` / `703` / `1120px` at `420` / `768` / `1280` / `1920px`, with `0px` page overflow on every sampled frame.

## Type of Change

- [ ] ✨ feat — new feature
- [x] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

Not attached — the change is only observable in the first ~200ms of load. Reproduce by throttling CPU and reloading `/docs/components/molecules/marquees`: before, the row of pills is fully visible and the page scrolls horizontally; after, it is clipped to the column from the first frame.

## Checklist

- [x] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [x] Storybook stories are added for new components / features — n/a, no API change
- [x] No type or lint errors (`pnpm lint`, `pnpm check-types`)
- [x] Build completes successfully (`pnpm build`)