### PR TITLE
docs: document the local patches on dialog/drawer/popover/select core primitives

### DIFF
--- a/.changeset/document-core-shadcn-patches.md
+++ b/.changeset/document-core-shadcn-patches.md
@@ -1,0 +1,7 @@
+---
+---
+
+Docs-only: adds maintenance comments enumerating the local patches on
+`core/dialog|drawer|popover|select` so a `shadcn add` overwrite can be
+re-applied (#363). No behaviour, API, or declaration change — intentionally no
+release.

--- a/packages/ui/src/core/dialog.tsx
+++ b/packages/ui/src/core/dialog.tsx
@@ -11,6 +11,32 @@ import { cn } from '@repo/ui/utils';
 import Button from '../components/atoms/button';
 import { OVERLAY_LAYER } from '../lib/z-layers';
 
+/*
+ * Vendored from shadcn's `new-york-v4` dialog registry entry.
+ *
+ * Local patches — re-apply these after any `shadcn add dialog`:
+ * 1. Imports: `DialogPrimitive` from `@radix-ui/react-dialog` (upstream uses
+ *    the unified `radix-ui` package, which this repo doesn't install), `cn`
+ *    from `@repo/ui/utils`, and `Button` from `../components/atoms/button`
+ *    (used by `DialogFooter`'s close button).
+ * 2. `OVERLAY_LAYER` (src/lib/z-layers.ts) replaces upstream's `z-50` on
+ *    `DialogOverlay` and `DialogContent`. Why: this package is published and
+ *    can't assume it owns the app's z-index scale — see #359.
+ * 3. `DialogContent` takes a `container` prop, defaulted to
+ *    `useConfig().getContainer()`, and passes it to `DialogPortal`. Why:
+ *    portalled content must stay inside the themed wrapper, or dark mode and
+ *    the CSS custom properties don't reach it.
+ * 4. `DialogContent` replaces upstream's `showCloseButton?: boolean` with
+ *    `CustomContentProps` (`classNames`, `closeIcon`, `closable`, `container`):
+ *    the close button is gated by `closable` (and `closable.disabled`) and
+ *    renders a caller-supplied `closeIcon`, and `classNames.mask` is forwarded
+ *    to the overlay.
+ * 5. `DialogFooter`'s close button uses this library's Button vocabulary
+ *    (`variant="outlined"`; upstream says `"outline"`).
+ *
+ * The rest of what `shadcn add dialog --diff` reports is Tailwind class
+ * ordering and prettier line-wrapping from this repo's formatter, not a patch.
+ */
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {

--- a/packages/ui/src/core/drawer.tsx
+++ b/packages/ui/src/core/drawer.tsx
@@ -9,6 +9,27 @@ import { cn } from '@repo/ui/utils';
 
 import { OVERLAY_LAYER } from '../lib/z-layers';
 
+/*
+ * Vendored from shadcn's `new-york-v4` drawer registry entry (built on `vaul`,
+ * same as upstream).
+ *
+ * Local patches — re-apply these after any `shadcn add drawer`:
+ * 1. Imports: `cn` from `@repo/ui/utils` (upstream uses its `cn` alias). The
+ *    `vaul` import is upstream-verbatim.
+ * 2. `OVERLAY_LAYER` (src/lib/z-layers.ts) replaces upstream's `z-50` on
+ *    `DrawerOverlay` and `DrawerContent`. Why: this package is published and
+ *    can't assume it owns the app's z-index scale — see #359.
+ * 3. `Drawer` root takes a `draggable` prop (`CustomProps`) → `handleOnly={!
+ *    draggable}`, plus `container` defaulted to `useConfig().getContainer()`.
+ *    Why: the container keeps portalled content inside the themed wrapper, or
+ *    dark mode and the CSS custom properties don't reach it.
+ * 4. `DrawerContent` takes `CustomContentProps` (`classNames`, `handlebar`,
+ *    `mask`): `classNames.mask` + `!mask && 'hidden'` on the overlay, and the
+ *    drag handlebar is gated by `handlebar` with `classNames.handlebar`.
+ *
+ * The rest of what `shadcn add drawer --diff` reports is Tailwind class
+ * ordering and prettier line-wrapping from this repo's formatter, not a patch.
+ */
 interface CustomProps {
   draggable?: boolean;
 }

--- a/packages/ui/src/core/popover.tsx
+++ b/packages/ui/src/core/popover.tsx
@@ -9,6 +9,25 @@ import { cn } from '@repo/ui/utils';
 
 import { OVERLAY_LAYER } from '../lib/z-layers';
 
+/*
+ * Vendored from shadcn's `new-york-v4` popover registry entry.
+ *
+ * Local patches — re-apply these after any `shadcn add popover`:
+ * 1. Imports: `PopoverPrimitive` from `@radix-ui/react-popover` (upstream uses
+ *    the unified `radix-ui` package, which this repo doesn't install), `cn`
+ *    from `@repo/ui/utils`.
+ * 2. `OVERLAY_LAYER` (src/lib/z-layers.ts) replaces upstream's `z-50` on
+ *    `PopoverContent`. Why: this package is published and can't assume it owns
+ *    the app's z-index scale — see #359.
+ * 3. `PopoverContent` takes a `container` prop, defaulted to
+ *    `useConfig().getContainer()`, and passes it to `PopoverPrimitive.Portal`
+ *    (upstream renders the portal with no `container`). Why: portalled content
+ *    must stay inside the themed wrapper, or dark mode and the CSS custom
+ *    properties don't reach it.
+ *
+ * The rest of what `shadcn add popover --diff` reports is Tailwind class
+ * ordering and prettier line-wrapping from this repo's formatter, not a patch.
+ */
 function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {

--- a/packages/ui/src/core/select.tsx
+++ b/packages/ui/src/core/select.tsx
@@ -10,6 +10,25 @@ import { cn } from '@repo/ui/utils';
 
 import { OVERLAY_LAYER } from '../lib/z-layers';
 
+/*
+ * Vendored from shadcn's `new-york-v4` select registry entry.
+ *
+ * Local patches — re-apply these after any `shadcn add select`:
+ * 1. Imports: `SelectPrimitive` from `@radix-ui/react-select` (upstream uses
+ *    the unified `radix-ui` package, which this repo doesn't install), `cn`
+ *    from `@repo/ui/utils`.
+ * 2. `OVERLAY_LAYER` (src/lib/z-layers.ts) replaces upstream's `z-50` on
+ *    `SelectContent`. Why: this package is published and can't assume it owns
+ *    the app's z-index scale — see #359.
+ * 3. `SelectContent` takes a `container` prop, defaulted to
+ *    `useConfig().getContainer()`, and passes it to `SelectPrimitive.Portal`
+ *    (upstream renders the portal with no `container`). Why: portalled content
+ *    must stay inside the themed wrapper, or dark mode and the CSS custom
+ *    properties don't reach it.
+ *
+ * The rest of what `shadcn add select --diff` reports is Tailwind class
+ * ordering and prettier line-wrapping from this repo's formatter, not a patch.
+ */
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {


### PR DESCRIPTION
Closes #363.

## Summary

Four `core/*` primitives carry structural divergences from their shadcn registry entries that can't be moved out to consumers (portal mounting and z-index layering happen inside the primitive that renders the portal). A `shadcn add <name>` overwrites the file wholesale and silently drops that wiring. This adds a maintenance comment to each listing the local patches so an overwrite can be re-applied from the file itself.

Each list was verified against `pnpm dlx shadcn@latest add <name> --diff -c packages/ui` (new-york-v4):

- **dialog** — `@radix-ui/react-dialog` + `cn` + local `Button` imports; `OVERLAY_LAYER` on overlay/content; `container`/`getContainer()` on `DialogPortal`; `CustomContentProps` (`classNames`/`closeIcon`/`closable`/`container`) replacing upstream's `showCloseButton`; footer `Button variant="outlined"`.
- **drawer** — `cn` import; `OVERLAY_LAYER`; `draggable`→`handleOnly` + `container` on the root; `CustomContentProps` (`classNames`/`handlebar`/`mask`).
- **popover** / **select** — `@radix-ui/*` + `cn` imports; `OVERLAY_LAYER` on content; `container`/`getContainer()` on the Portal.

Each comment also notes that the remaining diff (`shadcn add --diff`) is Tailwind class ordering + prettier wrapping from this repo's formatter, not a patch.

## Notes
- Comments use non-JSDoc `/* */` so they do **not** leak into the published `.d.ts` (verified: the declaration files are unchanged).
- Docs-only, no behaviour/API/declaration change — an **empty changeset** records that no release is needed.

## Test plan
- [x] `lint`, `check-types`, `build` clean
- [x] patch-list text confirmed absent from `dist/**/*.d.mts`
