### PR TITLE
fix: raise the shared overlay layer from z-50 to z-1000

### DIFF
--- a/.changeset/overlay-z-layer.md
+++ b/.changeset/overlay-z-layer.md
@@ -1,0 +1,51 @@
+---
+'@repo/ui': minor
+---
+
+Every floating/overlay primitive moves from `z-50` to `z-1000`, declared once as
+`OVERLAY_LAYER` in `src/lib/z-layers.ts`.
+
+`z-50` is shadcn's default, and it assumes you own the whole app and keep its
+chrome below 50. A published package doesn't get that assumption. Infima
+(Docusaurus) puts its navbar at `--ifm-z-index-fixed: 200` and its own overlay at
+400, so on this repo's own docs site a right-anchored `Drawer` had its top 60px —
+the entire header, meaning the title _and_ the close button — painted under the
+navbar, and the mask couldn't dim that strip. It still hit-tested fine, because
+vaul/Radix mark outside content `pointer-events: none` while a modal is open, so
+the close button was clickable but invisible. `Modal` escaped only by accident:
+it's vertically centred, so it lands below the navbar's 60px.
+
+Measured on the docs Drawer demo (1280×900):
+
+|                                 | Before                   | After                  |
+| ------------------------------- | ------------------------ | ---------------------- |
+| Overlay / content `z-index`     | `50`                     | `1000`                 |
+| Topmost element over the navbar | the navbar's own link    | `[data-slot=drawer-…]` |
+| Drawer header (y 0–78) visible  | no — navbar painted over | yes                    |
+| Navbar strip dimmed by the mask | no (`rgb(255,255,255)`)  | yes                    |
+
+Affected: `Modal`/`Dialog` (mask + content), `Drawer` (mask + content),
+`Popover`, `Select`'s popup, `Dropdown`'s menu, `FloatButton`, and
+`Layout.Header` when `position` is `sticky` or `fixed`.
+
+**They all moved together, to the same value, on purpose.** Nothing in that list
+ranks against anything else in it by z-index; relative order falls out of DOM
+order, which is what puts a `Select` popup above the `Drawer` it was opened from
+(Radix appends each portal to `body` as it opens) and a `Drawer` above
+`Layout.Header`. Giving one of them a different value would silently invert those
+pairs. Verified after the change: `Select` popup `1000`, `Popover` `1000`,
+`Dropdown` menu `1000`, all above the navbar's `200`.
+
+`Modal.confirm` and the imperative `Toast`/`Modal` stack roots are unchanged at
+`10000`, so an imperative confirm opened from inside a declarative `Modal` still
+lands on top — verified at `z=10000`. `Layout.Sider` stays at `z-10`: it only has
+to stay under this layer, and raising it in step would undo the fix that stopped
+it covering a sticky `Header`.
+
+Graded `minor` rather than `patch` because 1000 is a contract, not an
+implementation detail: the library now claims the band every major UI library
+reserves for modals (antd 1000, Bootstrap 1055, MUI 1300). A host that
+deliberately parks its own chrome between 50 and 1000 to sit above these
+components will see that inverted. Retune per call site with `className` /
+`classNames.mask` — both land after `OVERLAY_LAYER` in `cn()`, so
+`tailwind-merge` lets them win.

--- a/packages/ui/src/components/atoms/float-button/float-button.tsx
+++ b/packages/ui/src/components/atoms/float-button/float-button.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@repo/ui/utils';
 
+import { OVERLAY_LAYER } from '../../../lib/z-layers';
 import Button, { Props as ButtonProps } from '../button';
 
 export interface Props extends ButtonProps {}
@@ -9,7 +10,8 @@ const FloatButton = ({ className, children, ...props }: Props) => {
     <Button
       className={cn(
         'fixed right-5 bottom-5 rounded-full',
-        'z-50 h-12 w-12',
+        OVERLAY_LAYER,
+        'h-12 w-12',
         'shadow-md',
         className,
       )}

--- a/packages/ui/src/components/molecules/dropdown.tsx
+++ b/packages/ui/src/components/molecules/dropdown.tsx
@@ -7,6 +7,7 @@ import { AnimatePresence, motion } from 'motion/react';
 
 import { cn } from '@repo/ui/utils';
 
+import { OVERLAY_LAYER } from '../../lib/z-layers';
 import Menu, { MenuProps } from './menu';
 
 type ChangeEventHandler = (open: boolean) => void;
@@ -119,7 +120,8 @@ const Dropdown = ({
         {open && (
           <motion.div
             className={cn(
-              'absolute top-full z-50 pt-2',
+              'absolute top-full pt-2',
+              OVERLAY_LAYER,
               //
             )}
             initial={{ opacity: 0, y: -10 }}

--- a/packages/ui/src/components/templates/layout/header.tsx
+++ b/packages/ui/src/components/templates/layout/header.tsx
@@ -1,5 +1,7 @@
 import { cn } from '@repo/ui/utils';
 
+import { OVERLAY_LAYER } from '../../../lib/z-layers';
+
 export interface Props extends React.ComponentProps<'header'> {
   position?: 'sticky' | 'static' | 'fixed';
 }
@@ -13,8 +15,9 @@ const Header = ({
   return (
     <header
       className={cn(
-        position === 'sticky' && 'sticky top-0 z-50',
-        position === 'fixed' && 'fixed inset-x-0 top-0 z-50',
+        position !== 'static' && OVERLAY_LAYER,
+        position === 'sticky' && 'sticky top-0',
+        position === 'fixed' && 'fixed inset-x-0 top-0',
         'bg-background',
         'flex h-16 w-full items-center px-5',
         className,

--- a/packages/ui/src/components/templates/layout/sider.tsx
+++ b/packages/ui/src/components/templates/layout/sider.tsx
@@ -150,11 +150,13 @@ const Sider = ({
   return (
     <aside
       className={cn(
-        // Below Header's z-50 (and every other floating/overlay primitive
-        // in this library, which all use z-50) — Sider is a static layout
-        // column, not floating chrome, and previously outranked Header
-        // with an arbitrary z-100, covering it once Header stuck to the
-        // viewport top on scroll.
+        // Below Header — and below every other floating/overlay primitive
+        // in this library, which all share OVERLAY_LAYER (lib/z-layers.ts).
+        // Sider is a static layout column, not floating chrome, and
+        // previously outranked Header with an arbitrary z-100, covering it
+        // once Header stuck to the viewport top on scroll. Kept as a small
+        // absolute value rather than tracking OVERLAY_LAYER: it only has to
+        // stay under that layer, and raising it in step would defeat this.
         'z-10 flex h-full shrink-0 flex-col overflow-hidden',
         'transition-[width] duration-200',
         // Lets a Sider visually sit on the right without needing to

--- a/packages/ui/src/core/dialog.tsx
+++ b/packages/ui/src/core/dialog.tsx
@@ -9,6 +9,7 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import Button from '../components/atoms/button';
+import { OVERLAY_LAYER } from '../lib/z-layers';
 
 function Dialog({
   ...props
@@ -44,7 +45,8 @@ function DialogOverlay({
       className={cn(
         `data-[state=open]:animate-in data-[state=closed]:animate-out
         data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0
-        z-50 bg-black/50`,
+        bg-black/50`,
+        OVERLAY_LAYER,
         className,
       )}
       {...props}
@@ -96,10 +98,10 @@ function DialogContent({
           `bg-background data-[state=open]:animate-in
           data-[state=closed]:animate-out data-[state=closed]:fade-out-0
           data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95
-          data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid
-          w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%]
-          gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none
-          sm:max-w-lg`,
+          data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] grid w-full
+          max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4
+          rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg`,
+          OVERLAY_LAYER,
           className,
         )}
         {...props}

--- a/packages/ui/src/core/drawer.tsx
+++ b/packages/ui/src/core/drawer.tsx
@@ -7,6 +7,8 @@ import { Drawer as DrawerPrimitive } from 'vaul';
 import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
+import { OVERLAY_LAYER } from '../lib/z-layers';
+
 interface CustomProps {
   draggable?: boolean;
 }
@@ -56,7 +58,8 @@ function DrawerOverlay({
       className={cn(
         `data-[state=open]:animate-in data-[state=closed]:animate-out
         data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0
-        z-50 bg-black/50`,
+        bg-black/50`,
+        OVERLAY_LAYER,
         className,
       )}
       {...props}
@@ -90,7 +93,8 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+          'group/drawer-content bg-background fixed flex h-auto flex-col',
+          OVERLAY_LAYER,
           `data-[vaul-drawer-direction=top]:inset-x-0
           data-[vaul-drawer-direction=top]:top-0
           data-[vaul-drawer-direction=top]:mb-24

--- a/packages/ui/src/core/popover.tsx
+++ b/packages/ui/src/core/popover.tsx
@@ -7,6 +7,8 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
+import { OVERLAY_LAYER } from '../lib/z-layers';
+
 function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
@@ -43,9 +45,10 @@ function PopoverContent({
           data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2
           data-[side=left]:slide-in-from-right-2
           data-[side=right]:slide-in-from-left-2
-          data-[side=top]:slide-in-from-bottom-2 z-50 w-72
+          data-[side=top]:slide-in-from-bottom-2 w-72
           origin-(--radix-popover-content-transform-origin) rounded-md border
           p-4 shadow-md outline-hidden`,
+          OVERLAY_LAYER,
           className,
         )}
         {...props}

--- a/packages/ui/src/core/select.tsx
+++ b/packages/ui/src/core/select.tsx
@@ -8,6 +8,8 @@ import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
+import { OVERLAY_LAYER } from '../lib/z-layers';
+
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
@@ -87,10 +89,11 @@ function SelectContent({
           data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2
           data-[side=left]:slide-in-from-right-2
           data-[side=right]:slide-in-from-left-2
-          data-[side=top]:slide-in-from-bottom-2 relative z-50
+          data-[side=top]:slide-in-from-bottom-2 relative
           max-h-(--radix-select-content-available-height) min-w-[8rem]
           origin-(--radix-select-content-transform-origin) overflow-x-hidden
           overflow-y-auto rounded-md border shadow-md`,
+          OVERLAY_LAYER,
           position === 'popper' &&
             `data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1
             data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1`,

--- a/packages/ui/src/lib/z-layers.ts
+++ b/packages/ui/src/lib/z-layers.ts
@@ -1,0 +1,28 @@
+/**
+ * The single stacking layer every floating/overlay primitive in this library
+ * shares — dialog and drawer (mask + content), popover, select, dropdown,
+ * float button, and `Layout.Header`.
+ *
+ * **They are all deliberately equal.** Nothing here ranks against anything else
+ * here by z-index; relative order falls out of DOM order, which is what puts a
+ * Select popup above the Drawer it was opened from (Radix appends each portal to
+ * `body` as it opens) and a Drawer above `Layout.Header`. Give one of them a
+ * different value and those pairs silently invert. `Modal.confirm` and the
+ * imperative `Toast`/`Modal` stack roots sit above this on purpose (`z-10000` /
+ * `zIndex = '10000'`), so an imperative confirm opened from inside a declarative
+ * Modal still lands on top.
+ *
+ * **Why 1000 and not shadcn's default of 50.** 50 assumes you own the whole app
+ * and keep its chrome below that. This package is published, so it doesn't get
+ * that assumption: Infima (Docusaurus) puts its navbar at `--ifm-z-index-fixed: 200`
+ * and its own overlay at 400, so on this repo's own docs site a right-anchored
+ * Drawer had its top 60px — the entire header, title and close button — painted
+ * under the navbar. It still hit-tested fine, because vaul/Radix mark outside
+ * content `pointer-events: none` while a modal is open, so the close button was
+ * clickable but invisible. 1000 clears Infima's whole scale and sits in the band
+ * every major library reserves for modals (antd 1000, Bootstrap 1055, MUI 1300).
+ *
+ * Retune per call site with `className` / `classNames.mask` — both land after
+ * this in `cn()`, so `tailwind-merge` lets them win.
+ */
+export const OVERLAY_LAYER = 'z-1000';


### PR DESCRIPTION
## Problem

Open the `Drawer` on this repo's own docs site and its header — the title **and** the close button — is painted under the Docusaurus navbar. The mask can't dim that strip either.

Every floating/overlay primitive in `packages/ui` sits at shadcn's default `z-50`. That value assumes you own the whole app and keep its chrome below 50; a published package doesn't get that assumption. Infima puts the Docusaurus navbar at `--ifm-z-index-fixed: 200` (and its own overlay at 400), so the navbar simply wins. Neither the drawer content nor its overlay has a stacking-context ancestor — both are `position: fixed` with `body` as parent — so there is nothing local to fix it with.

Two details that made this confusing to diagnose, recorded so the next person doesn't re-derive them:

- **It hit-tests as if it were fine.** `document.elementFromPoint` reported the drawer's close button on top while the screenshot clearly showed the navbar over it. vaul/Radix mark outside content `pointer-events: none` while a modal is open, so hit-testing passes straight through the occluding navbar even though painting order is unchanged. The button was clickable but invisible. Use `elementsFromPoint` (plural) to see real paint order.
- **`Modal` escapes only by accident.** It's vertically centred (y≈372 at 900px tall), so it lands below the navbar's 60px. Same `z-50`, same bug, just not visible at the default viewport.

## Change

One declaration, `OVERLAY_LAYER` in `packages/ui/src/lib/z-layers.ts`, applied to every primitive that was at `z-50`:

| File | Site |
| --- | --- |
| `core/dialog.tsx` | mask + content |
| `core/drawer.tsx` | mask + content |
| `core/popover.tsx` | content |
| `core/select.tsx` | popup |
| `components/molecules/dropdown.tsx` | menu |
| `components/atoms/float-button/float-button.tsx` | button |
| `components/templates/layout/header.tsx` | `sticky` / `fixed` only |

**They all moved together, to the same value, deliberately.** Nothing in that list ranks against anything else in it by z-index — relative order falls out of DOM order, which is what puts a `Select` popup above the `Drawer` it was opened from (Radix appends each portal to `body` as it opens) and a `Drawer` above `Layout.Header`. Give one of them a different value and those pairs silently invert. Hence the single constant rather than eight edited strings: it makes the tie intentional and greppable instead of coincidental, and `z-layers.ts` carries the reasoning.

Not touched:

- `Modal.confirm` and the imperative `Toast`/`Modal` stack roots stay at `10000`, so an imperative confirm opened from inside a declarative `Modal` still lands on top.
- `Layout.Sider` stays at `z-10` — it only has to stay *under* this layer, and raising it in step would undo #302's fix that stopped it covering a sticky `Header`. Its comment asserted "every other floating/overlay primitive in this library … all use z-50", which is now wrong, so that's corrected.
- `core/resizable.tsx` and `core/calendar.tsx` keep their `z-10`; those are component-internal, not overlay chrome.

## Why 1000

It clears Infima's whole scale (dropdown 100, fixed 200, overlay 400) and sits in the band every major library reserves for modals — antd 1000, Bootstrap 1055, MUI 1300 — so hosts on other frameworks are covered too, not just Docusaurus.

Bare-numeric Tailwind v4 utilities do generate real CSS here; confirmed `.z-1000 { z-index: 1000 }` in `dist/style.css`, so no `z-[1000]` arbitrary value is needed. (`modal.tsx` already relied on this with `z-10000`.)

## Verification

Production `apps/web` build, served and driven with Playwright at 1280×900.

| | Before | After |
| --- | --- | --- |
| Overlay / content `z-index` | `50` | `1000` |
| Topmost element over the navbar logo | `b > a > div` (navbar's own content) | `div[drawer-overlay] > html` |
| Drawer header (y 0–78) visible | no | yes |
| Navbar strip dimmed by the mask | no — `rgb(255, 255, 255)` | yes |

Pairings the change must preserve, re-measured after:

- `Select` popup `z=1000`, `Popover` `z=1000`, `Dropdown` menu `z=1000` (`position: absolute`, height 135 — renders), all above the navbar's `200`.
- `Modal.confirm` still `z=10000` on both mask and content, i.e. still above the new layer.

Repo checks:

- `pnpm lint` — 0 errors (17417 pre-existing warnings, unchanged)
- `pnpm turbo run build` then `check-types` — 3/3 each. Note these must run sequentially: in parallel, `check-types` reads `dist/**` while `build` is rewriting it and fails with spurious `TS6053 File … .d.mts not found`.
- `pnpm check-regression-net` — public API surface unchanged (43 names, 13 subpaths), preflight reset intact, 39 SSR components render. `z-layers.ts` is internal, like `lib/chassis.ts`.
- `pnpm check-dynamic-classes` — clean (127 files)

One incidental cleanup: the first draft of the `z-layers.ts` doc comment contained the literal token `z-50`, which Tailwind's scanner picked up and emitted as a dead `z-index: 50` rule in `dist/style.css`. Reworded to "shadcn's default of 50"; the compiled sheet now contains only `1000` and `10000`.

## Scope

Graded `minor`, not `patch`, because 1000 is a contract rather than an implementation detail — the library now claims the modal band. A host that deliberately parks its own chrome between 50 and 1000 to sit above these components will see that inverted. Retune per call site with `className` / `classNames.mask`; both land after `OVERLAY_LAYER` in `cn()`, so `tailwind-merge` lets them win.

Independent of #356, #357 and #358; all four branch from the same `main` commit and touch disjoint files.