### PR TITLE
feat: add a core/* drift check against the shadcn registry

### DIFF
--- a/.changeset/core-drift-check.md
+++ b/.changeset/core-drift-check.md
@@ -1,0 +1,7 @@
+---
+---
+
+Tooling-only: adds `check-core-drift` (#362), a script that reports when a
+vendored `core/*` primitive falls behind its shadcn `new-york-v4` registry
+entry, plus a weekly advisory workflow and a baseline snapshot. Lives under
+`scripts/` / `.github/` — not shipped in `dist`, so no release is needed.

--- a/.github/workflows/core-drift.yml
+++ b/.github/workflows/core-drift.yml
@@ -1,0 +1,67 @@
+name: Core drift
+
+# Advisory-only: reports when a vendored `packages/ui/src/core/*` primitive has
+# fallen behind its shadcn `new-york-v4` registry entry (ui-kit#362). It is
+# network-bound and upstream can change under an unrelated PR, so it is kept
+# OUT of the required `ci.yml` path and runs on a weekly schedule (plus manual
+# dispatch). On drift it opens or refreshes a single tracking issue.
+
+on:
+  schedule:
+    # Mondays 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  core-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+
+      # The script only uses Node builtins + fetch and reads the checked-out
+      # source, so no install/build is needed.
+      - name: Run core drift check
+        id: drift
+        run: |
+          set +e
+          node packages/ui/scripts/check-core-drift.mjs --enforce \
+            | sed 's/\x1b\[[0-9;]*m//g' | tee drift-report.txt
+          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the drift tracking issue
+        if: steps.drift.outputs.exit != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MARKER='<!-- core-drift-report -->'
+          TITLE='core/* drift vs shadcn new-york-v4'
+          {
+            echo "$MARKER"
+            echo "Automated report from \`.github/workflows/core-drift.yml\` (#362)."
+            echo "A \`core/*\` primitive is behind its upstream registry entry, or the check errored."
+            echo
+            echo '```'
+            cat drift-report.txt
+            echo '```'
+            echo
+            echo "_Last run: $(date -u '+%Y-%m-%d %H:%M UTC') · ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}_"
+          } > issue-body.md
+
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq ".[] | select(.title == \"$TITLE\") | .number" | head -n1)
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body-file issue-body.md
+            gh issue comment "$EXISTING" --body "Drift check re-ran and still reports divergence — body updated ($(date -u '+%Y-%m-%d %H:%M UTC'))."
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md
+          fi

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,6 +58,7 @@
     "lint": "eslint . --max-warnings 0",
     "check-dynamic-classes": "node scripts/check-dynamic-tailwind-classes.mjs",
     "check-api-surface": "node scripts/check-api-surface.mjs",
+    "check-core-drift": "node scripts/check-core-drift.mjs",
     "check-preflight-reset": "node scripts/check-preflight-reset.mjs",
     "check-ssr-smoke": "node --import ./scripts/loaders/css-stub.mjs scripts/check-ssr-smoke.mjs",
     "check-regression-net": "pnpm run check-api-surface && pnpm run check-preflight-reset && pnpm run check-ssr-smoke",

--- a/packages/ui/scripts/check-core-drift.mjs
+++ b/packages/ui/scripts/check-core-drift.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// Drift check for the vendored shadcn primitives in `src/core/*` (ui-kit#362).
+//
+// `core/*` is deliberately a verbatim-ish copy of shadcn's `new-york-v4`
+// registry entries — the core membership rule in CLAUDE.md (criterion c) keeps
+// a primitive there precisely so upstream syncs stay diffable. That only pays
+// off if drift is detectable; `core/badge.tsx` once sat three upstream changes
+// behind and nothing noticed (#347).
+//
+// For each core file this fetches the upstream registry entry, normalises BOTH
+// sides so this repo's standing conventions don't register as drift (the `cn`
+// import path, the individual `@radix-ui/*` packages vs the unified `radix-ui`
+// one, `Slot.Root` vs `Slot`, import aliasing, quotes, semicolons, commas,
+// comments), then compares the two as token *sets* — so Tailwind class
+// reordering and prettier line-wrapping, which differ by construction, don't
+// count. It reports, per component:
+//
+//   · in sync          — identical after normalisation
+//   · local additions  — we carry tokens upstream doesn't (intentional patches)
+//   · upstream ahead    — upstream carries tokens we lack (the signal to look)
+//
+// Network-bound and upstream-mutable, so it must NOT sit in the required
+// `lint-and-build` path — see `.github/workflows/core-drift.yml`. Run advisory
+// by default (exit 0); pass `--enforce` to exit non-zero when any component is
+// behind upstream.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CORE_DIR = path.join(__dirname, '..', 'src', 'core');
+const SNAPSHOT_PATH = path.join(__dirname, 'core-drift.snapshot.json');
+const REGISTRY = name =>
+  `https://ui.shadcn.com/r/styles/new-york-v4/${name}.json`;
+
+// `--enforce` exits non-zero on a *regression* from the snapshot (a component
+// getting further from upstream), not on the standing, intentional divergence
+// the structural primitives carry by design (#363). `--update` re-baselines.
+const enforce = process.argv.includes('--enforce');
+const update = process.argv.includes('--update');
+
+// Strip `/* */` and `//` comments without touching string contents. Good
+// enough for these files — none embed comment markers inside a string literal.
+const stripComments = src =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1 ');
+
+const normalise = src => {
+  let s = stripComments(src);
+
+  // Import sources: collapse this repo's spellings onto upstream's.
+  // - the `cn` util (upstream registry emits `from "cn"`; we use @repo/ui/utils)
+  // - the Radix packaging: individual `@radix-ui/*` here, unified `radix-ui`
+  //   upstream
+  // - cross-primitive + lib registry paths vs our relative imports
+  s = s
+    .replace(/@repo\/ui\/utils/g, 'cn')
+    .replace(/@radix-ui\/react-[a-z-]+/g, 'radix-ui')
+    .replace(/@\/registry\/new-york-v4\/ui\//g, '')
+    .replace(/@\/registry\/new-york-v4\/lib\//g, '')
+    .replace(/@\/lib\//g, '')
+    .replace(/\.\.\/components\/atoms\//g, '')
+    .replace(/\.\.\/lib\//g, '')
+    .replace(/\.\//g, '');
+
+  // Import aliasing: `* as X` and `{ Foo as X }` both bind `X`; collapse to the
+  // local name so a namespace import reads the same as a named+aliased one.
+  s = s.replace(/\*\s+as\s+(\w+)/g, '$1').replace(/\b\w+\s+as\s+(\w+)/g, '$1');
+
+  // `Slot.Root` (unified radix-ui namespace) vs `Slot` (individual package).
+  s = s.replace(/\bSlot\.Root\b/g, 'Slot');
+
+  // Quote style, template backticks, statement punctuation — all noise here.
+  s = s.replace(/["'`]/g, '').replace(/[;,]/g, ' ');
+
+  // Detach structural punctuation so a class name never stays glued to the
+  // `className={cn(` / `>` around it — otherwise a reordered class list (which
+  // is semantically identical) reads as drift at its first/last member. Only
+  // `{}()<>=` are split; the characters Tailwind tokens are built from (`-`,
+  // `:`, `[`, `]`, `/`, `&`, `.`) are left alone. Splitting is applied to both
+  // sides, so any real token difference still survives.
+  s = s.replace(/([{}()<>=])/g, ' $1 ');
+
+  return s;
+};
+
+// Token *set* (not sequence): class reordering and wrapping drop out, so only
+// genuinely present/absent tokens remain.
+const tokenSet = src =>
+  new Set(
+    normalise(src)
+      .split(/\s+/)
+      .map(t => t.trim())
+      .filter(Boolean),
+  );
+
+const diff = (a, b) => [...a].filter(t => !b.has(t));
+
+const components = fs
+  .readdirSync(CORE_DIR)
+  .filter(f => f.endsWith('.tsx'))
+  .map(f => f.replace(/\.tsx$/, ''))
+  .sort();
+
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+const results = [];
+
+for (const name of components) {
+  const local = fs.readFileSync(path.join(CORE_DIR, `${name}.tsx`), 'utf8');
+
+  let upstream;
+  try {
+    const res = await fetch(REGISTRY(name));
+    if (!res.ok) {
+      results.push({ name, status: 'no-upstream', detail: `HTTP ${res.status}` });
+      continue;
+    }
+    const json = await res.json();
+    upstream = (json.files ?? []).map(f => f.content).join('\n');
+    if (!upstream) {
+      results.push({ name, status: 'no-upstream', detail: 'empty registry entry' });
+      continue;
+    }
+  } catch (e) {
+    results.push({ name, status: 'error', detail: e.message });
+    continue;
+  }
+
+  const localTokens = tokenSet(local);
+  const upstreamTokens = tokenSet(upstream);
+  const added = diff(localTokens, upstreamTokens); // we have, upstream doesn't
+  const behind = diff(upstreamTokens, localTokens); // upstream has, we don't
+
+  let status;
+  if (added.length === 0 && behind.length === 0) {
+    status = 'in-sync';
+  } else if (behind.length === 0) {
+    status = 'local-additions';
+  } else {
+    status = 'upstream-ahead';
+  }
+
+  results.push({ name, status, added, behind });
+}
+
+const label = {
+  'in-sync': `${GREEN}in sync${RESET}`,
+  'local-additions': `${YELLOW}local additions${RESET}`,
+  'upstream-ahead': `${RED}upstream ahead${RESET}`,
+  'no-upstream': `${DIM}no upstream entry${RESET}`,
+  error: `${RED}error${RESET}`,
+};
+
+console.log(`\nCore drift vs shadcn new-york-v4 (${components.length} components)\n`);
+
+for (const r of results) {
+  console.log(`  ${r.name.padEnd(16)} ${label[r.status]}`);
+  if (r.detail) {
+    console.log(`    ${DIM}${r.detail}${RESET}`);
+  }
+  if (r.added?.length) {
+    console.log(`    ${DIM}+ local: ${r.added.join(' ')}${RESET}`);
+  }
+  if (r.behind?.length) {
+    console.log(`    ${RED}- upstream has: ${r.behind.join(' ')}${RESET}`);
+  }
+}
+
+console.log(
+  `\n${results.filter(r => r.status === 'in-sync').length} in sync · ` +
+    `${results.filter(r => r.status === 'local-additions').length} local additions · ` +
+    `${results.filter(r => r.status === 'upstream-ahead').length} upstream ahead · ` +
+    `${results.filter(r => r.status === 'no-upstream').length} no entry` +
+    (results.some(r => r.status === 'error')
+      ? ` · ${results.filter(r => r.status === 'error').length} errored`
+      : '') +
+    '\n',
+);
+
+// Baseline snapshot of each component's status + the exact tokens it lags
+// behind upstream on — so the standing intentional divergence (OVERLAY_LAYER,
+// and the documented structural patches) is recorded once and only a *new*
+// regression trips `--enforce`. Same `--update` idiom as api-surface.
+const RANK = { 'in-sync': 0, 'local-additions': 1, 'upstream-ahead': 2 };
+const snapshot = Object.fromEntries(
+  results
+    .filter(r => r.status in RANK)
+    .map(r => [r.name, { status: r.status, behind: [...(r.behind ?? [])].sort() }]),
+);
+
+if (update) {
+  fs.writeFileSync(SNAPSHOT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`);
+  console.log(`✓ Wrote baseline snapshot (${Object.keys(snapshot).length} components).\n`);
+  process.exit(0);
+}
+
+if (!fs.existsSync(SNAPSHOT_PATH)) {
+  console.error(
+    `✘ No baseline at ${path.relative(process.cwd(), SNAPSHOT_PATH)} — run with --update first.`,
+  );
+  process.exit(1);
+}
+const baseline = JSON.parse(fs.readFileSync(SNAPSHOT_PATH, 'utf8'));
+
+const regressions = [];
+for (const [name, cur] of Object.entries(snapshot)) {
+  const base = baseline[name];
+  if (!base) {
+    regressions.push(`${name}: new component, not in baseline`);
+    continue;
+  }
+  if (RANK[cur.status] > RANK[base.status]) {
+    regressions.push(`${name}: ${base.status} → ${cur.status}`);
+    continue;
+  }
+  const newlyBehind = cur.behind.filter(t => !base.behind.includes(t));
+  if (newlyBehind.length) {
+    regressions.push(`${name}: new upstream-only tokens — ${newlyBehind.join(' ')}`);
+  }
+}
+
+const errored = results.filter(r => r.status === 'error');
+
+if (regressions.length || errored.length) {
+  if (regressions.length) {
+    console.log(`${RED}Regressions vs baseline:${RESET}`);
+    regressions.forEach(r => console.log(`  ${RED}• ${r}${RESET}`));
+  }
+  errored.forEach(r => console.log(`  ${RED}• ${r.name}: ${r.detail}${RESET}`));
+  console.log(
+    `\n${DIM}If the new divergence is intentional, re-baseline with \`pnpm check-core-drift --update\`.${RESET}\n`,
+  );
+  if (enforce) {
+    process.exit(1);
+  }
+} else {
+  console.log(`${GREEN}✓ No regression vs baseline.${RESET}\n`);
+}

--- a/packages/ui/scripts/core-drift.snapshot.json
+++ b/packages/ui/scripts/core-drift.snapshot.json
@@ -1,0 +1,114 @@
+{
+  "accordion": {
+    "status": "local-additions",
+    "behind": []
+  },
+  "badge": {
+    "status": "local-additions",
+    "behind": []
+  },
+  "button": {
+    "status": "local-additions",
+    "behind": []
+  },
+  "calendar": {
+    "status": "upstream-ahead",
+    "behind": [
+      "2",
+      "8",
+      "[&:nth-child",
+      "[--cell-size:--spacing",
+      "[data-selected",
+      "]",
+      "dark:hover:text-accent-foreground",
+      "props.showWeekNumber",
+      "size-auto",
+      "true]:rounded-l-md",
+      "true]:rounded-r-md",
+      "type"
+    ]
+  },
+  "checkbox": {
+    "status": "upstream-ahead",
+    "behind": [
+      "rounded-[4px]"
+    ]
+  },
+  "dialog": {
+    "status": "upstream-ahead",
+    "behind": [
+      "outline",
+      "true",
+      "z-50"
+    ]
+  },
+  "drawer": {
+    "status": "upstream-ahead",
+    "behind": [
+      "w-[100px]",
+      "z-50"
+    ]
+  },
+  "field": {
+    "status": "local-additions",
+    "behind": []
+  },
+  "input": {
+    "status": "in-sync",
+    "behind": []
+  },
+  "label": {
+    "status": "in-sync",
+    "behind": []
+  },
+  "popover": {
+    "status": "upstream-ahead",
+    "behind": [
+      "z-50"
+    ]
+  },
+  "progress": {
+    "status": "local-additions",
+    "behind": []
+  },
+  "radio-group": {
+    "status": "local-additions",
+    "behind": []
+  },
+  "resizable": {
+    "status": "in-sync",
+    "behind": []
+  },
+  "select": {
+    "status": "upstream-ahead",
+    "behind": [
+      "z-50"
+    ]
+  },
+  "separator": {
+    "status": "in-sync",
+    "behind": []
+  },
+  "skeleton": {
+    "status": "in-sync",
+    "behind": []
+  },
+  "slider": {
+    "status": "upstream-ahead",
+    "behind": [
+      "?",
+      "_values",
+      "_values.length",
+      "bg-muted",
+      "bg-white"
+    ]
+  },
+  "switch": {
+    "status": "local-additions",
+    "behind": []
+  },
+  "textarea": {
+    "status": "in-sync",
+    "behind": []
+  }
+}


### PR DESCRIPTION
Closes #362.

## Summary

Adds a drift check for the vendored shadcn primitives in `src/core/*`. `core/*` is deliberately a near-verbatim copy of the `new-york-v4` registry (CLAUDE.md core membership rule, criterion c), and that only pays off if drift is detectable — `core/badge.tsx` once sat three upstream releases behind unnoticed (#347).

`scripts/check-core-drift.mjs` fetches each primitive's registry entry, normalises **both** sides so this repo's standing conventions don't register as drift (the `cn` import path, the individual `@radix-ui/*` packages vs the unified `radix-ui` one, `Slot.Root` → `Slot`, import aliasing, quotes, semicolons, commas, comments), then compares the two as token **sets** — so Tailwind class reordering and prettier line-wrapping, which differ by construction, don't count. Per component it reports **in sync** / **local additions** / **upstream ahead** and prints the differing tokens both ways.

### Baseline & enforcement
A baseline snapshot (`scripts/core-drift.snapshot.json`) records the current state, so `--enforce` trips only on a **regression** from it — not on the standing intentional divergence the structural primitives carry (`OVERLAY_LAYER`, the `container`/`getContainer()` portal wiring, etc., documented in #363). `--update` re-baselines (same idiom as `api-surface`).

### CI
Kept **out** of the required `lint-and-build` path — it's network-bound and upstream can change under an unrelated PR. `.github/workflows/core-drift.yml` runs it weekly (+ manual dispatch) and opens/updates a single tracking issue on regression.

## Verification (matches the issue's expected baseline)
- 6 in sync: `input` `label` `resizable` `separator` `skeleton` `textarea`
- `badge` / `button`: only the `type Props` re-export (local additions)
- upstream-ahead signals surfaced include `calendar` (`showWeekNumber`, `size-auto`, `dark:hover:text-accent-foreground`) and `slider` (`bg-muted` / `bg-white`) — exactly the gaps the issue lists
- `--update` → bare `--enforce` reports no regression (exit 0)
- editing a class in `core/input.tsx` flips it to `in-sync → upstream-ahead` and exits 1; reverting restores clean

## Test plan
- [x] `node scripts/check-core-drift.mjs` (report) and `--enforce` (exit 0 at baseline)
- [x] `lint`
- [x] tooling-only; not shipped in `dist` — empty changeset
