### PR TITLE
chore: bump lucide-react to ^1.45.0

### DIFF
--- a/.changeset/bump-lucide-react.md
+++ b/.changeset/bump-lucide-react.md
@@ -1,0 +1,9 @@
+---
+'@repo/ui': patch
+---
+
+Bump lucide-react to ^1.45.0
+
+The only shadcn-related dependency behind latest — the `@radix-ui/react-*`
+family, `class-variance-authority`, `clsx`, `tailwind-merge` and `vaul` were
+already current. Icons-only update, no API change.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,7 +21,7 @@
     "@uiw/react-codemirror": "^4.25.11",
     "codemirror": "^6.0.0",
     "gsap": "^3.15.0",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.45.0",
     "next": "^16.3.1",
     "postcss": "^8.5.26",
     "react": "^19.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
     "clsx": "^2.0.0",
     "codemirror": "^6.0.0",
     "date-fns": "^4.4.0",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.45.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -111,7 +111,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
     "gsap": "^3.15.0",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.45.0",
     "motion": "^13.1.0",
     "react-colorful": "^5.8.0",
     "react-day-picker": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^3.15.0
         version: 3.15.0
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.45.0
+        version: 1.45.0(react@19.2.8)
       next:
         specifier: ^16.3.1
         version: 16.3.1(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -160,8 +160,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.45.0
+        version: 1.45.0(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -316,8 +316,8 @@ importers:
         specifier: ^3.15.0
         version: 3.15.0
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.45.0
+        version: 1.45.0(react@19.2.8)
       motion:
         specifier: ^13.1.0
         version: 13.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -6908,8 +6908,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.31.0:
-    resolution: {integrity: sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==}
+  lucide-react@1.45.0:
+    resolution: {integrity: sha512-yH1ubCAduho9UR7oJhRXIQXogksRILBiTuZC4/bQIGeB9JOkxMlSuEHyyZpo1Z3S0yWJO2KTSUZbjiNvVxeOUw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -17530,7 +17530,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.31.0(react@19.2.8):
+  lucide-react@1.45.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 


### PR DESCRIPTION
## Summary

Updates the shadcn-related dependencies to latest. In practice only `lucide-react` was behind — the `@radix-ui/react-*` family, `class-variance-authority`, `clsx`, `tailwind-merge` and `vaul` were already at their latest published versions.

- `lucide-react` `^1.31.0` → `^1.45.0` in `packages/ui` and both apps (`docs`, `web`), so the monorepo resolves a single version.
- Icons-only update; no API change. `patch` changeset for `@repo/ui`.

`tailwindcss` / `@tailwindcss/postcss` are out of scope here — they're the styling framework, not shadcn component packages.

## Test plan
- [x] monorepo `check-types` (ui + docs + web)
- [x] `@repo/ui` `lint`, `build`
- [x] `check-regression-net` (api-surface, preflight-reset, ssr-smoke) green
