### PR TITLE
refactor!: remove deprecated type aliases and pre-8.0 preset colour spellings

### DIFF
--- a/.changeset/remove-deprecated-aliases.md
+++ b/.changeset/remove-deprecated-aliases.md
@@ -1,0 +1,34 @@
+---
+'@repo/ui': major
+---
+
+Remove the deprecated `type` aliases and the pre-8.0 preset colour spellings
+
+The aliases added non-breaking by #318 (semantic-state axis) and #342 (Tailwind
+palette names) are removed now that 9.0.0 is the first major since they shipped.
+
+**Breaking — semantic state.** `Modal` and `Toast` no longer accept `type`; use
+`status` (`'info' | 'success' | 'error' | 'warning'`). `Modal.confirm()` is
+unchanged — the two-button confirm is now an internal `mode` axis rather than
+`type='confirm'`, so the imperative call keeps working.
+
+- `<Modal type="info" />` / `Modal.info({ type: 'info' })` → `status="info"`
+- `<Toast type="error" />` → `status="error"`
+
+**Breaking — preset colour spellings** on `Button` and `Tag`:
+
+| removed    | use instead |
+| ---------- | ----------- |
+| `magenta`  | `fuchsia`   |
+| `geekblue` | `indigo`    |
+| `gold`     | `amber`     |
+| `volcano`  | _(none)_    |
+
+`volcano` has no successor — it rendered `orange-600`, the same hue as `orange`
+one lightness step darker, not a distinct hue. Callers who want that exact
+shade set the custom property directly, e.g. `style={{ '--btn-bg':
+'var(--color-orange-600)' }}` (`--tag-bg` on `Tag`).
+
+These spellings were never exported values (`lib/colors.ts` is internal), so the
+change is to prop types and stylesheet rules only — the public API surface
+snapshot is unchanged.

--- a/apps/docs/stories/organisms/toast/index.stories.tsx
+++ b/apps/docs/stories/organisms/toast/index.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Toast> = {
     layout: 'centered',
   },
   argTypes: {
-    type: {
+    status: {
       control: { type: 'select' },
       options: ['info', 'success', 'error', 'warning'],
     },
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    type: 'info',
+    status: 'info',
     title: '알림',
     description: '이것은 토스트 알림입니다.',
     closable: true,

--- a/apps/web/docs/components/atoms/button.mdx
+++ b/apps/web/docs/components/atoms/button.mdx
@@ -105,18 +105,5 @@ Preset `color` names follow Tailwind's own palette names:
 `danger`. Each resolves from the matching `--color-*` Tailwind theme variable,
 so a colour word renders the same hue on `Button` and `Tag`.
 
-:::note[Deprecated spellings]
-
-`magenta`, `geekblue`, `gold` and `volcano` still work and render exactly what
-they always did, but are deprecated and will be removed in the next major.
-They named antd's palette while rendering Tailwind's, so the name and the
-value disagreed — use `fuchsia`, `indigo` and `amber` instead.
-
-`volcano` has no successor: every other preset is a distinct hue at Tailwind's
-`500` step, but `volcano` is `orange-600` — the same hue as `orange`, one step
-darker. If you need that exact shade, set `--btn-bg` directly.
-
-:::
-
 `Button` also accepts the rest of Radix UI's `Slot` props via `asChild`, and
 the native `<button>` attributes.

--- a/apps/web/docs/components/atoms/tag.mdx
+++ b/apps/web/docs/components/atoms/tag.mdx
@@ -40,16 +40,6 @@ own colours — `blue`, `purple`, `cyan`, `green`, `fuchsia`, `pink`, `red`,
 The presets are defined once and shared by both components, so a colour word is
 guaranteed to render the same hue on `Tag` and `Button`.
 
-:::note[Deprecated spellings]
-
-`magenta`, `geekblue`, `gold` and `volcano` still work and render exactly what
-they always did, but are deprecated and will be removed in the next major —
-use `fuchsia`, `indigo` and `amber` instead. `volcano` has no successor; it is
-`orange` one lightness step darker. See the `Button` page for the full
-rationale.
-
-:::
-
 `success` and `warning` have no `Button` counterpart by design: a `Tag` marks
 state, which is why antd's `Tag` also carries status colours its `Button` does
 not.

--- a/packages/ui/src/components/atoms/button.tsx
+++ b/packages/ui/src/components/atoms/button.tsx
@@ -9,7 +9,7 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { button } from '../../core';
-import { type DeprecatedPresetColor, type PresetColor } from '../../lib/colors';
+import { type PresetColor } from '../../lib/colors';
 
 const Core = button.Button;
 
@@ -106,13 +106,9 @@ export interface Props extends Omit<
    * Color, independent of `variant`. Defaults to `'default'`, or to whatever
    * `type` maps to when `type` is set. `danger` overrides this.
    *
-   * Preset hues use Tailwind's colour names (#342). The pre-8.0 spellings
-   * `magenta`/`geekblue`/`gold`/`volcano` still work and render unchanged, but
-   * are deprecated — use `fuchsia`/`indigo`/`amber` instead (`volcano` has no
-   * successor; it is `orange` one lightness step darker).
+   * Preset hues use Tailwind's colour names (#342).
    */
-  color?:
-    PresetColor | DeprecatedPresetColor | 'default' | 'primary' | 'danger';
+  color?: PresetColor | 'default' | 'primary' | 'danger';
   loading?: boolean | { icon: React.ReactNode };
 }
 

--- a/packages/ui/src/components/atoms/tag.tsx
+++ b/packages/ui/src/components/atoms/tag.tsx
@@ -6,7 +6,7 @@ import { useConfig } from '@repo/ui/providers';
 import { cn } from '@repo/ui/utils';
 
 import { badge } from '../../core';
-import { type DeprecatedPresetColor, type PresetColor } from '../../lib/colors';
+import { type PresetColor } from '../../lib/colors';
 
 const Core = badge.Badge;
 
@@ -29,19 +29,10 @@ export interface Props extends Omit<
    * `success`/`warning` have no `Button` counterpart on purpose: a Tag marks
    * state, which is why antd's Tag also carries them while its Button does not.
    *
-   * Preset hues use Tailwind's colour names (#342). The pre-8.0 spellings
-   * `magenta`/`geekblue`/`gold`/`volcano` still work and render unchanged, but
-   * are deprecated — use `fuchsia`/`indigo`/`amber` instead (`volcano` has no
-   * successor; it is `orange` one lightness step darker).
+   * Preset hues use Tailwind's colour names (#342).
    */
   color?:
-    | 'default'
-    | 'primary'
-    | 'success'
-    | 'warning'
-    | 'danger'
-    | PresetColor
-    | DeprecatedPresetColor;
+    'default' | 'primary' | 'success' | 'warning' | 'danger' | PresetColor;
 }
 
 // Geometry, the focus/aria chassis and the svg sizing all come from

--- a/packages/ui/src/components/organisms/modal.tsx
+++ b/packages/ui/src/components/organisms/modal.tsx
@@ -65,12 +65,11 @@ type ModalStatus = 'info' | 'success' | 'error' | 'warning';
 interface StaticProps extends Props {
   status?: ModalStatus;
   /**
-   * @deprecated Use `status` for the semantic state. Kept as an alias so
-   * existing `type="info|success|error|warning"` calls keep working. `confirm`
-   * is an interaction mode, not a status — call `Modal.confirm()` instead
-   * (still accepted here as `type="confirm"` for back-compat).
+   * Interaction mode set by `Modal.confirm()` to request the two-button
+   * footer. `confirm` is a mode, not a status, so it rides its own axis rather
+   * than `status` — call `Modal.confirm()` rather than setting this directly.
    */
-  type?: ModalStatus | 'confirm';
+  mode?: 'confirm';
   id?: string;
   icon?: React.ReactNode;
   container?: HTMLElement;
@@ -185,7 +184,7 @@ const STATIC_ICONS = {
 const StaticModal = ({
   id,
   status,
-  type,
+  mode,
   title,
   content,
   okText,
@@ -201,10 +200,9 @@ const StaticModal = ({
   const resolvedOkText = okText ?? locale.ok ?? DEFAULT_LOCALE.ok;
   const resolvedCancelText =
     cancelText ?? locale.cancel ?? DEFAULT_LOCALE.cancel;
-  // `confirm` is an interaction mode (two-button footer), not a status. The
-  // semantic state comes from `status`, with `type` as its deprecated alias.
-  const isConfirm = type === 'confirm';
-  const resolvedStatus = status ?? (isConfirm ? undefined : type);
+  // `confirm` is an interaction mode (two-button footer), not a status; the
+  // semantic state comes from `status`.
+  const isConfirm = mode === 'confirm';
 
   const closeModal = (callback?: () => void) => {
     callback?.();
@@ -270,9 +268,7 @@ const StaticModal = ({
           )}
         >
           {icon ||
-            (isConfirm
-              ? STATIC_ICONS.confirm
-              : resolvedStatus && STATIC_ICONS[resolvedStatus])}
+            (isConfirm ? STATIC_ICONS.confirm : status && STATIC_ICONS[status])}
           {title}
         </p>
       }
@@ -318,9 +314,9 @@ Modal.error = (props: StaticProps) =>
   modalStack.render({ status: 'error', ...props });
 Modal.warning = (props: StaticProps) =>
   modalStack.render({ status: 'warning', ...props });
-// `confirm` is a mode, not a status, so it rides the `type` axis (the only
-// place it lives) rather than `status`.
+// `confirm` is a mode, not a status, so it rides its own `mode` axis rather
+// than `status`.
 Modal.confirm = (props: StaticProps) =>
-  modalStack.render({ type: 'confirm', ...props });
+  modalStack.render({ mode: 'confirm', ...props });
 
 export default Modal;

--- a/packages/ui/src/components/organisms/toast.tsx
+++ b/packages/ui/src/components/organisms/toast.tsx
@@ -20,12 +20,6 @@ type ToastStatus = 'info' | 'success' | 'error' | 'warning';
 
 export interface Props {
   status?: ToastStatus;
-  /**
-   * @deprecated Use `status`. Kept as an alias so existing
-   * `type="info|success|error|warning"` usage keeps working; `status` matches
-   * the shared semantic-state vocabulary used by `Result`.
-   */
-  type?: ToastStatus;
   title: React.ReactNode;
   description?: React.ReactNode;
   icon?: React.ReactNode;
@@ -50,7 +44,6 @@ const STATUS_ICONS: Record<ToastStatus, React.ReactNode> = {
 
 const Toast = ({
   status,
-  type,
   title,
   description,
   icon,
@@ -60,12 +53,10 @@ const Toast = ({
   onClose,
 }: Props) => {
   const { locale } = useConfig();
-  // `type` is the deprecated alias for `status`; prefer `status` when both set.
-  const resolvedStatus = status ?? type;
 
   return (
     <div
-      role={resolvedStatus === 'error' ? 'alert' : 'status'}
+      role={status === 'error' ? 'alert' : 'status'}
       className={cn(
         'pointer-events-auto flex w-80 items-start gap-3 rounded-lg',
         'bg-background text-foreground border p-4 shadow-lg',
@@ -73,9 +64,9 @@ const Toast = ({
         //
       )}
     >
-      {(icon || resolvedStatus) && (
+      {(icon || status) && (
         <div className="mt-0.5 shrink-0 [&_svg]:size-5">
-          {icon || (resolvedStatus && STATUS_ICONS[resolvedStatus])}
+          {icon || (status && STATUS_ICONS[status])}
         </div>
       )}
       <div className="flex-1 space-y-1">
@@ -174,7 +165,7 @@ Toast.destroyAll = () => {
   toastStack.destroy();
 };
 
-type TriggerOptions = Omit<StaticProps, 'status' | 'type' | 'title'>;
+type TriggerOptions = Omit<StaticProps, 'status' | 'title'>;
 
 Toast.info = (title: React.ReactNode, props?: TriggerOptions) =>
   toastStack.render({ status: 'info', title, ...props });

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -262,23 +262,6 @@
     --preset-color: var(--color-amber-500);
   }
 
-  /* Deprecated pre-8.0 spellings, resolving to the exact same hues they always
-   * rendered (see lib/colors.ts). Removed in the next major. `volcano` is the
-   * one with no canonical successor — it is `orange` one lightness step
-   * darker, not a hue of its own. */
-  :is([data-slot='button'], [data-slot='tag'])[data-color='magenta'] {
-    --preset-color: var(--color-fuchsia-500);
-  }
-  :is([data-slot='button'], [data-slot='tag'])[data-color='geekblue'] {
-    --preset-color: var(--color-indigo-500);
-  }
-  :is([data-slot='button'], [data-slot='tag'])[data-color='gold'] {
-    --preset-color: var(--color-amber-500);
-  }
-  :is([data-slot='button'], [data-slot='tag'])[data-color='volcano'] {
-    --preset-color: var(--color-orange-600);
-  }
-
   [data-slot='button'][data-color] {
     --btn-bg: var(--preset-color);
     --btn-fg: white;
@@ -290,8 +273,7 @@
   /* Hues light enough that white text on them fails contrast. */
   [data-slot='button'][data-color='yellow'],
   [data-slot='button'][data-color='lime'],
-  [data-slot='button'][data-color='amber'],
-  [data-slot='button'][data-color='gold'] {
+  [data-slot='button'][data-color='amber'] {
     --btn-fg: black;
   }
 

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -4,13 +4,11 @@
  * `data-color`), so the same word means the same hue on either component
  * (#320).
  *
- * The names track **Tailwind's own palette names** (#342). They always did
- * track Tailwind's *values* — every preset was a Tailwind hue, just spelled
- * with antd's vocabulary — so four of them said one thing and rendered
- * another: `magenta` rendered Tailwind's `fuchsia`, `geekblue` rendered
- * `indigo`, `gold` rendered `amber`. Aligning the spelling makes the name and
- * the value agree, and lets `globals.css` resolve each entry straight from the
- * matching `--color-*` theme variable instead of a hand-copied hex.
+ * The names track **Tailwind's own palette names** (#342): every preset is a
+ * Tailwind hue spelled the way Tailwind spells it, so the name and the value
+ * agree and `globals.css` can resolve each entry straight from the matching
+ * `--color-*` theme variable instead of a hand-copied hex. The pre-8.0 antd
+ * spellings were removed in 9.0.0.
  *
  * Keep this list in sync with the `[data-color='…']` rules there.
  */
@@ -32,41 +30,7 @@ export const PRESET_COLORS = [
 export type PresetColor = (typeof PRESET_COLORS)[number];
 
 /**
- * Pre-8.0 spellings, still accepted and still rendering exactly what they
- * rendered before — they are aliases, not a behaviour change:
- *
- * | deprecated | renders           | canonical spelling            |
- * | ---------- | ----------------- | ----------------------------- |
- * | `magenta`  | `--color-fuchsia-500` | `fuchsia`                 |
- * | `geekblue` | `--color-indigo-500`  | `indigo`                  |
- * | `gold`     | `--color-amber-500`   | `amber`                   |
- * | `volcano`  | `--color-orange-600`  | *(none — see below)*      |
- *
- * `volcano` is the odd one out and has no canonical successor. Every other
- * preset is a distinct hue at Tailwind's `500` step, but `volcano` is
- * `orange-600` — the same hue as `orange`, one step darker. That makes it a
- * lightness variant masquerading as a hue, so it doesn't belong in a list
- * whose axis is "one entry per hue". It keeps rendering `orange-600` until the
- * next major; callers who want that exact shade can set `--btn-bg`/`--tag-bg`
- * directly.
- *
- * All four are removed in the next major.
+ * Runtime membership test — true when `color` is one of the shared presets.
  */
-export const DEPRECATED_PRESET_COLORS = [
-  'magenta',
-  'geekblue',
-  'gold',
-  'volcano',
-] as const;
-
-export type DeprecatedPresetColor = (typeof DEPRECATED_PRESET_COLORS)[number];
-
-/**
- * Runtime membership test — true when `color` is one of the shared presets,
- * including the deprecated spellings (they still resolve to a preset hue).
- */
-export const isPresetColor = (
-  color: string,
-): color is PresetColor | DeprecatedPresetColor =>
-  (PRESET_COLORS as readonly string[]).includes(color) ||
-  (DEPRECATED_PRESET_COLORS as readonly string[]).includes(color);
+export const isPresetColor = (color: string): color is PresetColor =>
+  (PRESET_COLORS as readonly string[]).includes(color);


### PR DESCRIPTION
Closes #351.

## Summary

Remove the deprecated aliases that #318 (semantic-state axis) and #342 (Tailwind palette names) shipped non-breaking, now that 9.0.0 is the first major since they landed. This is the checklist #351 tracked for "when 9.0.0 is cut".

### Semantic state — `type` → `status`
- `Modal` and `Toast` no longer accept `type`; use `status` (`'info' | 'success' | 'error' | 'warning'`).
- `Modal.confirm()` is unchanged. The confirm two-button footer moved off `type='confirm'` onto an internal `mode?: 'confirm'` axis on `StaticProps`, so the imperative helper keeps working — this avoids the trap #351 flagged (deleting `type` outright would have broken `Modal.confirm()`).
- `Toast`'s `TriggerOptions` `Omit` drops the now-dead `'type'`.

### Preset colour spellings on `Button` / `Tag`

| removed | use instead |
| --- | --- |
| `magenta` | `fuchsia` |
| `geekblue` | `indigo` |
| `gold` | `amber` |
| `volcano` | *(none)* |

`volcano` has no successor — it rendered `orange-600` (same hue as `orange`, one step darker). Callers wanting that shade set `--btn-bg` / `--tag-bg` directly. Removed `DEPRECATED_PRESET_COLORS` / `DeprecatedPresetColor` from `lib/colors.ts`, simplified `isPresetColor`, dropped the four alias rules in `globals.css` plus the `gold` contrast-exception line (`amber` already covers it), and removed the "Deprecated spellings" admonitions from the button/tag docs.

## Breaking change

A `major` changeset is included. These spellings were never exported values (`lib/colors.ts` is internal), so only prop types and stylesheet rules change — the public API surface snapshot is unchanged.

## Test plan
- [x] `tsc -b`, `lint` clean
- [x] `build` clean
- [x] `check-api-surface` green, **no snapshot update** (43 names, 13 subpaths)
- [x] `check-preflight-reset`, `check-ssr-smoke` (39 components, Button/Tag chassis intact), `check-dynamic-classes` green
- [x] `git grep "@deprecated" / "magenta|geekblue|volcano|data-color='gold'"` over `packages/ui/src` returns nothing
