### PR TITLE
docs: document the irreducible local patches on switch/progress/accordion core primitives

### DIFF
--- a/.changeset/document-remaining-core-divergences.md
+++ b/.changeset/document-remaining-core-divergences.md
@@ -1,0 +1,10 @@
+---
+---
+
+Docs-only: documents the irreducible local patches on `core/switch`,
+`core/progress`, and `core/accordion` (#361). Each carries a change that reaches
+into the primitive's sub-tree — the switch thumb/label, the progress indicator's
+inline style for vertical direction, and the accordion's chevron replacement —
+so it can't be moved out to a consumer like `checkbox`/`radio-group` were, and
+is documented in place (as #363 did for the four structural primitives). No
+behaviour, API, or declaration change — intentionally no release.

--- a/packages/ui/src/core/accordion.tsx
+++ b/packages/ui/src/core/accordion.tsx
@@ -7,6 +7,24 @@ import { ChevronDownIcon } from 'lucide-react';
 
 import { cn } from '@repo/ui/utils';
 
+/*
+ * Vendored from shadcn's `new-york-v4` accordion registry entry.
+ *
+ * Local patches — re-apply these after any `shadcn add accordion`:
+ * 1. Import `cn` from `@repo/ui/utils` (upstream uses its `cn` alias) and
+ *    `AccordionPrimitive` from `@radix-ui/react-accordion` (upstream uses the
+ *    unified `radix-ui` package, which this repo doesn't install).
+ * 2. `AccordionTrigger` gains `CustomTriggerProps` with `expandIcon`, which
+ *    *replaces* the default `ChevronDownIcon` (`{expandIcon || <ChevronDown/>}`).
+ *
+ * Why this stays a local patch rather than moving to `molecules/collapse`
+ * (#361): `expandIcon` replaces the built-in chevron, but a verbatim trigger
+ * always renders that chevron. Reproducing a replacement through the verbatim
+ * primitive would mean hiding the chevron and re-injecting an icon via
+ * children, which changes the DOM and the `[&[data-state=open]>svg]` rotation
+ * target. Irreducibly structural (like #363). The rest of
+ * `shadcn add accordion --diff` is class ordering / prettier wrapping.
+ */
 function Accordion({
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Root>) {

--- a/packages/ui/src/core/progress.tsx
+++ b/packages/ui/src/core/progress.tsx
@@ -6,6 +6,24 @@ import * as ProgressPrimitive from '@radix-ui/react-progress';
 
 import { cn } from '@repo/ui/utils';
 
+/*
+ * Vendored from shadcn's `new-york-v4` progress registry entry.
+ *
+ * Local patches — re-apply these after any `shadcn add progress`:
+ * 1. Import `cn` from `@repo/ui/utils` (upstream uses its `cn` alias) and
+ *    `ProgressPrimitive` from `@radix-ui/react-progress` (upstream uses the
+ *    unified `radix-ui` package, which this repo doesn't install).
+ * 2. `CustomProps` adds `barClassName` (merged onto the Indicator's className)
+ *    and `barStyle` (merged into the Indicator's inline `style`).
+ *
+ * Why this stays a local patch rather than moving to `atoms/progress` (#361):
+ * `atoms/progress` supports a vertical direction, which needs the Indicator
+ * sized by `height %` via `barStyle` — overriding upstream's inline
+ * `transform: translateX(...)`. Inline style can't be overridden through a
+ * `className`, so the consumer must reach the Indicator's `style`, which a
+ * verbatim primitive doesn't expose. Irreducibly structural (like #363). The
+ * rest of `shadcn add progress --diff` is class ordering / prettier wrapping.
+ */
 interface CustomProps {
   barClassName?: string;
   barStyle?: React.CSSProperties;

--- a/packages/ui/src/core/switch.tsx
+++ b/packages/ui/src/core/switch.tsx
@@ -6,6 +6,25 @@ import * as SwitchPrimitive from '@radix-ui/react-switch';
 
 import { cn } from '@repo/ui/utils';
 
+/*
+ * Vendored from shadcn's `new-york-v4` switch registry entry.
+ *
+ * Local patches — re-apply these after any `shadcn add switch`:
+ * 1. Import `cn` from `@repo/ui/utils` (upstream uses its `cn` alias) and
+ *    `SwitchPrimitive` from `@radix-ui/react-switch` (upstream uses the unified
+ *    `radix-ui` package, which this repo doesn't install).
+ * 2. `CustomProps` adds `handleClassName` (merged onto `SwitchPrimitive.Thumb`)
+ *    and `children` (rendered inside the Root, after the Thumb).
+ *
+ * Why this stays a local patch rather than moving to `atoms/switch` (#361):
+ * both reach *into* the primitive's sub-tree. `atoms/switch` is an antd-style
+ * switch whose public `classNames.handle` is a runtime string that has to land
+ * on the Thumb, and whose `checkedChildren`/`unCheckedChildren` labels render
+ * inside the track (the Root) — neither is expressible through a verbatim
+ * primitive + `className` composition, so this one is irreducibly structural
+ * (like the four in #363). The rest of `shadcn add switch --diff` is class
+ * ordering / prettier wrapping, not a patch.
+ */
 interface CustomProps {
   handleClassName?: string;
   children?: React.ReactNode;


### PR DESCRIPTION
Closes #361 (final piece — see #370 for the first two).

## Summary

The other three of #361's five primitives carry local changes that **reach into the primitive's sub-tree**, so — unlike `checkbox`/`radio-group` (#370) — they can't be moved out to a consumer without changing the rendered DOM or orphaning the vendored file. This documents each in place with a `#363`-style maintenance comment, so a `shadcn add` overwrite can be re-applied and the divergence is understood as intentional.

- **`core/switch`** — `handleClassName` lands on the Thumb and `children` render inside the track (Root). `atoms/switch`'s public `classNames.handle` is a runtime string that must reach the Thumb, and its `checked/unCheckedChildren` labels live inside the track — neither is expressible through a verbatim primitive + `className`.
- **`core/progress`** — `barStyle` overrides the Indicator's inline `transform` so the vertical direction can size by `height %`. Inline style can't be overridden through a `className`.
- **`core/accordion`** — `expandIcon` *replaces* the built-in chevron; a verbatim trigger always renders that chevron, and faking a replacement changes the DOM and the `[&[data-state=open]>svg]` rotation target.

Comments use non-JSDoc `/* */`, so nothing leaks into the published `.d.ts` (verified). Docs-only — an **empty changeset** records no release.

## Outcome for #361
- `checkbox`, `radio-group` → moved to upstream-verbatim (#370)
- `switch`, `progress`, `accordion` → documented as irreducible local patches (this PR), same treatment #363 gave the four structural primitives
- `calendar`, `slider`, `field` were already out of scope in the issue (need an upstream-sync decision)

## Test plan
- [x] `lint`, `check-types`, `build` clean
- [x] patch-list text confirmed absent from `dist/**/*.d.mts`
