### PR TITLE
fix(drawer): wrap the footer and extra slots instead of dropping the wrapper

### DIFF
--- a/.changeset/drawer-footer-wrapper.md
+++ b/.changeset/drawer-footer-wrapper.md
@@ -1,0 +1,41 @@
+---
+'@repo/ui': patch
+---
+
+`Drawer`'s `footer` is wrapped in the footer bar again, and `classNames.footer` /
+`classNames.extra` do something again.
+
+`Drawer` rendered its `footer` and `extra` slots through
+`renderConditional(value, wrapper)`, which returns the value **unwrapped** when
+it is already a React element and only calls `wrapper` for strings, numbers and
+arrays. A footer is practically always an element, so the wrapper was skipped in
+the common case: `DrawerFooter` never mounted, and `classNames.footer` — a
+documented prop — silently did nothing. `extra` lost its `shrink-0` wrapper and
+`classNames.extra` the same way.
+
+Measured on the docs Drawer demo (`direction="right"`, `size="small"`, 1280px
+viewport, so a 384px panel):
+
+|                               | Before                           | After           |
+| ----------------------------- | -------------------------------- | --------------- |
+| `[data-slot="drawer-footer"]` | absent                           | present         |
+| Footer button width           | `384px` (full panel)             | `352px`         |
+| Inset from the panel edges    | `0px` / `0px`                    | `16px` / `16px` |
+| Pinned to the panel bottom    | no — sat directly under the body | yes (`mt-auto`) |
+
+Without the wrapper the button became a direct child of `drawer-content`, which
+is `flex flex-col`; `align-items: stretch` blew it out to the full panel width
+with no padding.
+
+`PageHeader`'s `extra` had the identical bug and is fixed the same way — note its
+sibling `title`/`subTitle` were already written as plain conditionals.
+
+Both now render as `{value != null && <Wrapper>{value}</Wrapper>}`.
+`renderConditional` itself is unchanged: the element opt-out is deliberate for
+content slots like `Card`/`Popover`/`List`'s `title`, where forcing the wrapper
+would nest a caller-supplied heading inside `<h6>`. It now carries a doc comment
+saying so, so a layout wrapper doesn't get routed through it again.
+
+The footer keeps its stacked full-width layout (`flex flex-col`), so a footer
+with two buttons still stacks them rather than switching to `Modal`'s
+right-aligned row. Override with `classNames.footer` — which now works.

--- a/packages/ui/src/components/organisms/drawer.tsx
+++ b/packages/ui/src/components/organisms/drawer.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { X } from 'lucide-react';
 
 import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
-import { cn, renderConditional } from '@repo/ui/utils';
+import { cn } from '@repo/ui/utils';
 
 import { drawer } from '../../core';
 import Button from '../atoms/button';
@@ -214,9 +214,9 @@ const Drawer = ({
               <DrawerTitle className={cn(classNames?.title)}>
                 {title}
               </DrawerTitle>
-              {renderConditional(extra, v => (
-                <div className={cn('shrink-0', classNames?.extra)}>{v}</div>
-              ))}
+              {extra != null && (
+                <div className={cn('shrink-0', classNames?.extra)}>{extra}</div>
+              )}
             </div>
           </div>
           <DrawerDescription className="hidden" />
@@ -230,9 +230,11 @@ const Drawer = ({
         >
           {children}
         </div>
-        {renderConditional(footer, v => (
-          <DrawerFooter className={cn(classNames?.footer)}>{v}</DrawerFooter>
-        ))}
+        {footer != null && (
+          <DrawerFooter className={cn(classNames?.footer)}>
+            {footer}
+          </DrawerFooter>
+        )}
       </DrawerContent>
     </DrawerCore>
   );

--- a/packages/ui/src/components/templates/page-header.tsx
+++ b/packages/ui/src/components/templates/page-header.tsx
@@ -3,7 +3,7 @@
 import { ArrowLeft } from 'lucide-react';
 
 import { DEFAULT_LOCALE, useConfig } from '@repo/ui/providers';
-import { cn, renderConditional } from '@repo/ui/utils';
+import { cn } from '@repo/ui/utils';
 
 import Button from '../atoms/button';
 
@@ -69,9 +69,9 @@ const PageHeader = ({
               </p>
             )}
           </div>
-          {renderConditional(extra, v => (
-            <div className={cn('shrink-0', classNames?.extra)}>{v}</div>
-          ))}
+          {extra != null && (
+            <div className={cn('shrink-0', classNames?.extra)}>{extra}</div>
+          )}
         </div>
       </div>
       {children}

--- a/packages/ui/src/lib/utils/index.ts
+++ b/packages/ui/src/lib/utils/index.ts
@@ -7,6 +7,18 @@ export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));
 };
 
+/**
+ * Renders a slot value, applying `wrapper` only to values that aren't already
+ * a React element. Passing an element opts out of the wrapper entirely.
+ *
+ * **Only use this for content slots where that opt-out is the point** — a
+ * `title` the caller may want to supply as their own heading, so we don't end
+ * up nesting `<h6><h3>`. Do *not* use it for a wrapper that carries layout the
+ * component owns (padding, `shrink-0`, a footer bar): the common case is an
+ * element, so the wrapper would be skipped exactly when it's needed, and any
+ * `classNames.*` threaded through it would silently do nothing. Write those as
+ * a plain `{value != null && <Wrapper>{value}</Wrapper>}`.
+ */
 export const renderConditional = <T extends React.ReactNode>(
   value: T,
   wrapper?: (value: NonNullable<T>) => React.ReactNode,


### PR DESCRIPTION
## Summary

Opening the Drawer on its docs page put the footer button flush against both panel edges at the full panel width. `DrawerFooter` was never mounting: `Drawer` renders `footer` and `extra` through `renderConditional(value, wrapper)`, which returns the value **unwrapped** when it is already a React element and only calls `wrapper` for strings, numbers and arrays. A footer is practically always an element, so the wrapper was skipped in exactly the common case.

Fallout beyond the layout: `classNames.footer` and `classNames.extra` — both documented in `drawer.mdx` — silently did nothing whenever the corresponding prop was an element.

`PageHeader`'s `extra` had the identical bug.

## Changes

- `drawer.tsx`: render `footer` as `{footer != null && <DrawerFooter>…}` and `extra` as `{extra != null && <div className="shrink-0">…}`.
- `page-header.tsx`: same for `extra`, matching its sibling `title`/`subTitle` which were already plain conditionals.
- `lib/utils/index.ts`: document `renderConditional`'s element opt-out as being for *content* slots only, so a layout wrapper doesn't get routed through it again. The function itself is unchanged.
- Add a `patch` changeset for `@repo/ui`.

### Why the button filled the panel

Without the wrapper the button became a direct child of `drawer-content`, which is `flex flex-col`. Column flex with the default `align-items: stretch` stretches items across the cross axis, so the button took the panel's full width, with no `p-4` and no `mt-auto` to pin it to the bottom.

Measured on the docs demo (`direction="right"`, `size="small"`, 1280px viewport → 384px panel):

| | Before | After |
| --- | --- | --- |
| `[data-slot="drawer-footer"]` | absent | present |
| Footer button width | `384px` (full panel) | `352px` |
| Inset from the panel edges | `0px` / `0px` | `16px` / `16px` |
| Pinned to the panel bottom | no — sat directly under the body | yes (`mt-auto` resolves to `611.6px`) |

`PageHeader`, same page-load check: the `Save` button's parent is now `div.shrink-0` with computed `flex-shrink: 0`, where before the button was the flex child itself and could shrink.

### Why `renderConditional` was left alone

The element opt-out is deliberate for the other four call sites — `Card`, `Popover` and `List` pass a `title` through it, and forcing the wrapper there would nest a caller-supplied heading inside `Typography.Title`'s `<h6>`. The defect is using a content-slot helper for a wrapper that carries layout the component owns; fixing those two call sites is the narrower and safer change.

### Footer layout

The footer keeps shadcn's stacked full-width layout (`flex flex-col gap-2 p-4`) rather than switching to `Modal`'s `flex-row justify-end`, so a two-button footer still stacks. `classNames.footer` is the override — and it works now.

## Type of Change

- [ ] ✨ feat — new feature
- [x] 🐛 fix — bug fix
- [ ] ♻️ refactor — code refactoring
- [ ] 💄 style — UI / style changes
- [ ] 📝 docs — documentation update
- [ ] 🔧 chore — build or config changes

## Screenshots

Docs Drawer demo, 1280px:

- **Before** — `Done` spans the full 384px panel, edge to edge, sitting directly under the body text.
- **After** — `Done` is 352px with a 16px inset on both sides, pinned to the panel bottom.

## Checklist

- [x] Commit messages follow the [convention](.github/COMMIT_CONVENTION.md)
- [x] Storybook stories are added for new components / features — n/a, no API change
- [x] No type or lint errors (`pnpm lint` → 0 errors, `pnpm check-types`)
- [x] Build completes successfully (`pnpm build`, plus `check-regression-net` 43 names / 13 subpaths / 39 SSR components and `check-dynamic-classes` 126 files)