### PR TITLE
refactor: make core/checkbox and core/radio-group upstream-verbatim

### DIFF
--- a/.changeset/core-verbatim-checkbox-radio.md
+++ b/.changeset/core-verbatim-checkbox-radio.md
@@ -1,0 +1,18 @@
+---
+'@repo/ui': patch
+---
+
+Make `core/checkbox` and `core/radio-group` upstream-verbatim (#361)
+
+Moves the presentational local patches out of two vendored primitives so they
+match their shadcn `new-york-v4` registry entries and can be re-synced with
+`shadcn add --overwrite`. Public API and rendered output are unchanged.
+
+- `core/checkbox`: restore upstream's `rounded-[4px]`; the atom
+  (`atoms/checkbox`) now contributes `rounded-sm` through its own `cn()` stack
+  (same radius — Tailwind `rounded-sm` == 4px — and tailwind-merge lets it win).
+- `core/radio-group`: drop the `asChild` branch; the button-style radio in
+  `atoms/radio/group` renders `RadioGroupPrimitive.Item` directly (same
+  `data-slot`), so the primitive is the plain dot item again.
+
+The drift check (#362) now reports both as `in sync`.

--- a/packages/ui/src/components/atoms/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/atoms/checkbox/checkbox.tsx
@@ -118,7 +118,10 @@ const Checkbox = ({
         value={itemValue}
         checked={checked}
         disabled={disabled}
-        className={cn(cursorClassName)}
+        // `rounded-sm` used to live on the vendored primitive; it moved here so
+        // `core/checkbox` stays upstream-verbatim (`rounded-[4px]`). Same radius
+        // (Tailwind `rounded-sm` == 4px), and tailwind-merge lets it win (#361).
+        className={cn('rounded-sm', cursorClassName)}
         onCheckedChange={onChange}
       />
       {children && (

--- a/packages/ui/src/components/atoms/radio/group.tsx
+++ b/packages/ui/src/components/atoms/radio/group.tsx
@@ -3,6 +3,7 @@
 import { useId } from 'react';
 
 import { useControllableState } from '@jbpark/use-hooks';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 
 import { cn } from '@repo/ui/utils';
 
@@ -19,7 +20,7 @@ import {
 import { RadioGroupContext } from './context';
 import Radio from './radio';
 
-const { RadioGroup: Core, RadioGroupItem: Item } = radio;
+const { RadioGroup: Core } = radio;
 
 export type { OptionValue };
 
@@ -122,9 +123,13 @@ const RadioGroup = ({
               // `asChild` gives the Button real radio semantics (role,
               // aria-checked, roving tabindex, arrow-key nav, click/keyboard
               // selection via the shared Core's onValueChange below) instead
-              // of a plain list of buttons with none of that.
-              <Item
+              // of a plain list of buttons with none of that. Uses the Radix
+              // primitive directly (not `core/RadioGroupItem`) so that core
+              // stays upstream-verbatim with no `asChild` branch (#361); the
+              // `data-slot` matches what the default item emits.
+              <RadioGroupPrimitive.Item
                 asChild
+                data-slot="radio-group-item"
                 value={String(item.value)}
                 disabled={disabled || item.disabled}
               >
@@ -155,7 +160,7 @@ const RadioGroup = ({
                 >
                   {item.label}
                 </Button>
-              </Item>
+              </RadioGroupPrimitive.Item>
             ) : (
               <Radio
                 id={getOptionId(index)}

--- a/packages/ui/src/core/checkbox.tsx
+++ b/packages/ui/src/core/checkbox.tsx
@@ -20,7 +20,7 @@ function Checkbox({
         dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary
         focus-visible:border-ring focus-visible:ring-ring/50
         aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40
-        aria-invalid:border-destructive size-4 shrink-0 rounded-sm border
+        aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border
         shadow-xs transition-shadow outline-none focus-visible:ring-[3px]
         disabled:cursor-not-allowed disabled:opacity-50`,
         className,

--- a/packages/ui/src/core/radio-group.tsx
+++ b/packages/ui/src/core/radio-group.tsx
@@ -22,24 +22,8 @@ function RadioGroup({
 
 function RadioGroupItem({
   className,
-  asChild,
-  children,
   ...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Item> & {
-  asChild?: boolean;
-}) {
-  // `asChild` hands the rendered element to `children` entirely (e.g. a
-  // `Button`), so the default dot indicator doesn't apply — Radix clones
-  // its own role/aria-checked/keyboard handling onto that single child
-  // instead of onto its own `<button>`.
-  if (asChild) {
-    return (
-      <RadioGroupPrimitive.Item asChild data-slot="radio-group-item" {...props}>
-        {children}
-      </RadioGroupPrimitive.Item>
-    );
-  }
-
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
   return (
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"


### PR DESCRIPTION
Part of #361 (does **not** close it — 2 of the 5 primitives).

## Summary

Moves the presentational local patches out of two vendored primitives so they match their shadcn `new-york-v4` registry entries and can be re-synced with `shadcn add --overwrite`. Public API and rendered output are unchanged.

- **`core/checkbox`** — restore upstream's `rounded-[4px]`. `atoms/checkbox` now contributes `rounded-sm` through its own `cn()` stack. Same radius (Tailwind `rounded-sm` == 4px) and tailwind-merge lets the atom win, so the emitted class is unchanged. Single consumer (`atoms/checkbox/checkbox.tsx`; the checkbox group goes through the atom, not the primitive).
- **`core/radio-group`** — drop the `asChild` branch so the primitive is the plain dot item again. The button-style radio in `atoms/radio/group` now renders `RadioGroupPrimitive.Item` directly with the same `data-slot="radio-group-item"`, so the rendered element is identical.

## Verification
- `check-types`, `lint`, `build` clean
- `check-regression-net` (api-surface / preflight-reset / ssr-smoke, 39 components) green
- `shadcn add checkbox|radio-group --diff`: no structural local deletions (only class ordering / prettier wrapping remain)
- cross-checked with the #362 drift script: both now report **in sync** (the repo's clean count goes 6 → 8)

## Out of scope (follow-ups)
- `switch`, `progress`, `accordion` stay for separate PRs — their locals aren't purely presentational (switch renders label `children` inside the track and retargets the thumb via a runtime `classNames.handle`; progress overrides the indicator's inline `style` for vertical direction; accordion's `expandIcon` *replaces* the built-in chevron). Each needs a small behaviour-preserving restructure + its own render check.
- After this and #369 both merge, re-baseline the drift snapshot: `pnpm --filter @repo/ui check-core-drift --update` (checkbox/radio moving to `in sync` is an improvement, so `--enforce` won't fail in the meantime).
